### PR TITLE
Fail closed for cross-Node repair confirmation

### DIFF
--- a/knowledge_node_repair_evidence.py
+++ b/knowledge_node_repair_evidence.py
@@ -3,6 +3,7 @@
 import json
 from pathlib import Path
 
+from knowledge_node_canonical import canonicalize_knowledge_node_id
 from question_bank import QuestionBankError, get_question_tag
 
 
@@ -42,20 +43,29 @@ _FORMAL_STRONG_PAIRS = _load_formal_strong_pairs()
 def classify_repair_confirmation(previous_question_id: str, candidate_question_id: str) -> str:
     """Classify conservatively using existing reviewed metadata only.
 
-    Different task or primary ability demonstrates a materially different demand.
-    When metadata cannot prove that difference, fail closed as weak evidence.
+    Strong evidence requires two different questions in the same canonical Node.
+    Different task or primary ability then demonstrates a materially different
+    demand. When metadata cannot prove either condition, fail closed as weak.
     """
     previous = str(previous_question_id or "")
     candidate = str(candidate_question_id or "")
     if not previous or not candidate or previous == candidate:
         return SAME_QUESTION
-    if frozenset((previous, candidate)) in _FORMAL_STRONG_PAIRS:
-        return DIFFERENT_QUESTION_STRONG
     try:
         previous_tag = get_question_tag(previous)
         candidate_tag = get_question_tag(candidate)
     except (KeyError, ValueError, QuestionBankError):
         return DIFFERENT_QUESTION_WEAK
+    previous_node = canonicalize_knowledge_node_id(
+        str(previous_tag.get("knowledge_node_id") or "")
+    )
+    candidate_node = canonicalize_knowledge_node_id(
+        str(candidate_tag.get("knowledge_node_id") or "")
+    )
+    if not previous_node or not candidate_node or previous_node != candidate_node:
+        return DIFFERENT_QUESTION_WEAK
+    if frozenset((previous, candidate)) in _FORMAL_STRONG_PAIRS:
+        return DIFFERENT_QUESTION_STRONG
     previous_demand = (previous_tag.get("task"), previous_tag.get("primary_ability"))
     candidate_demand = (candidate_tag.get("task"), candidate_tag.get("primary_ability"))
     if all(previous_demand) and all(candidate_demand) and previous_demand != candidate_demand:

--- a/tests/test_repair_confirmation_node_guard.py
+++ b/tests/test_repair_confirmation_node_guard.py
@@ -1,0 +1,67 @@
+import json
+from pathlib import Path
+
+from knowledge_node_canonical import canonicalize_knowledge_node_id
+from knowledge_node_repair_evidence import (
+    DIFFERENT_QUESTION_STRONG,
+    DIFFERENT_QUESTION_WEAK,
+    SAME_QUESTION,
+    classify_repair_confirmation,
+)
+from question_bank import get_question_tag
+
+
+PILOT_PAIRS = (
+    ("Q8", "Q1595"),
+    ("Q25", "Q1596"),
+    ("Q36", "Q1597"),
+    ("Q109", "Q1598"),
+    ("Q195", "Q1599"),
+    ("Q331", "Q1600"),
+    ("Q379", "Q1601"),
+    ("Q684", "Q1602"),
+    ("Q705", "Q1603"),
+    ("Q1305", "Q1604"),
+    ("Q1504", "Q1605"),
+)
+
+
+def canonical_node(question_id):
+    return canonicalize_knowledge_node_id(
+        get_question_tag(question_id)["knowledge_node_id"]
+    )
+
+
+def test_same_question_remains_same_question():
+    assert classify_repair_confirmation("Q8", "Q8") == SAME_QUESTION
+
+
+def test_cross_node_questions_fail_closed_even_when_demands_differ():
+    assert canonical_node("Q8") != canonical_node("Q1596")
+    assert classify_repair_confirmation("Q8", "Q1596") == DIFFERENT_QUESTION_WEAK
+
+
+def test_safety_strong_repair_pilot_pairs_remain_strong():
+    for source_q, alternate_q in PILOT_PAIRS:
+        assert canonical_node(source_q) == canonical_node(alternate_q)
+        assert classify_repair_confirmation(source_q, alternate_q) == DIFFERENT_QUESTION_STRONG
+
+
+def test_every_reviewed_strong_pair_stays_within_one_canonical_node():
+    pair_path = (
+        Path(__file__).resolve().parents[1]
+        / "data"
+        / "question_bank"
+        / "strong_different_question_pairs.json"
+    )
+    records = json.loads(pair_path.read_text(encoding="utf-8-sig"))
+    reviewed = [
+        item for item in records
+        if item.get("review_status") == "reviewed" and item.get("strength") == "strong"
+    ]
+    assert reviewed
+    for item in reviewed:
+        first, second = item["question_ids"]
+        assert canonical_node(first) == canonical_node(second)
+        assert canonical_node(first) == canonicalize_knowledge_node_id(item["knowledge_node_id"])
+        assert classify_repair_confirmation(first, second) == DIFFERENT_QUESTION_STRONG


### PR DESCRIPTION
Superseded by tested integration PR #28, which includes the cross-Node STRONG fail-closed protection and is already merged to main. This draft is retained only as historical implementation context.