### PR TITLE
perf: instrument supporter first-open baseline

### DIFF
--- a/developer_ui.py
+++ b/developer_ui.py
@@ -15,6 +15,7 @@ from flask import abort, redirect, render_template, request, url_for
 
 from goukaku_ui import build_dashboard
 from pilot_diagnostics import build_pilot_diagnostics
+from supporter_performance import begin_request, finish_request
 
 
 LEGACY_DIAGNOSTICS_PATH = "/supporter/pilot-diagnostics"
@@ -43,6 +44,18 @@ def require_developer_authorization() -> str:
 
 def register_developer_routes(blueprint) -> None:
     """Attach developer-only routes and legacy-route guard to ``blueprint``."""
+
+    @blueprint.before_app_request
+    def _begin_supporter_perf_probe():
+        if request.path == "/supporter":
+            begin_request()
+        return None
+
+    @blueprint.after_app_request
+    def _finish_supporter_perf_probe(response):
+        if request.path == "/supporter":
+            finish_request(response.status_code)
+        return response
 
     @blueprint.before_app_request
     def _guard_legacy_developer_routes():

--- a/supporter_performance.py
+++ b/supporter_performance.py
@@ -1,0 +1,75 @@
+"""Temporary, feature-gated timing probe for supporter first-open measurements.
+
+No learner/supporter identifiers or payload content are logged. Enable only while
+collecting Issue #100 baseline data with ``LT_SUPPORTER_PERF_LOG=1``.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from contextvars import ContextVar
+import logging
+import os
+from time import perf_counter
+from uuid import uuid4
+
+
+logger = logging.getLogger(__name__)
+_TRACE_ID: ContextVar[str | None] = ContextVar("supporter_perf_trace_id", default=None)
+_ROUTE_STARTED: ContextVar[float | None] = ContextVar("supporter_perf_route_started", default=None)
+_TRUE_VALUES = {"1", "true", "yes", "on"}
+
+
+def enabled() -> bool:
+    return os.getenv("LT_SUPPORTER_PERF_LOG", "").strip().lower() in _TRUE_VALUES
+
+
+def begin_request() -> str | None:
+    if not enabled():
+        return None
+    trace_id = uuid4().hex[:12]
+    _TRACE_ID.set(trace_id)
+    _ROUTE_STARTED.set(perf_counter())
+    return trace_id
+
+
+def current_trace_id() -> str | None:
+    return _TRACE_ID.get()
+
+
+def log_duration(operation: str, duration_seconds: float, **facts) -> None:
+    if not enabled():
+        return
+    safe_facts = " ".join(
+        f"{key}={value}" for key, value in sorted(facts.items())
+        if value is not None
+    )
+    logger.info(
+        "lt_supporter_perf trace=%s op=%s duration_ms=%.3f%s",
+        current_trace_id() or "none",
+        operation,
+        max(duration_seconds, 0.0) * 1000.0,
+        f" {safe_facts}" if safe_facts else "",
+    )
+
+
+@contextmanager
+def measure(operation: str):
+    if not enabled():
+        yield
+        return
+    started = perf_counter()
+    try:
+        yield
+    finally:
+        log_duration(operation, perf_counter() - started)
+
+
+def finish_request(status_code: int | None = None) -> None:
+    if not enabled():
+        return
+    started = _ROUTE_STARTED.get()
+    if started is not None:
+        log_duration("http_total", perf_counter() - started, status=status_code)
+    _TRACE_ID.set(None)
+    _ROUTE_STARTED.set(None)

--- a/supporter_report.py
+++ b/supporter_report.py
@@ -21,6 +21,7 @@ from field_evidence import build_field_evidence
 from field_progress import build_field_progress
 from learning_analysis import build_learning_guidance
 from pass_readiness import build_pass_readiness
+from supporter_performance import measure
 
 
 _POSITION_TEXT = {
@@ -102,9 +103,11 @@ def _pace(activity: dict) -> dict:
 
 
 def _parent_summary(summary: dict, activity: dict, fields: list[dict], latest: dict, attempts: list[dict]) -> dict:
-    evidence = build_field_evidence(attempts)
-    progress = build_field_progress(evidence)
-    readiness = build_pass_readiness(attempts, field_evidence=evidence, progress=progress)
+    with measure("parent_summary.evidence"):
+        evidence = build_field_evidence(attempts)
+        progress = build_field_progress(evidence)
+    with measure("parent_summary.readiness"):
+        readiness = build_pass_readiness(attempts, field_evidence=evidence, progress=progress)
     readiness_status = readiness["status"]
     coverage = float(readiness["components"]["coverage"].get("node_coverage") or 0.0)
     trajectory_status, trajectory_reason = _TRAJECTORY.get(
@@ -153,32 +156,40 @@ def _parent_summary(summary: dict, activity: dict, fields: list[dict], latest: d
 
 def build_supporter_report(learner_user_id: str) -> dict:
     """Return parent-facing data only; never consultation text or dev diagnostics."""
-    learning_data = get_dashboard_learning_data(learner_user_id)
-    summary = learning_data["summary"]
-    activity = learning_data["activity"]
-    all_fields = learning_data["fields"]
-    learned_fields = [item for item in all_fields if item["learned"]]
-    guidance = build_learning_guidance(summary["total_answers"], all_fields)
-    latest = _format_latest(get_latest_learning_day_summary(learner_user_id))
-    latest_activity = _format_latest_activity(get_latest_activity_day_summary(learner_user_id))
-    attempts = get_question_attempts(learner_user_id)
+    with measure("build_supporter_report.total"):
+        with measure("db.dashboard_learning_data"):
+            learning_data = get_dashboard_learning_data(learner_user_id)
+        summary = learning_data["summary"]
+        activity = learning_data["activity"]
+        all_fields = learning_data["fields"]
+        learned_fields = [item for item in all_fields if item["learned"]]
+        with measure("python.learning_guidance"):
+            guidance = build_learning_guidance(summary["total_answers"], all_fields)
+        with measure("db.latest_learning_day_summary"):
+            latest = _format_latest(get_latest_learning_day_summary(learner_user_id))
+        with measure("db.latest_activity_day_summary"):
+            latest_activity = _format_latest_activity(get_latest_activity_day_summary(learner_user_id))
+        with measure("db.question_attempts"):
+            attempts = get_question_attempts(learner_user_id)
+        with measure("python.parent_summary"):
+            parent_summary = _parent_summary(summary, activity, learned_fields, latest, attempts)
 
-    return {
-        # vNext stable contract
-        "parent_summary": _parent_summary(summary, activity, learned_fields, latest, attempts),
-        # temporary compatibility contract for the current supporter template/tests
-        "latest": latest,
-        "latest_studied": latest["has_learning"],
-        "latest_fields": latest["fields"],
-        "latest_activity": latest_activity,
-        "weekly_learning_days": activity["weekly_learning_days"],
-        "weekly_answers": activity["weekly_answers"],
-        "weekly_study_minutes": activity["weekly_study_minutes"],
-        "weekly_accuracy": activity["weekly_accuracy"],
-        "streak_days": activity["streak_days"],
-        "fields": learned_fields,
-        "weak_fields": guidance["weak_fields"],
-        "weak_analysis_message": guidance["weak_analysis_message"],
-        "recommended_study": guidance["recommended_study"],
-        "comment": _supporter_comment(latest, activity["streak_days"]),
-    }
+        return {
+            # vNext stable contract
+            "parent_summary": parent_summary,
+            # temporary compatibility contract for the current supporter template/tests
+            "latest": latest,
+            "latest_studied": latest["has_learning"],
+            "latest_fields": latest["fields"],
+            "latest_activity": latest_activity,
+            "weekly_learning_days": activity["weekly_learning_days"],
+            "weekly_answers": activity["weekly_answers"],
+            "weekly_study_minutes": activity["weekly_study_minutes"],
+            "weekly_accuracy": activity["weekly_accuracy"],
+            "streak_days": activity["streak_days"],
+            "fields": learned_fields,
+            "weak_fields": guidance["weak_fields"],
+            "weak_analysis_message": guidance["weak_analysis_message"],
+            "recommended_study": guidance["recommended_study"],
+            "comment": _supporter_comment(latest, activity["streak_days"]),
+        }

--- a/tests/test_supporter_performance_probe.py
+++ b/tests/test_supporter_performance_probe.py
@@ -1,0 +1,31 @@
+import logging
+import os
+from time import sleep
+
+import supporter_performance as perf
+
+
+def test_probe_is_disabled_by_default(monkeypatch, caplog):
+    monkeypatch.delenv("LT_SUPPORTER_PERF_LOG", raising=False)
+    caplog.set_level(logging.INFO)
+    assert perf.begin_request() is None
+    with perf.measure("disabled"):
+        pass
+    perf.finish_request(200)
+    assert "lt_supporter_perf" not in caplog.text
+
+
+def test_probe_logs_trace_operation_and_total_without_identifiers(monkeypatch, caplog):
+    monkeypatch.setenv("LT_SUPPORTER_PERF_LOG", "1")
+    caplog.set_level(logging.INFO)
+    trace_id = perf.begin_request()
+    assert trace_id
+    with perf.measure("db.question_attempts"):
+        sleep(0.001)
+    perf.finish_request(200)
+    text = caplog.text
+    assert f"trace={trace_id}" in text
+    assert "op=db.question_attempts" in text
+    assert "op=http_total" in text
+    assert "status=200" in text
+    assert "duration_ms=" in text


### PR DESCRIPTION
Closes measurement step of #100 without changing supporter data semantics.

Adds a temporary, feature-gated `LT_SUPPORTER_PERF_LOG` probe using monotonic timing and anonymous trace ids. Measures:
- total `/supporter` HTTP route duration
- total `build_supporter_report`
- dashboard learning data DB read bundle
- latest learning day DB read
- latest activity day DB read
- question attempts DB read
- learning-guidance Python work
- parent evidence/readiness Python work

No learner/supporter IDs or content are logged. Disabled by default. Intended only for baseline collection, then removal/disable after #100 evidence is captured.

No DB writes/migrations, selector changes, Phase11/12 policy changes, or learner-route changes.