### PR TITLE
diag: add adaptive past-exam source-mix audit

### DIFF
--- a/adaptive_source_mix.py
+++ b/adaptive_source_mix.py
@@ -1,0 +1,108 @@
+"""Read-only source-mix diagnostics for learner question routes.
+
+This module is deliberately diagnostic-only.  It never changes selector priority:
+Safety, repair evidence, cooldown and formal route policy remain authoritative.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any, Callable, Iterable, Mapping
+
+from question_bank import get_question_tag
+
+
+KNOWN_SOURCES = ("past_exam", "original")
+
+
+def _source_for_question(question_id: str, tag_getter: Callable[[str], Mapping[str, Any]]) -> str:
+    source = str(tag_getter(question_id).get("source") or "").strip()
+    return source if source in KNOWN_SOURCES else "unknown"
+
+
+def _bucket() -> dict[str, Any]:
+    return {
+        "question_count": 0,
+        "correct_count": 0,
+        "answered_count": 0,
+        "confidence_sum": 0,
+        "confidence_count": 0,
+        "question_ids": [],
+    }
+
+
+def _finish(bucket: Mapping[str, Any]) -> dict[str, Any]:
+    answered = int(bucket["answered_count"])
+    confidence_count = int(bucket["confidence_count"])
+    return {
+        "question_count": int(bucket["question_count"]),
+        "correct_count": int(bucket["correct_count"]),
+        "answered_count": answered,
+        "accuracy": (int(bucket["correct_count"]) / answered) if answered else None,
+        "mean_confidence": (
+            float(bucket["confidence_sum"]) / confidence_count if confidence_count else None
+        ),
+        "question_ids": list(bucket["question_ids"]),
+    }
+
+
+def build_source_mix_audit(
+    question_results: Iterable[Mapping[str, Any]],
+    *,
+    tag_getter: Callable[[str], Mapping[str, Any]] = get_question_tag,
+) -> dict[str, Any]:
+    """Summarize source mix by route and selection group without mutating input.
+
+    ``question_results`` should be persisted learner-result rows (for example the
+    flattened ``learning_events.question_results`` objects). Unknown/zero answers
+    stay in exposure counts but do not affect accuracy.
+    """
+    source_buckets = defaultdict(_bucket)
+    route_buckets: dict[str, dict[str, dict[str, Any]]] = defaultdict(lambda: defaultdict(_bucket))
+    group_buckets: dict[str, dict[str, dict[str, Any]]] = defaultdict(lambda: defaultdict(_bucket))
+    total = 0
+
+    for raw in question_results:
+        item = dict(raw)
+        question_id = str(item.get("question_id") or "").strip().upper()
+        if not question_id:
+            continue
+        source = _source_for_question(question_id, tag_getter)
+        route = str(item.get("learning_source") or "unknown").strip() or "unknown"
+        group = str(item.get("selection_group") or "unclassified").strip() or "unclassified"
+        status = str(item.get("answer_status") or "answered").strip().lower()
+        answered = status != "unknown"
+        confidence = item.get("confidence")
+
+        for bucket in (source_buckets[source], route_buckets[route][source], group_buckets[group][source]):
+            bucket["question_count"] += 1
+            bucket["question_ids"].append(question_id)
+            if answered:
+                bucket["answered_count"] += 1
+                if item.get("is_correct") is True:
+                    bucket["correct_count"] += 1
+                if confidence in (1, 2, 3):
+                    bucket["confidence_sum"] += int(confidence)
+                    bucket["confidence_count"] += 1
+        total += 1
+
+    def finalize_nested(raw_nested):
+        return {
+            outer: {source: _finish(bucket) for source, bucket in sorted(inner.items())}
+            for outer, inner in sorted(raw_nested.items())
+        }
+
+    by_source = {source: _finish(bucket) for source, bucket in sorted(source_buckets.items())}
+    past = by_source.get("past_exam", {}).get("question_count", 0)
+    return {
+        "question_count": total,
+        "past_exam_count": int(past),
+        "past_exam_share": (int(past) / total) if total else None,
+        "by_source": by_source,
+        "by_learning_source": finalize_nested(route_buckets),
+        "by_selection_group": finalize_nested(group_buckets),
+        "policy_note": (
+            "Source is diagnostic evidence only; it must not override Safety, repair, "
+            "retention/cooldown, or formal selector priority."
+        ),
+    }

--- a/tests/test_adaptive_source_mix.py
+++ b/tests/test_adaptive_source_mix.py
@@ -1,0 +1,46 @@
+from copy import deepcopy
+
+from adaptive_source_mix import build_source_mix_audit
+
+
+TAGS = {
+    "Q1": {"source": "original"},
+    "Q2": {"source": "past_exam"},
+    "Q3": {"source": "past_exam"},
+    "Q4": {"source": "original"},
+}
+
+
+def _tags(question_id):
+    return TAGS[question_id]
+
+
+def test_source_mix_preserves_input_and_splits_route_group_accuracy_confidence():
+    rows = [
+        {"question_id": "Q1", "learning_source": "adaptive_daily", "selection_group": "repair", "answer_status": "answered", "is_correct": True, "confidence": 1},
+        {"question_id": "Q2", "learning_source": "adaptive_daily", "selection_group": "repair", "answer_status": "answered", "is_correct": False, "confidence": 3},
+        {"question_id": "Q3", "learning_source": "dashboard_recommendation", "selection_group": "exploration", "answer_status": "answered", "is_correct": True, "confidence": 2},
+        {"question_id": "Q4", "learning_source": "adaptive_daily", "selection_group": "exploration", "answer_status": "unknown", "is_correct": False, "confidence": None},
+    ]
+    before = deepcopy(rows)
+    result = build_source_mix_audit(rows, tag_getter=_tags)
+    assert rows == before
+    assert result["question_count"] == 4
+    assert result["past_exam_count"] == 2
+    assert result["past_exam_share"] == 0.5
+    assert result["by_source"]["past_exam"]["accuracy"] == 0.5
+    assert result["by_source"]["past_exam"]["mean_confidence"] == 2.5
+    assert result["by_source"]["original"]["answered_count"] == 1
+    assert result["by_learning_source"]["dashboard_recommendation"]["past_exam"]["question_ids"] == ["Q3"]
+    assert result["by_selection_group"]["repair"]["past_exam"]["accuracy"] == 0.0
+    assert "must not override" in result["policy_note"]
+
+
+def test_empty_and_missing_classification_are_safe():
+    assert build_source_mix_audit([], tag_getter=_tags)["past_exam_share"] is None
+    result = build_source_mix_audit(
+        [{"question_id": "Q1", "answer_status": "answered", "is_correct": True}],
+        tag_getter=_tags,
+    )
+    assert result["by_learning_source"]["unknown"]["original"]["question_count"] == 1
+    assert result["by_selection_group"]["unclassified"]["original"]["question_count"] == 1


### PR DESCRIPTION
Advances #105 with a pure read-only source-mix diagnostic. It summarizes persisted learner question results by formal question source (`past_exam`/`original`), learner route, and selection group, including answered accuracy and mean confidence. Unknown answers remain exposure evidence but do not affect accuracy.

The module is diagnostic-only and explicitly does not alter selector priority. Safety, repair evidence, retention/cooldown and formal selection remain authoritative.

No Production DB write, schema/index change, selector change, or learner-facing promotion.