### PR TITLE
Prepare active-cycle Phase11 rule integration

### DIFF
--- a/phase11_active_field_facts.py
+++ b/phase11_active_field_facts.py
@@ -1,0 +1,87 @@
+"""Pure Phase11 J1-J3 field facts from active current-cycle weakness."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any, Mapping
+
+from knowledge_node_weakness_evidence import (
+    CROSS_QUESTION_CONFIDENT_WRONG,
+    CROSS_QUESTION_WRONG,
+    REPEATED_SAME_QUESTION_WRONG,
+)
+
+
+REPEATED_LEVELS = {
+    REPEATED_SAME_QUESTION_WRONG,
+    CROSS_QUESTION_WRONG,
+    CROSS_QUESTION_CONFIDENT_WRONG,
+}
+
+
+def build_active_field_facts(
+    active_by_node: Mapping[str, Mapping[str, Any]],
+    *,
+    field_by_question: Mapping[str, int],
+    critical_nodes: set[str] | frozenset[str] = frozenset(),
+) -> dict[int, dict[str, Any]]:
+    """Attribute active J1-J3 evidence only to fields of active wrong Qs.
+
+    Generic canonical-Node field memberships are deliberately not used here.
+    If one active repair cycle contains wrong Qs from two fields, both observed
+    source fields receive that Node's cross-question evidence.
+    """
+    facts: dict[int, dict[str, Any]] = defaultdict(lambda: {
+        "critical_safety_unresolved_count": 0,
+        "active_cross_question_confident_wrong_node_count": 0,
+        "active_cross_question_wrong_node_count": 0,
+        "active_repeated_weakness_node_count": 0,
+        "active_confident_wrong_repairing_node_count": 0,
+        "active_evaluable_wrong_repairing_node_count": 0,
+        "active_node_ids": set(),
+        "active_wrong_question_ids": set(),
+    })
+
+    for node_id, source in active_by_node.items():
+        wrong_qs = {
+            str(q)
+            for q in source.get("active_evaluable_wrong_question_ids", [])
+            if str(q) in field_by_question
+        }
+        if not wrong_qs:
+            continue
+        source_fields = {int(field_by_question[q]) for q in wrong_qs}
+        confident_qs = {
+            str(q)
+            for q in source.get("active_confident_wrong_question_ids", [])
+            if str(q) in field_by_question
+        }
+        confident_fields = {int(field_by_question[q]) for q in confident_qs}
+        level = source.get("active_weakness_evidence_level")
+
+        for field_id in source_fields:
+            item = facts[field_id]
+            item["active_node_ids"].add(node_id)
+            item["active_wrong_question_ids"].update(
+                q for q in wrong_qs if int(field_by_question[q]) == field_id
+            )
+            item["active_evaluable_wrong_repairing_node_count"] += 1
+            if node_id in critical_nodes:
+                item["critical_safety_unresolved_count"] += 1
+            if level == CROSS_QUESTION_CONFIDENT_WRONG:
+                item["active_cross_question_confident_wrong_node_count"] += 1
+            if level == CROSS_QUESTION_WRONG:
+                item["active_cross_question_wrong_node_count"] += 1
+            if level in REPEATED_LEVELS:
+                item["active_repeated_weakness_node_count"] += 1
+
+        for field_id in confident_fields:
+            facts[field_id]["active_confident_wrong_repairing_node_count"] += 1
+
+    normalized: dict[int, dict[str, Any]] = {}
+    for field_id, source in sorted(facts.items()):
+        item = dict(source)
+        item["active_node_ids"] = sorted(item["active_node_ids"])
+        item["active_wrong_question_ids"] = sorted(item["active_wrong_question_ids"])
+        normalized[field_id] = item
+    return normalized

--- a/phase11_active_repair_rules.py
+++ b/phase11_active_repair_rules.py
@@ -1,0 +1,87 @@
+"""Pure Phase11 J2/J3 candidate ordering from active current-cycle facts."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+
+def _field_record(field_records: Mapping[int, Mapping[str, Any]], field_id: int) -> Mapping[str, Any]:
+    return field_records.get(field_id, {})
+
+
+def build_j2_candidates(
+    active_field_facts: Mapping[int, Mapping[str, Any]],
+    *,
+    field_records: Mapping[int, Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    """Return J2 candidates using confirmed active weakness only."""
+    candidates: list[dict[str, Any]] = []
+    for field_id, active in active_field_facts.items():
+        cross_confident = int(
+            active.get("active_cross_question_confident_wrong_node_count") or 0
+        )
+        confident_nodes = int(
+            active.get("active_confident_wrong_repairing_node_count") or 0
+        )
+        if not (cross_confident or confident_nodes >= 2):
+            continue
+        active_repairing = int(
+            active.get("active_evaluable_wrong_repairing_node_count") or 0
+        )
+        field = _field_record(field_records, int(field_id))
+        evaluable_count = int(field.get("evaluable_answer_count") or 0)
+        evaluable_accuracy = field.get("evaluable_accuracy")
+        reliable_accuracy = (
+            float(evaluable_accuracy)
+            if evaluable_count >= 10 and evaluable_accuracy is not None
+            else 1.0
+        )
+        candidates.append({
+            "field_id": int(field_id),
+            "active_cross_question_confident_wrong_node_count": cross_confident,
+            "active_confident_wrong_repairing_node_count": confident_nodes,
+            "active_evaluable_wrong_repairing_node_count": active_repairing,
+            "evaluable_answer_count": evaluable_count,
+            "evaluable_accuracy": evaluable_accuracy,
+            "reliable_accuracy": reliable_accuracy,
+        })
+    return sorted(
+        candidates,
+        key=lambda item: (
+            -item["active_cross_question_confident_wrong_node_count"],
+            -item["active_confident_wrong_repairing_node_count"],
+            -item["active_evaluable_wrong_repairing_node_count"],
+            item["reliable_accuracy"],
+            item["field_id"],
+        ),
+    )
+
+
+def build_j3_candidates(
+    active_field_facts: Mapping[int, Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    """Return J3 candidates using confirmed active weakness only."""
+    candidates: list[dict[str, Any]] = []
+    for field_id, active in active_field_facts.items():
+        cross_wrong = int(active.get("active_cross_question_wrong_node_count") or 0)
+        repeated = int(active.get("active_repeated_weakness_node_count") or 0)
+        if not (cross_wrong or repeated >= 2):
+            continue
+        active_repairing = int(
+            active.get("active_evaluable_wrong_repairing_node_count") or 0
+        )
+        candidates.append({
+            "field_id": int(field_id),
+            "active_cross_question_wrong_node_count": cross_wrong,
+            "active_repeated_weakness_node_count": repeated,
+            "active_evaluable_wrong_repairing_node_count": active_repairing,
+        })
+    return sorted(
+        candidates,
+        key=lambda item: (
+            -item["active_cross_question_wrong_node_count"],
+            -item["active_repeated_weakness_node_count"],
+            -item["active_evaluable_wrong_repairing_node_count"],
+            item["field_id"],
+        ),
+    )

--- a/phase11_active_safety.py
+++ b/phase11_active_safety.py
@@ -1,0 +1,88 @@
+"""Pure Phase11 J1 Safety candidates from current-cycle active weakness."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Mapping
+
+from knowledge_node_weakness_evidence import (
+    CROSS_QUESTION_CONFIDENT_WRONG,
+    CROSS_QUESTION_WRONG,
+    REPEATED_SAME_QUESTION_WRONG,
+)
+
+
+def _parse_time(value: Any) -> datetime | None:
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+
+
+def _priority_tier(source: Mapping[str, Any]) -> int:
+    level = source.get("active_weakness_evidence_level")
+    if level == CROSS_QUESTION_CONFIDENT_WRONG:
+        return 0
+    if level == CROSS_QUESTION_WRONG:
+        return 1
+    if source.get("active_has_confident_wrong"):
+        return 2
+    if level == REPEATED_SAME_QUESTION_WRONG:
+        return 3
+    return 4
+
+
+def build_active_safety_candidates(
+    active_by_node: Mapping[str, Mapping[str, Any]],
+    *,
+    field_by_question: Mapping[str, int],
+    critical_nodes: set[str] | frozenset[str],
+) -> list[dict[str, Any]]:
+    """Return ordered Critical Safety J1 candidates from active wrong evidence.
+
+    Fields are attributed only from active evaluable wrong question sources.
+    Unknown-only active repair cycles do not create J1 candidates.
+    """
+    candidates: list[dict[str, Any]] = []
+    for node_id in sorted(critical_nodes):
+        source = active_by_node.get(node_id)
+        if not source or int(source.get("active_evaluable_wrong_attempt_count") or 0) <= 0:
+            continue
+        wrong_qs = {
+            str(q)
+            for q in source.get("active_evaluable_wrong_question_ids", [])
+            if str(q) in field_by_question
+        }
+        source_fields = sorted({int(field_by_question[q]) for q in wrong_qs})
+        if not source_fields:
+            continue
+        tier = _priority_tier(source)
+        parsed = _parse_time(source.get("active_last_evaluable_wrong_at"))
+        recency_key = -parsed.timestamp() if parsed else 0
+        for field_id in source_fields:
+            candidates.append({
+                "priority_tier": tier,
+                "recency_key": recency_key,
+                "field_id": field_id,
+                "canonical_node_id": node_id,
+                "active_wrong_attempt_count": int(
+                    source.get("active_evaluable_wrong_attempt_count") or 0
+                ),
+                "active_weakness_evidence_level": source.get(
+                    "active_weakness_evidence_level"
+                ),
+            })
+    return sorted(
+        candidates,
+        key=lambda item: (
+            item["priority_tier"],
+            item["recency_key"],
+            item["field_id"],
+            item["canonical_node_id"],
+        ),
+    )

--- a/phase11_active_weakness.py
+++ b/phase11_active_weakness.py
@@ -53,6 +53,16 @@ def build_active_repair_weakness(
         evaluable_wrong = [
             item for item in evaluable_cycle if item.get("is_correct") is False
         ]
+        active_wrong_question_ids = sorted({
+            str(item.get("question_id") or "")
+            for item in evaluable_wrong
+            if item.get("question_id")
+        })
+        active_confident_wrong_question_ids = sorted({
+            str(item.get("question_id") or "")
+            for item in evaluable_wrong
+            if item.get("question_id") and item.get("confidence") == 1
+        })
         result[node] = {
             "canonical_node_id": node,
             "active_repair_cycle_attempt_count": len(active_cycle),
@@ -61,15 +71,13 @@ def build_active_repair_weakness(
             ),
             "active_evaluable_attempt_count": len(evaluable_cycle),
             "active_evaluable_wrong_attempt_count": len(evaluable_wrong),
-            "active_evaluable_wrong_question_count": len({
-                str(item.get("question_id") or "") for item in evaluable_wrong
-            }),
+            "active_evaluable_wrong_question_count": len(active_wrong_question_ids),
+            "active_evaluable_wrong_question_ids": active_wrong_question_ids,
             "active_confident_wrong_count": sum(
                 item.get("confidence") == 1 for item in evaluable_wrong
             ),
-            "active_has_confident_wrong": any(
-                item.get("confidence") == 1 for item in evaluable_wrong
-            ),
+            "active_confident_wrong_question_ids": active_confident_wrong_question_ids,
+            "active_has_confident_wrong": bool(active_confident_wrong_question_ids),
             "active_weakness_evidence_level": (
                 weakness.get("evidence_level") if weakness else NO_WRONG_EVIDENCE
             ),

--- a/phase11_active_weakness.py
+++ b/phase11_active_weakness.py
@@ -17,6 +17,10 @@ from knowledge_node_weakness_evidence import (
 )
 
 
+def _attempt_time_value(item: dict[str, Any]) -> Any:
+    return item.get("attempted_at") or item.get("answered_at")
+
+
 def build_active_repair_weakness(
     attempts: Iterable[dict[str, Any]],
     *,
@@ -63,6 +67,9 @@ def build_active_repair_weakness(
             for item in evaluable_wrong
             if item.get("question_id") and item.get("confidence") == 1
         })
+        last_wrong_time = (
+            _attempt_time_value(evaluable_wrong[-1]) if evaluable_wrong else None
+        )
         result[node] = {
             "canonical_node_id": node,
             "active_repair_cycle_attempt_count": len(active_cycle),
@@ -73,6 +80,7 @@ def build_active_repair_weakness(
             "active_evaluable_wrong_attempt_count": len(evaluable_wrong),
             "active_evaluable_wrong_question_count": len(active_wrong_question_ids),
             "active_evaluable_wrong_question_ids": active_wrong_question_ids,
+            "active_last_evaluable_wrong_at": last_wrong_time,
             "active_confident_wrong_count": sum(
                 item.get("confidence") == 1 for item in evaluable_wrong
             ),

--- a/phase11_evaluable_nonrepair_rules.py
+++ b/phase11_evaluable_nonrepair_rules.py
@@ -1,0 +1,63 @@
+"""Pure Phase11 J5/J6 candidate ordering using evaluable field evidence."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+
+def build_j5_sparse_field_candidates(
+    field_records: Mapping[int, Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    """Return post-foundation J5 sparse fields using evaluable answers only."""
+    candidates: list[dict[str, Any]] = []
+    for field_id, field in field_records.items():
+        evaluable_count = int(field.get("evaluable_answer_count") or 0)
+        if evaluable_count >= 10:
+            continue
+        node_coverage = float((field.get("node_coverage") or {}).get("percent") or 0)
+        candidates.append({
+            "field_id": int(field_id),
+            "evaluable_answer_count": evaluable_count,
+            "node_coverage_percent": node_coverage,
+            "raw_answer_count": int(field.get("question_answer_count") or 0),
+            "unknown_answer_count": int(field.get("unknown_answer_count") or 0),
+        })
+    return sorted(
+        candidates,
+        key=lambda item: (
+            item["evaluable_answer_count"],
+            item["node_coverage_percent"],
+            item["field_id"],
+        ),
+    )
+
+
+def build_j6_uncertain_correct_candidates(
+    field_records: Mapping[int, Mapping[str, Any]],
+    *,
+    uncertain_correct_by_field: Mapping[int, int],
+) -> list[dict[str, Any]]:
+    """Return J6 candidates with evaluable denominators."""
+    candidates: list[dict[str, Any]] = []
+    for field_id, field in field_records.items():
+        evaluable_count = int(field.get("evaluable_answer_count") or 0)
+        uncertain_correct = int(uncertain_correct_by_field.get(int(field_id), 0))
+        if evaluable_count < 5 or uncertain_correct < 3:
+            continue
+        proportion = uncertain_correct / evaluable_count
+        candidates.append({
+            "field_id": int(field_id),
+            "uncertain_correct_count": uncertain_correct,
+            "evaluable_answer_count": evaluable_count,
+            "uncertain_correct_proportion": proportion,
+            "checking_node_count": int(field.get("checking_node_count") or 0),
+        })
+    return sorted(
+        candidates,
+        key=lambda item: (
+            -item["uncertain_correct_count"],
+            -item["uncertain_correct_proportion"],
+            -item["checking_node_count"],
+            item["field_id"],
+        ),
+    )

--- a/tests/test_phase11_active_field_facts.py
+++ b/tests/test_phase11_active_field_facts.py
@@ -1,0 +1,112 @@
+from knowledge_node_weakness_evidence import (
+    CROSS_QUESTION_CONFIDENT_WRONG,
+    CROSS_QUESTION_WRONG,
+    NO_WRONG_EVIDENCE,
+    REPEATED_SAME_QUESTION_WRONG,
+    SINGLE_WRONG,
+)
+from phase11_active_field_facts import build_active_field_facts
+
+
+def node(
+    *,
+    wrong_qs,
+    confident_qs=(),
+    level=SINGLE_WRONG,
+):
+    return {
+        "active_evaluable_wrong_question_ids": list(wrong_qs),
+        "active_confident_wrong_question_ids": list(confident_qs),
+        "active_weakness_evidence_level": level,
+    }
+
+
+def test_single_field_active_wrong_stays_in_observed_source_field():
+    facts = build_active_field_facts(
+        {"KN1": node(wrong_qs=["Q1"])},
+        field_by_question={"Q1": 3},
+    )
+    assert set(facts) == {3}
+    assert facts[3]["active_evaluable_wrong_repairing_node_count"] == 1
+    assert facts[3]["active_wrong_question_ids"] == ["Q1"]
+
+
+def test_static_unobserved_member_field_is_not_invented():
+    facts = build_active_field_facts(
+        {"KN1": node(wrong_qs=["Q1"])},
+        field_by_question={"Q1": 3, "QOTHER": 9},
+    )
+    assert 9 not in facts
+
+
+def test_cross_question_wrong_spanning_two_observed_fields_contributes_to_both():
+    facts = build_active_field_facts(
+        {"KN1": node(
+            wrong_qs=["Q1", "Q2"],
+            level=CROSS_QUESTION_WRONG,
+        )},
+        field_by_question={"Q1": 3, "Q2": 9},
+    )
+    assert facts[3]["active_cross_question_wrong_node_count"] == 1
+    assert facts[9]["active_cross_question_wrong_node_count"] == 1
+    assert facts[3]["active_repeated_weakness_node_count"] == 1
+    assert facts[9]["active_repeated_weakness_node_count"] == 1
+
+
+def test_cross_confident_node_is_node_level_in_each_observed_source_field():
+    facts = build_active_field_facts(
+        {"KN1": node(
+            wrong_qs=["Q1", "Q2"],
+            confident_qs=["Q1"],
+            level=CROSS_QUESTION_CONFIDENT_WRONG,
+        )},
+        field_by_question={"Q1": 3, "Q2": 9},
+    )
+    assert facts[3]["active_cross_question_confident_wrong_node_count"] == 1
+    assert facts[9]["active_cross_question_confident_wrong_node_count"] == 1
+    assert facts[3]["active_confident_wrong_repairing_node_count"] == 1
+    assert facts[9]["active_confident_wrong_repairing_node_count"] == 0
+
+
+def test_critical_safety_is_attributed_only_where_active_wrong_was_observed():
+    facts = build_active_field_facts(
+        {"KN1": node(wrong_qs=["Q1"])},
+        field_by_question={"Q1": 8},
+        critical_nodes={"KN1"},
+    )
+    assert facts[8]["critical_safety_unresolved_count"] == 1
+
+
+def test_unknown_only_or_no_wrong_fact_creates_no_field_weakness():
+    facts = build_active_field_facts(
+        {"KN1": node(wrong_qs=[], level=NO_WRONG_EVIDENCE)},
+        field_by_question={"Q1": 8},
+        critical_nodes={"KN1"},
+    )
+    assert facts == {}
+
+
+def test_repeated_same_question_counts_as_repeated_in_its_observed_field():
+    facts = build_active_field_facts(
+        {"KN1": node(
+            wrong_qs=["Q1"],
+            level=REPEATED_SAME_QUESTION_WRONG,
+        )},
+        field_by_question={"Q1": 4},
+    )
+    assert facts[4]["active_repeated_weakness_node_count"] == 1
+    assert facts[4]["active_cross_question_wrong_node_count"] == 0
+
+
+def test_multiple_nodes_accumulate_without_double_counting_one_node_per_field():
+    facts = build_active_field_facts(
+        {
+            "KN1": node(wrong_qs=["Q1", "Q2"], level=CROSS_QUESTION_WRONG),
+            "KN2": node(wrong_qs=["Q3"], confident_qs=["Q3"]),
+        },
+        field_by_question={"Q1": 5, "Q2": 5, "Q3": 5},
+    )
+    assert facts[5]["active_evaluable_wrong_repairing_node_count"] == 2
+    assert facts[5]["active_cross_question_wrong_node_count"] == 1
+    assert facts[5]["active_confident_wrong_repairing_node_count"] == 1
+    assert facts[5]["active_node_ids"] == ["KN1", "KN2"]

--- a/tests/test_phase11_active_repair_rules.py
+++ b/tests/test_phase11_active_repair_rules.py
@@ -1,0 +1,114 @@
+from phase11_active_repair_rules import build_j2_candidates, build_j3_candidates
+
+
+def active(
+    *,
+    cross_confident=0,
+    confident_nodes=0,
+    cross_wrong=0,
+    repeated=0,
+    repairing=0,
+):
+    return {
+        "active_cross_question_confident_wrong_node_count": cross_confident,
+        "active_confident_wrong_repairing_node_count": confident_nodes,
+        "active_cross_question_wrong_node_count": cross_wrong,
+        "active_repeated_weakness_node_count": repeated,
+        "active_evaluable_wrong_repairing_node_count": repairing,
+    }
+
+
+def field(*, evaluable_count=0, evaluable_accuracy=None):
+    return {
+        "evaluable_answer_count": evaluable_count,
+        "evaluable_accuracy": evaluable_accuracy,
+    }
+
+
+def test_j2_cross_confident_precedes_confident_node_cluster():
+    candidates = build_j2_candidates(
+        {
+            1: active(cross_confident=1, confident_nodes=1, repairing=1),
+            2: active(confident_nodes=3, repairing=3),
+        },
+        field_records={1: field(), 2: field()},
+    )
+    assert [item["field_id"] for item in candidates] == [1, 2]
+
+
+def test_j2_uses_active_evaluable_repairing_burden_not_total_state_count():
+    candidates = build_j2_candidates(
+        {
+            1: active(confident_nodes=2, repairing=2),
+            2: active(confident_nodes=2, repairing=4),
+        },
+        field_records={1: field(), 2: field()},
+    )
+    assert [item["field_id"] for item in candidates] == [2, 1]
+
+
+def test_j2_sparse_evaluable_accuracy_cannot_win():
+    candidates = build_j2_candidates(
+        {
+            1: active(confident_nodes=2, repairing=2),
+            2: active(confident_nodes=2, repairing=2),
+        },
+        field_records={
+            1: field(evaluable_count=4, evaluable_accuracy=0.0),
+            2: field(evaluable_count=10, evaluable_accuracy=0.8),
+        },
+    )
+    assert [item["field_id"] for item in candidates] == [2, 1]
+    assert candidates[1]["reliable_accuracy"] == 1.0
+
+
+def test_j2_evaluable_accuracy_breaks_exact_reliable_tie():
+    candidates = build_j2_candidates(
+        {
+            1: active(confident_nodes=2, repairing=2),
+            2: active(confident_nodes=2, repairing=2),
+        },
+        field_records={
+            1: field(evaluable_count=10, evaluable_accuracy=0.7),
+            2: field(evaluable_count=10, evaluable_accuracy=0.5),
+        },
+    )
+    assert [item["field_id"] for item in candidates] == [2, 1]
+
+
+def test_j2_requires_cross_confident_or_two_confident_nodes():
+    candidates = build_j2_candidates(
+        {1: active(confident_nodes=1, repairing=5)},
+        field_records={1: field(evaluable_count=20, evaluable_accuracy=0.2)},
+    )
+    assert candidates == []
+
+
+def test_j3_cross_wrong_precedes_repeated_cluster():
+    candidates = build_j3_candidates({
+        1: active(cross_wrong=1, repeated=1, repairing=1),
+        2: active(repeated=3, repairing=3),
+    })
+    assert [item["field_id"] for item in candidates] == [1, 2]
+
+
+def test_j3_uses_active_evaluable_repairing_burden():
+    candidates = build_j3_candidates({
+        1: active(repeated=2, repairing=2),
+        2: active(repeated=2, repairing=4),
+    })
+    assert [item["field_id"] for item in candidates] == [2, 1]
+
+
+def test_j3_lone_repeated_node_does_not_trigger():
+    candidates = build_j3_candidates({
+        1: active(repeated=1, repairing=1),
+    })
+    assert candidates == []
+
+
+def test_j3_two_repeated_nodes_trigger():
+    candidates = build_j3_candidates({
+        1: active(repeated=2, repairing=2),
+    })
+    assert [item["field_id"] for item in candidates] == [1]

--- a/tests/test_phase11_active_safety.py
+++ b/tests/test_phase11_active_safety.py
@@ -1,0 +1,109 @@
+from datetime import datetime, timedelta, timezone
+
+from knowledge_node_weakness_evidence import (
+    CROSS_QUESTION_CONFIDENT_WRONG,
+    CROSS_QUESTION_WRONG,
+    REPEATED_SAME_QUESTION_WRONG,
+    SINGLE_WRONG,
+)
+from phase11_active_safety import build_active_safety_candidates
+
+
+BASE = datetime(2026, 9, 1, tzinfo=timezone.utc)
+
+
+def fact(
+    *,
+    wrong_qs,
+    level=SINGLE_WRONG,
+    confident=False,
+    count=1,
+    when=BASE,
+):
+    return {
+        "active_evaluable_wrong_question_ids": list(wrong_qs),
+        "active_evaluable_wrong_attempt_count": count,
+        "active_has_confident_wrong": confident,
+        "active_weakness_evidence_level": level,
+        "active_last_evaluable_wrong_at": when,
+    }
+
+
+def test_unknown_only_or_no_evaluable_wrong_creates_no_safety_candidate():
+    candidates = build_active_safety_candidates(
+        {"KN1": fact(wrong_qs=[], count=0)},
+        field_by_question={"Q1": 8},
+        critical_nodes={"KN1"},
+    )
+    assert candidates == []
+
+
+def test_noncritical_active_wrong_is_not_j1_candidate():
+    candidates = build_active_safety_candidates(
+        {"KN1": fact(wrong_qs=["Q1"])},
+        field_by_question={"Q1": 8},
+        critical_nodes=set(),
+    )
+    assert candidates == []
+
+
+def test_j1_tier_order_matches_existing_phase11_policy():
+    candidates = build_active_safety_candidates(
+        {
+            "KNCROSSCONF": fact(
+                wrong_qs=["Q1", "Q2"],
+                level=CROSS_QUESTION_CONFIDENT_WRONG,
+                confident=True,
+            ),
+            "KNCROSS": fact(
+                wrong_qs=["Q3", "Q4"],
+                level=CROSS_QUESTION_WRONG,
+            ),
+            "KNCONF": fact(wrong_qs=["Q5"], confident=True),
+            "KNREPEAT": fact(
+                wrong_qs=["Q6"],
+                level=REPEATED_SAME_QUESTION_WRONG,
+                count=2,
+            ),
+            "KNSINGLE": fact(wrong_qs=["Q7"]),
+        },
+        field_by_question={
+            "Q1": 8, "Q2": 8, "Q3": 8, "Q4": 8,
+            "Q5": 8, "Q6": 8, "Q7": 8,
+        },
+        critical_nodes={"KNCROSSCONF", "KNCROSS", "KNCONF", "KNREPEAT", "KNSINGLE"},
+    )
+    assert [item["canonical_node_id"] for item in candidates] == [
+        "KNCROSSCONF", "KNCROSS", "KNCONF", "KNREPEAT", "KNSINGLE"
+    ]
+    assert [item["priority_tier"] for item in candidates] == [0, 1, 2, 3, 4]
+
+
+def test_more_recent_wrong_wins_within_same_tier():
+    candidates = build_active_safety_candidates(
+        {
+            "KNOLD": fact(wrong_qs=["Q1"], when=BASE),
+            "KNNEW": fact(wrong_qs=["Q2"], when=BASE + timedelta(hours=1)),
+        },
+        field_by_question={"Q1": 8, "Q2": 8},
+        critical_nodes={"KNOLD", "KNNEW"},
+    )
+    assert [item["canonical_node_id"] for item in candidates] == ["KNNEW", "KNOLD"]
+
+
+def test_multi_field_node_uses_only_observed_wrong_source_fields():
+    candidates = build_active_safety_candidates(
+        {"KN1": fact(wrong_qs=["Q1", "Q2"], level=CROSS_QUESTION_WRONG)},
+        field_by_question={"Q1": 3, "Q2": 9},
+        critical_nodes={"KN1"},
+    )
+    assert [item["field_id"] for item in candidates] == [3, 9]
+
+
+def test_unobserved_static_member_field_is_not_invented():
+    candidates = build_active_safety_candidates(
+        {"KN1": fact(wrong_qs=["Q1"])},
+        field_by_question={"Q1": 3, "QSTATIC": 9},
+        critical_nodes={"KN1"},
+    )
+    assert [item["field_id"] for item in candidates] == [3]

--- a/tests/test_phase11_evaluable_nonrepair_rules.py
+++ b/tests/test_phase11_evaluable_nonrepair_rules.py
@@ -1,0 +1,84 @@
+from phase11_evaluable_nonrepair_rules import (
+    build_j5_sparse_field_candidates,
+    build_j6_uncertain_correct_candidates,
+)
+
+
+def field(
+    *,
+    evaluable=0,
+    raw=0,
+    unknown=0,
+    coverage=0.0,
+    checking=0,
+):
+    return {
+        "evaluable_answer_count": evaluable,
+        "question_answer_count": raw,
+        "unknown_answer_count": unknown,
+        "node_coverage": {"percent": coverage},
+        "checking_node_count": checking,
+    }
+
+
+def test_j5_uses_evaluable_count_not_raw_attempt_count():
+    candidates = build_j5_sparse_field_candidates({
+        1: field(evaluable=0, raw=10, unknown=10, coverage=10.0),
+        2: field(evaluable=10, raw=10, unknown=0, coverage=10.0),
+    })
+    assert [item["field_id"] for item in candidates] == [1]
+    assert candidates[0]["raw_answer_count"] == 10
+    assert candidates[0]["evaluable_answer_count"] == 0
+
+
+def test_j5_orders_by_evaluable_then_coverage_then_field_id():
+    candidates = build_j5_sparse_field_candidates({
+        3: field(evaluable=4, coverage=10.0),
+        2: field(evaluable=4, coverage=5.0),
+        1: field(evaluable=3, coverage=50.0),
+    })
+    assert [item["field_id"] for item in candidates] == [1, 2, 3]
+
+
+def test_j5_excludes_fields_with_ten_evaluable_answers():
+    assert build_j5_sparse_field_candidates({1: field(evaluable=10)}) == []
+
+
+def test_j6_unknown_attempts_do_not_satisfy_five_answer_minimum():
+    candidates = build_j6_uncertain_correct_candidates(
+        {1: field(evaluable=3, raw=5, unknown=2)},
+        uncertain_correct_by_field={1: 3},
+    )
+    assert candidates == []
+
+
+def test_j6_requires_three_uncertain_correct_answers():
+    candidates = build_j6_uncertain_correct_candidates(
+        {1: field(evaluable=10)},
+        uncertain_correct_by_field={1: 2},
+    )
+    assert candidates == []
+
+
+def test_j6_orders_count_then_evaluable_proportion_then_checking():
+    candidates = build_j6_uncertain_correct_candidates(
+        {
+            1: field(evaluable=10, checking=1),
+            2: field(evaluable=5, checking=0),
+            3: field(evaluable=5, checking=3),
+        },
+        uncertain_correct_by_field={1: 3, 2: 3, 3: 3},
+    )
+    assert [item["field_id"] for item in candidates] == [3, 2, 1]
+    assert candidates[0]["uncertain_correct_proportion"] == 0.6
+
+
+def test_j6_field_id_is_final_tie_break():
+    candidates = build_j6_uncertain_correct_candidates(
+        {
+            2: field(evaluable=5, checking=1),
+            1: field(evaluable=5, checking=1),
+        },
+        uncertain_correct_by_field={1: 3, 2: 3},
+    )
+    assert [item["field_id"] for item in candidates] == [1, 2]


### PR DESCRIPTION
Superseded by tested integration PR #28, which includes the active-cycle J1-J6 evidence/ranking preparation and is already merged to main. Historical draft only.