### PR TITLE
Fix Production dashboard token loss through LIFF entry

### DIFF
--- a/app.py
+++ b/app.py
@@ -1555,19 +1555,19 @@ def is_complete_reset_command(message_text):
 # =========================================================
 
 def build_dashboard_url(user_id):
-    """LIFF設定済みならLIFFブラウザ、未設定なら通常Web URLを返す。"""
+    """Return an authenticated learner URL without relying on LIFF query forwarding."""
     dashboard_token = create_dashboard_token(user_id) if user_id else ""
+    public_dashboard_url = (
+        os.getenv("PUBLIC_BASE_URL", "https://line-bot-project-bxjq.onrender.com").rstrip("/")
+        + "/goukaku-no-michi"
+    )
+    if dashboard_token:
+        return public_dashboard_url + "?token=" + dashboard_token
+
     liff_id = os.getenv("LIFF_ID", "").strip()
     if liff_id:
-        dashboard_url = f"https://liff.line.me/{liff_id}"
-    else:
-        dashboard_url = (
-            os.getenv("PUBLIC_BASE_URL", "https://line-bot-project-bxjq.onrender.com").rstrip("/")
-            + "/goukaku-no-michi"
-        )
-    if dashboard_token:
-        dashboard_url += "?token=" + dashboard_token
-    return dashboard_url
+        return f"https://liff.line.me/{liff_id}"
+    return public_dashboard_url
 
 
 def create_home_message(user_id=None):

--- a/tests/test_dashboard_link_authentication.py
+++ b/tests/test_dashboard_link_authentication.py
@@ -1,0 +1,47 @@
+import os
+from urllib.parse import parse_qs, urlparse
+
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
+os.environ.setdefault("CHANNEL_ACCESS_TOKEN", "test-token")
+os.environ.setdefault("CHANNEL_SECRET", "test-secret")
+
+import app as app_module
+from app import app
+
+
+def _assert_authenticated_dashboard_url(url, user_id):
+    parsed = urlparse(url)
+    assert parsed.path == "/goukaku-no-michi"
+    token = parse_qs(parsed.query)["token"][0]
+    assert app_module.dashboard_user_id(token) == user_id
+    return token
+
+
+def test_home_message_uses_authenticated_direct_dashboard_url_with_liff(monkeypatch):
+    monkeypatch.setenv("LIFF_ID", "1234567890-test")
+    monkeypatch.setenv("PUBLIC_BASE_URL", "https://example.test")
+
+    message = app_module.create_home_message("home-dashboard-user")
+    dashboard_url = message.quick_reply.items[0].action.uri
+    token = _assert_authenticated_dashboard_url(dashboard_url, "home-dashboard-user")
+
+    assert not dashboard_url.startswith("https://liff.line.me/")
+    assert app.test_client().get(f"/goukaku-no-michi?token={token}").status_code == 200
+
+
+def test_dashboard_text_reply_keeps_authenticated_token(monkeypatch):
+    monkeypatch.setenv("LIFF_ID", "1234567890-test")
+    monkeypatch.setenv("PUBLIC_BASE_URL", "https://example.test")
+    replies = []
+    monkeypatch.setattr(app_module, "reply_to_line", lambda token, text: replies.append((token, text)))
+
+    app_module.reply_dashboard_link("reply-token", "reply-dashboard-user")
+
+    dashboard_url = replies[0][1].splitlines()[-1]
+    _assert_authenticated_dashboard_url(dashboard_url, "reply-dashboard-user")
+
+
+def test_dashboard_route_remains_fail_closed():
+    client = app.test_client()
+    assert client.get("/goukaku-no-michi").status_code == 403
+    assert client.get("/goukaku-no-michi?token=invalid").status_code == 403

--- a/tests/test_quiz_answer_numbering.py
+++ b/tests/test_quiz_answer_numbering.py
@@ -1201,18 +1201,23 @@ class NewUserWelcomeTest(unittest.TestCase):
 
         self.assertEqual([("test-reply-token", user_id)], calls)
 
-    def test_dashboard_link_uses_liff_url_when_liff_id_is_configured(self) -> None:
+    def test_authenticated_dashboard_link_keeps_token_when_liff_id_is_configured(self) -> None:
         function_globals = app.build_dashboard_url.__globals__
         original_getenv = function_globals["os"].getenv
-        function_globals["os"].getenv = lambda key, default="": (
-            "1234567890-test" if key == "LIFF_ID" else original_getenv(key, default)
+        values = {
+            "LIFF_ID": "1234567890-test",
+            "PUBLIC_BASE_URL": "https://example.test",
+        }
+        function_globals["os"].getenv = lambda key, default="": values.get(
+            key, original_getenv(key, default)
         )
         try:
             url = app.build_dashboard_url("liff-dashboard-user")
         finally:
             function_globals["os"].getenv = original_getenv
 
-        self.assertTrue(url.startswith("https://liff.line.me/1234567890-test?token="))
+        self.assertTrue(url.startswith("https://example.test/goukaku-no-michi?token="))
+        self.assertTrue(url.split("?token=", 1)[1])
 
     def test_teach_me_gensan_enters_dedicated_term_explanation_mode(self) -> None:
         user_id = "gensan-term-user"


### PR DESCRIPTION
## Production regression
After #139 made learner-data routes fail closed, the LINE `合格への道` entry could return 403. `build_dashboard_url(user_id)` attached the signed dashboard token to a LIFF URL, but the repository has no contract that forwards that LIFF query parameter to `/goukaku-no-michi`.

## Fix
- User-specific dashboard links now open `PUBLIC_BASE_URL/goukaku-no-michi?token=<signed token>` directly, even when `LIFF_ID` is configured.
- Anonymous/non-user fallback behavior retains the existing LIFF URL, so unrelated LIFF usage is not removed.
- `create_home_message()` and `reply_dashboard_link()` continue sharing `build_dashboard_url()`.
- #139 fail-closed behavior remains unchanged: missing/invalid token is still 403.

## Guardrails
- No selector, Recent Cooldown, repair evidence, Safety, Phase 11, DB schema/data, payment, Render environment, or supporter/internal auth changes.

## Tests
- Focused: 48 passed.
- Full CI-equivalent: 871 passed, 125 subtests passed, 1 repository-documented unmanaged UTF fixture deselected.
- Only the existing four LINE SDK deprecation warnings remain.