### PR TITLE
test: restore saved adaptive audit CI coverage

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,10 +27,8 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt pytest
       - name: Run test suite
-        # The UTF candidate fixture lives outside this repo, and the saved-adaptive
-        # UI assertion targets the retired supporter diagnostics URL. Both are
-        # covered elsewhere by runtime loader and new internal-boundary tests.
+        # This UTF candidate fixture lives outside the repository. Runtime loader
+        # compatibility is covered separately; all repository-contained tests run.
         run: >-
           python -m pytest -q
           --deselect=tests/test_quiz_answer_numbering.py::ConfigurableQuizTest::test_runtime_loader_supports_current_utf16_and_candidate_utf8
-          --deselect=tests/test_saved_adaptive_daily_audit.py::test_supporter_route_displays_persisted_fields_and_keeps_simulation

--- a/tests/test_saved_adaptive_daily_audit.py
+++ b/tests/test_saved_adaptive_daily_audit.py
@@ -10,9 +10,7 @@ from app import app
 from database import (
     get_latest_adaptive_daily_learning_event,
     get_latest_adaptive_daily_learning_session_events,
-    set_supporter_link,
 )
-from goukaku_ui import create_supporter_token
 from pilot_diagnostics import build_saved_adaptive_daily_audit
 
 
@@ -78,7 +76,7 @@ def test_missing_audit_field_is_fail_and_empty_is_safe():
     assert build_saved_adaptive_daily_audit(None)["exists"] is False
 
 
-def test_supporter_route_displays_persisted_fields_and_keeps_simulation():
+def test_internal_route_displays_persisted_fields_and_keeps_simulation(monkeypatch):
     results = [_result(number) for number in range(1, 31)]
     results[0]["recent_question_repeat"] = True
     for index in range(6):
@@ -88,10 +86,10 @@ def test_supporter_route_displays_persisted_fields_and_keeps_simulation():
             "question_results": results[index * 5:(index + 1) * 5],
         }
     before = dict(database._local_learning_events)
-    set_supporter_link("supporter", "learner")
-    token = create_supporter_token("supporter")
+    monkeypatch.setenv("LT_INTERNAL_ADMIN_TOKEN", "developer-token")
     response = app.test_client().get(
-        f"/supporter/pilot-diagnostics?token={token}&learner_user_id=learner"
+        "/internal/pilot-diagnostics"
+        "?token=developer-token&learner_user_id=learner&period=7"
     )
     html = response.get_data(as_text=True)
     assert response.status_code == 200


### PR DESCRIPTION
Moves the saved adaptive_daily diagnostics UI regression to the developer-only `/internal/pilot-diagnostics` route introduced by #99, then removes that test from CI deselection. Leaves only the known external UTF candidate fixture deselected.

No runtime behavior, DB, selector, Phase11/12, or learner route changes.