### PR TITLE
Attribute Phase11 J4 retention to reference question field

### DIFF
--- a/phase11_retention_field_facts.py
+++ b/phase11_retention_field_facts.py
@@ -1,0 +1,93 @@
+"""Pure Phase11 J4 retention attribution from formal reference questions."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any, Iterable, Mapping
+
+
+def build_retention_field_facts(
+    node_states: Iterable[Mapping[str, Any]],
+    *,
+    field_by_question: Mapping[str, int],
+) -> dict[str, Any]:
+    """Attribute recheck_due Nodes to the field of their retention reference Q.
+
+    Missing/unmapped reference questions are surfaced as unattributed instead of
+    being copied across static canonical-Node memberships.
+    """
+    by_field: dict[int, dict[str, Any]] = defaultdict(lambda: {
+        "recheck_due_node_count": 0,
+        "max_overdue_days": 0,
+        "total_overdue_days": 0,
+        "canonical_node_ids": [],
+        "retention_reference_question_ids": [],
+    })
+    unattributed: list[dict[str, Any]] = []
+
+    for source in node_states:
+        if source.get("state") != "recheck_due":
+            continue
+        node_id = str(source.get("canonical_node_id") or "")
+        reference_q = str(source.get("retention_reference_question_id") or "")
+        overdue = max(0, int(source.get("due_overdue_days") or 0))
+        field_id = field_by_question.get(reference_q)
+        if field_id is None:
+            unattributed.append({
+                "canonical_node_id": node_id,
+                "retention_reference_question_id": reference_q or None,
+                "due_overdue_days": overdue,
+                "reason": "missing_or_unmapped_retention_reference_question",
+            })
+            continue
+        field_id = int(field_id)
+        item = by_field[field_id]
+        item["recheck_due_node_count"] += 1
+        item["max_overdue_days"] = max(item["max_overdue_days"], overdue)
+        item["total_overdue_days"] += overdue
+        item["canonical_node_ids"].append(node_id)
+        item["retention_reference_question_ids"].append(reference_q)
+
+    normalized: dict[int, dict[str, Any]] = {}
+    for field_id, source in sorted(by_field.items()):
+        item = dict(source)
+        item["canonical_node_ids"] = sorted(item["canonical_node_ids"])
+        item["retention_reference_question_ids"] = sorted(
+            item["retention_reference_question_ids"]
+        )
+        normalized[field_id] = item
+
+    return {
+        "by_field": normalized,
+        "unattributed": sorted(
+            unattributed,
+            key=lambda item: (
+                -item["due_overdue_days"],
+                item["canonical_node_id"],
+            ),
+        ),
+    }
+
+
+def build_j4_candidates(retention_facts: Mapping[str, Any]) -> list[dict[str, Any]]:
+    """Return J4 fields in the existing Phase11 retention tie-break order."""
+    candidates = []
+    for field_id, source in retention_facts.get("by_field", {}).items():
+        count = int(source.get("recheck_due_node_count") or 0)
+        if count <= 0:
+            continue
+        candidates.append({
+            "field_id": int(field_id),
+            "recheck_due_node_count": count,
+            "max_overdue_days": int(source.get("max_overdue_days") or 0),
+            "total_overdue_days": int(source.get("total_overdue_days") or 0),
+        })
+    return sorted(
+        candidates,
+        key=lambda item: (
+            -item["recheck_due_node_count"],
+            -item["max_overdue_days"],
+            -item["total_overdue_days"],
+            item["field_id"],
+        ),
+    )

--- a/tests/test_phase11_retention_field_facts.py
+++ b/tests/test_phase11_retention_field_facts.py
@@ -1,0 +1,96 @@
+from phase11_retention_field_facts import (
+    build_j4_candidates,
+    build_retention_field_facts,
+)
+
+
+def state(
+    node,
+    *,
+    status="recheck_due",
+    ref=None,
+    overdue=0,
+):
+    return {
+        "canonical_node_id": node,
+        "state": status,
+        "retention_reference_question_id": ref,
+        "due_overdue_days": overdue,
+    }
+
+
+def test_recheck_due_is_attributed_to_reference_question_field_only():
+    facts = build_retention_field_facts(
+        [state("KN1", ref="Q1", overdue=3)],
+        field_by_question={"Q1": 7, "QSTATIC": 9},
+    )
+    assert set(facts["by_field"]) == {7}
+    assert facts["by_field"][7]["canonical_node_ids"] == ["KN1"]
+    assert facts["unattributed"] == []
+
+
+def test_non_due_states_do_not_create_j4_evidence():
+    facts = build_retention_field_facts(
+        [state("KN1", status="repaired", ref="Q1", overdue=0)],
+        field_by_question={"Q1": 7},
+    )
+    assert facts["by_field"] == {}
+    assert facts["unattributed"] == []
+
+
+def test_missing_reference_is_unattributed_not_duplicated():
+    facts = build_retention_field_facts(
+        [state("KN1", ref=None, overdue=4)],
+        field_by_question={"Q1": 7},
+    )
+    assert facts["by_field"] == {}
+    assert facts["unattributed"][0]["canonical_node_id"] == "KN1"
+    assert facts["unattributed"][0]["retention_reference_question_id"] is None
+
+
+def test_unmapped_reference_is_unattributed():
+    facts = build_retention_field_facts(
+        [state("KN1", ref="QUNKNOWN", overdue=2)],
+        field_by_question={"Q1": 7},
+    )
+    assert facts["by_field"] == {}
+    assert facts["unattributed"][0]["reason"] == "missing_or_unmapped_retention_reference_question"
+
+
+def test_field_aggregates_count_max_and_total_overdue():
+    facts = build_retention_field_facts(
+        [
+            state("KN1", ref="Q1", overdue=2),
+            state("KN2", ref="Q2", overdue=5),
+        ],
+        field_by_question={"Q1": 7, "Q2": 7},
+    )
+    field = facts["by_field"][7]
+    assert field["recheck_due_node_count"] == 2
+    assert field["max_overdue_days"] == 5
+    assert field["total_overdue_days"] == 7
+
+
+def test_j4_candidate_order_matches_existing_policy():
+    facts = {
+        "by_field": {
+            1: {"recheck_due_node_count": 2, "max_overdue_days": 3, "total_overdue_days": 5},
+            2: {"recheck_due_node_count": 2, "max_overdue_days": 5, "total_overdue_days": 5},
+            3: {"recheck_due_node_count": 2, "max_overdue_days": 5, "total_overdue_days": 8},
+            4: {"recheck_due_node_count": 1, "max_overdue_days": 20, "total_overdue_days": 20},
+        },
+        "unattributed": [],
+    }
+    candidates = build_j4_candidates(facts)
+    assert [item["field_id"] for item in candidates] == [3, 2, 1, 4]
+
+
+def test_j4_field_id_is_final_tie_break():
+    facts = {
+        "by_field": {
+            2: {"recheck_due_node_count": 1, "max_overdue_days": 2, "total_overdue_days": 2},
+            1: {"recheck_due_node_count": 1, "max_overdue_days": 2, "total_overdue_days": 2},
+        },
+        "unattributed": [],
+    }
+    assert [item["field_id"] for item in build_j4_candidates(facts)] == [1, 2]


### PR DESCRIPTION
Superseded by tested integration PR #28, which includes J4 retention attribution to the reference-question field and is already merged to main. Historical draft only.