### PR TITLE
Add current-cycle Phase11 active weakness facts

### DIFF
--- a/phase11_active_weakness.py
+++ b/phase11_active_weakness.py
@@ -1,0 +1,77 @@
+"""Pure Phase11 active-weakness facts scoped to the current formal repair cycle."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import datetime
+from typing import Any, Iterable
+
+from knowledge_node_canonical import canonicalize_knowledge_node_id
+from knowledge_node_repair_cycle import (
+    current_evaluable_repair_cycle,
+    current_repair_cycle,
+)
+from knowledge_node_weakness_evidence import (
+    NO_WRONG_EVIDENCE,
+    derive_repeated_weakness_evidence,
+)
+
+
+def build_active_repair_weakness(
+    attempts: Iterable[dict[str, Any]],
+    *,
+    as_of: datetime | None = None,
+) -> dict[str, dict[str, Any]]:
+    """Return current-cycle weakness facts keyed by canonical Node.
+
+    Unknown may keep a Node in an active repairing run, but confirmed weakness
+    is derived only from evaluable non-unknown attempts in that current run.
+    Completed historical repair cycles are excluded.
+    """
+    histories: dict[tuple[str, str], list[dict[str, Any]]] = defaultdict(list)
+    for source in attempts:
+        item = dict(source)
+        node = canonicalize_knowledge_node_id(
+            str(item.get("knowledge_node_id") or "")
+        )
+        if not node or not item.get("question_id"):
+            continue
+        histories[(str(item.get("user_id") or ""), node)].append(item)
+
+    result: dict[str, dict[str, Any]] = {}
+    for (_user, node), history in sorted(histories.items()):
+        active_cycle = current_repair_cycle(history, as_of=as_of)
+        if not active_cycle:
+            continue
+        evaluable_cycle = current_evaluable_repair_cycle(history, as_of=as_of)
+        weakness_records = derive_repeated_weakness_evidence(evaluable_cycle)
+        weakness = weakness_records[0] if weakness_records else None
+        evaluable_wrong = [
+            item for item in evaluable_cycle if item.get("is_correct") is False
+        ]
+        result[node] = {
+            "canonical_node_id": node,
+            "active_repair_cycle_attempt_count": len(active_cycle),
+            "active_unknown_attempt_count": sum(
+                item.get("answer_status") == "unknown" for item in active_cycle
+            ),
+            "active_evaluable_attempt_count": len(evaluable_cycle),
+            "active_evaluable_wrong_attempt_count": len(evaluable_wrong),
+            "active_evaluable_wrong_question_count": len({
+                str(item.get("question_id") or "") for item in evaluable_wrong
+            }),
+            "active_confident_wrong_count": sum(
+                item.get("confidence") == 1 for item in evaluable_wrong
+            ),
+            "active_has_confident_wrong": any(
+                item.get("confidence") == 1 for item in evaluable_wrong
+            ),
+            "active_weakness_evidence_level": (
+                weakness.get("evidence_level") if weakness else NO_WRONG_EVIDENCE
+            ),
+            "active_weakness_evidence_reason": (
+                weakness.get("evidence_reason")
+                if weakness else "No evaluable wrong answer exists in the current repair cycle."
+            ),
+        }
+    return result

--- a/phase11_active_weakness.py
+++ b/phase11_active_weakness.py
@@ -28,18 +28,22 @@ def build_active_repair_weakness(
     is derived only from evaluable non-unknown attempts in that current run.
     Completed historical repair cycles are excluded.
     """
-    histories: dict[tuple[str, str], list[dict[str, Any]]] = defaultdict(list)
-    for source in attempts:
-        item = dict(source)
+    attempts = [dict(item) for item in attempts]
+    user_ids = {str(item.get("user_id") or "") for item in attempts}
+    if len(user_ids) > 1:
+        raise ValueError("attempts must belong to one user")
+
+    histories: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for item in attempts:
         node = canonicalize_knowledge_node_id(
             str(item.get("knowledge_node_id") or "")
         )
         if not node or not item.get("question_id"):
             continue
-        histories[(str(item.get("user_id") or ""), node)].append(item)
+        histories[node].append(item)
 
     result: dict[str, dict[str, Any]] = {}
-    for (_user, node), history in sorted(histories.items()):
+    for node, history in sorted(histories.items()):
         active_cycle = current_repair_cycle(history, as_of=as_of)
         if not active_cycle:
             continue

