### PR TITLE
Add shared evaluable field evidence metrics

### DIFF
--- a/field_evidence.py
+++ b/field_evidence.py
@@ -128,6 +128,10 @@ def build_field_evidence(
         field_questions = _CATALOG["questions_by_field"][field_id]
         field_nodes = _CATALOG["nodes_by_field"][field_id]
         field_attempts = attempts_by_field[field_id]
+        evaluable_field_attempts = [
+            item for item in field_attempts
+            if item.get("answer_status") != "unknown"
+        ]
         attempted_nodes = field_nodes & set(states)
         state_counts = Counter(states[node_id]["state"] for node_id in attempted_nodes)
         state_counts["unseen"] = len(field_nodes - attempted_nodes)
@@ -144,6 +148,10 @@ def build_field_evidence(
         correct_answer_count = sum(
             item.get("is_correct") is True and item.get("answer_status") != "unknown"
             for item in field_attempts
+        )
+        evaluable_correct_count = sum(
+            item.get("is_correct") is True
+            for item in evaluable_field_attempts
         )
         weakness_counts = Counter(
             weakness[node_id]["evidence_level"]
@@ -171,6 +179,7 @@ def build_field_evidence(
             int(states[node_id].get("confident_correct_after_wrong_count") or 0)
             for node_id in attempted_nodes
         )
+        evaluable_answer_count = len(evaluable_field_attempts)
         fields.append({
             "field_id": field_id,
             "field_name": field_name,
@@ -210,6 +219,12 @@ def build_field_evidence(
             "question_accuracy": (
                 correct_answer_count / len(field_attempts)
                 if field_attempts else None
+            ),
+            "evaluable_answer_count": evaluable_answer_count,
+            "evaluable_correct_count": evaluable_correct_count,
+            "evaluable_accuracy": (
+                evaluable_correct_count / evaluable_answer_count
+                if evaluable_answer_count else None
             ),
             "repeated_weakness_evidence_count": sum(
                 weakness_counts[level] for level in REPEATED_WEAKNESS_LEVELS

--- a/tests/test_evaluable_field_evidence.py
+++ b/tests/test_evaluable_field_evidence.py
@@ -1,0 +1,93 @@
+from datetime import datetime, timedelta, timezone
+
+from field_evidence import build_field_evidence
+from question_bank import get_category_small, get_question_tag
+
+
+BASE = datetime(2026, 9, 2, tzinfo=timezone.utc)
+
+
+def attempt(q, correct, confidence, minute, *, status="answered"):
+    return {
+        "user_id": "u",
+        "question_id": q,
+        "knowledge_node_id": get_question_tag(q)["knowledge_node_id"],
+        "selected_answers": [] if status == "unknown" else ["A"],
+        "answer_status": status,
+        "is_correct": correct,
+        "confidence": confidence,
+        "answered_at": BASE + timedelta(minutes=minute),
+        "event_key": f"e-{minute}",
+        "attempt_position": 1,
+    }
+
+
+def field(report, q="Q1"):
+    field_id = get_category_small(q)
+    return next(item for item in report["fields"] if item["field_id"] == field_id)
+
+
+def test_unknown_counts_as_raw_exposure_but_not_evaluable_answer():
+    item = field(build_field_evidence([
+        attempt("Q1", False, None, 1, status="unknown"),
+    ]))
+    assert item["question_answer_count"] == 1
+    assert item["unknown_answer_count"] == 1
+    assert item["question_correct_count"] == 0
+    assert item["question_accuracy"] == 0.0
+    assert item["evaluable_answer_count"] == 0
+    assert item["evaluable_correct_count"] == 0
+    assert item["evaluable_accuracy"] is None
+
+
+def test_evaluable_accuracy_excludes_unknown_from_denominator():
+    item = field(build_field_evidence([
+        attempt("Q1", True, 1, 1),
+        attempt("Q1", False, 2, 2),
+        attempt("Q1", False, None, 3, status="unknown"),
+    ]))
+    assert item["question_answer_count"] == 3
+    assert item["question_correct_count"] == 1
+    assert item["question_accuracy"] == 1 / 3
+    assert item["unknown_answer_count"] == 1
+    assert item["evaluable_answer_count"] == 2
+    assert item["evaluable_correct_count"] == 1
+    assert item["evaluable_accuracy"] == 0.5
+
+
+def test_extra_unknown_does_not_change_evaluable_accuracy():
+    baseline = field(build_field_evidence([
+        attempt("Q1", True, 1, 1),
+        attempt("Q1", False, 2, 2),
+    ]))
+    with_unknown = field(build_field_evidence([
+        attempt("Q1", True, 1, 1),
+        attempt("Q1", False, 2, 2),
+        attempt("Q1", False, None, 3, status="unknown"),
+        attempt("Q1", False, None, 4, status="unknown"),
+    ]))
+    assert baseline["evaluable_answer_count"] == 2
+    assert with_unknown["evaluable_answer_count"] == 2
+    assert baseline["evaluable_accuracy"] == with_unknown["evaluable_accuracy"] == 0.5
+    assert baseline["question_accuracy"] != with_unknown["question_accuracy"]
+
+
+def test_existing_raw_accuracy_semantics_remain_compatible():
+    item = field(build_field_evidence([
+        attempt("Q1", True, 1, 1),
+        attempt("Q1", False, None, 2, status="unknown"),
+    ]))
+    assert item["question_answer_count"] == 2
+    assert item["question_correct_count"] == 1
+    assert item["question_accuracy"] == 0.5
+    assert item["evaluable_answer_count"] == 1
+    assert item["evaluable_correct_count"] == 1
+    assert item["evaluable_accuracy"] == 1.0
+
+
+def test_empty_field_has_zero_evaluable_counts_and_no_evaluable_accuracy():
+    empty_report = build_field_evidence([])
+    empty_field = empty_report["fields"][0]
+    assert empty_field["evaluable_answer_count"] == 0
+    assert empty_field["evaluable_correct_count"] == 0
+    assert empty_field["evaluable_accuracy"] is None


### PR DESCRIPTION
Superseded by tested integration PR #28, which includes evaluable field-evidence semantics and is already merged to main. Historical draft only.