--- a/tests/test_phase11_active_weakness.py
+++ b/tests/test_phase11_active_weakness.py
@@ -1,0 +1,142 @@
+from datetime import datetime, timedelta, timezone
+
+import knowledge_node_state_transition as transition
+from knowledge_node_repair_evidence import DIFFERENT_QUESTION_STRONG, DIFFERENT_QUESTION_WEAK
+from knowledge_node_weakness_evidence import (
+    CROSS_QUESTION_CONFIDENT_WRONG,
+    CROSS_QUESTION_WRONG,
+    NO_WRONG_EVIDENCE,
+    SINGLE_WRONG,
+)
+from phase11_active_weakness import build_active_repair_weakness
+
+
+BASE = datetime(2026, 9, 1, tzinfo=timezone.utc)
+
+
+def attempt(q, *, correct, confidence, minute=0, days=0, unknown=False):
+    return {
+        "id": days * 1000 + minute + 1,
+        "event_key": f"e-{q}-{days}-{minute}",
+        "user_id": "u",
+        "question_id": q,
+        "knowledge_node_id": "KN0268",
+        "selected_answers": [] if unknown else ["A"],
+        "answer_status": "unknown" if unknown else "answered",
+        "is_correct": correct,
+        "confidence": confidence,
+        "answered_at": BASE + timedelta(days=days, minutes=minute),
+        "attempt_position": 1,
+    }
+
+
+def classifier(strong_pairs):
+    strong_pairs = set(strong_pairs)
+
+    def classify(old, new):
+        return DIFFERENT_QUESTION_STRONG if (old, new) in strong_pairs else DIFFERENT_QUESTION_WEAK
+
+    return classify
+
+
+def test_completed_repair_has_no_active_weakness(monkeypatch):
+    monkeypatch.setattr(
+        transition,
+        "classify_repair_confirmation",
+        classifier({("Q1", "Q2")}),
+    )
+    attempts = [
+        attempt("Q1", correct=False, confidence=2),
+        attempt("Q2", correct=True, confidence=1, minute=1),
+    ]
+    assert build_active_repair_weakness(attempts) == {}
+
+
+def test_unknown_only_current_cycle_is_unresolved_but_not_confirmed_weakness():
+    facts = build_active_repair_weakness([
+        attempt("Q1", correct=False, confidence=None, unknown=True),
+    ])["KN0268"]
+    assert facts["active_repair_cycle_attempt_count"] == 1
+    assert facts["active_unknown_attempt_count"] == 1
+    assert facts["active_evaluable_wrong_attempt_count"] == 0
+    assert facts["active_weakness_evidence_level"] == NO_WRONG_EVIDENCE
+
+
+def test_one_current_cycle_wrong_is_single_wrong():
+    facts = build_active_repair_weakness([
+        attempt("Q1", correct=False, confidence=2),
+    ])["KN0268"]
+    assert facts["active_evaluable_wrong_question_count"] == 1
+    assert facts["active_weakness_evidence_level"] == SINGLE_WRONG
+
+
+def test_two_current_cycle_wrong_questions_are_cross_question_wrong():
+    facts = build_active_repair_weakness([
+        attempt("Q1", correct=False, confidence=2),
+        attempt("Q2", correct=False, confidence=3, minute=1),
+    ])["KN0268"]
+    assert facts["active_evaluable_wrong_question_count"] == 2
+    assert facts["active_weakness_evidence_level"] == CROSS_QUESTION_WRONG
+
+
+def test_current_cycle_confident_cross_wrong_is_confident(monkeypatch):
+    facts = build_active_repair_weakness([
+        attempt("Q1", correct=False, confidence=1),
+        attempt("Q2", correct=False, confidence=2, minute=1),
+    ])["KN0268"]
+    assert facts["active_has_confident_wrong"] is True
+    assert facts["active_confident_wrong_count"] == 1
+    assert facts["active_weakness_evidence_level"] == CROSS_QUESTION_CONFIDENT_WRONG
+
+
+def test_old_cross_wrong_does_not_leak_after_completed_repair_and_new_single_wrong(monkeypatch):
+    monkeypatch.setattr(
+        transition,
+        "classify_repair_confirmation",
+        classifier({("Q1", "Q3"), ("Q2", "Q3")}),
+    )
+    attempts = [
+        attempt("Q1", correct=False, confidence=2),
+        attempt("Q2", correct=False, confidence=1, minute=1),
+        attempt("Q3", correct=True, confidence=1, minute=2),
+        attempt("Q4", correct=False, confidence=2, minute=3),
+    ]
+    facts = build_active_repair_weakness(attempts)["KN0268"]
+    assert facts["active_evaluable_wrong_question_count"] == 1
+    assert facts["active_has_confident_wrong"] is False
+    assert facts["active_weakness_evidence_level"] == SINGLE_WRONG
+
+
+def test_old_cross_wrong_does_not_revive_from_new_unknown(monkeypatch):
+    monkeypatch.setattr(
+        transition,
+        "classify_repair_confirmation",
+        classifier({("Q1", "Q3"), ("Q2", "Q3")}),
+    )
+    attempts = [
+        attempt("Q1", correct=False, confidence=2),
+        attempt("Q2", correct=False, confidence=1, minute=1),
+        attempt("Q3", correct=True, confidence=1, minute=2),
+        attempt("Q4", correct=False, confidence=None, minute=3, unknown=True),
+    ]
+    facts = build_active_repair_weakness(attempts)["KN0268"]
+    assert facts["active_evaluable_wrong_attempt_count"] == 0
+    assert facts["active_has_confident_wrong"] is False
+    assert facts["active_weakness_evidence_level"] == NO_WRONG_EVIDENCE
+
+
+def test_failed_due_recheck_uses_only_new_cycle(monkeypatch):
+    monkeypatch.setattr(
+        transition,
+        "classify_repair_confirmation",
+        classifier({("Q1", "Q2")}),
+    )
+    attempts = [
+        attempt("Q1", correct=False, confidence=1),
+        attempt("Q2", correct=True, confidence=1, minute=1),
+        attempt("Q3", correct=False, confidence=2, days=8),
+    ]
+    facts = build_active_repair_weakness(attempts)["KN0268"]
+    assert facts["active_evaluable_wrong_question_count"] == 1
+    assert facts["active_has_confident_wrong"] is False
+    assert facts["active_weakness_evidence_level"] == SINGLE_WRONG

--- a/tests/test_phase11_active_weakness.py
+++ b/tests/test_phase11_active_weakness.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timedelta, timezone
 
+import pytest
 import knowledge_node_state_transition as transition
 from knowledge_node_repair_evidence import DIFFERENT_QUESTION_STRONG, DIFFERENT_QUESTION_WEAK
 from knowledge_node_weakness_evidence import (
@@ -14,11 +15,11 @@ from phase11_active_weakness import build_active_repair_weakness
 BASE = datetime(2026, 9, 1, tzinfo=timezone.utc)
 
 
-def attempt(q, *, correct, confidence, minute=0, days=0, unknown=False):
+def attempt(q, *, correct, confidence, minute=0, days=0, unknown=False, user="u"):
     return {
         "id": days * 1000 + minute + 1,
-        "event_key": f"e-{q}-{days}-{minute}",
-        "user_id": "u",
+        "event_key": f"e-{user}-{q}-{days}-{minute}",
+        "user_id": user,
         "question_id": q,
         "knowledge_node_id": "KN0268",
         "selected_answers": [] if unknown else ["A"],
@@ -79,7 +80,7 @@ def test_two_current_cycle_wrong_questions_are_cross_question_wrong():
     assert facts["active_weakness_evidence_level"] == CROSS_QUESTION_WRONG
 
 
-def test_current_cycle_confident_cross_wrong_is_confident(monkeypatch):
+def test_current_cycle_confident_cross_wrong_is_confident():
     facts = build_active_repair_weakness([
         attempt("Q1", correct=False, confidence=1),
         attempt("Q2", correct=False, confidence=2, minute=1),
@@ -140,3 +141,11 @@ def test_failed_due_recheck_uses_only_new_cycle(monkeypatch):
     assert facts["active_evaluable_wrong_question_count"] == 1
     assert facts["active_has_confident_wrong"] is False
     assert facts["active_weakness_evidence_level"] == SINGLE_WRONG
+
+
+def test_mixed_users_fail_closed():
+    with pytest.raises(ValueError, match="one user"):
+        build_active_repair_weakness([
+            attempt("Q1", correct=False, confidence=2, user="a"),
+            attempt("Q2", correct=False, confidence=2, minute=1, user="b"),
+        ])


### PR DESCRIPTION
Superseded by tested integration PR #28, which includes current-cycle active weakness facts and is already merged to main. Historical draft only.