### PR TITLE
Fix LIFF state dashboard token recovery

### DIFF
--- a/goukaku_ui.py
+++ b/goukaku_ui.py
@@ -1,4 +1,5 @@
 import os
+from urllib.parse import parse_qs
 
 from flask import Blueprint, abort, redirect, render_template, request, url_for
 from itsdangerous import BadSignature, URLSafeSerializer, URLSafeTimedSerializer
@@ -91,6 +92,28 @@ def authorized_dashboard_learner(token):
     if not user_id:
         abort(403)
     return user_id
+
+
+def learner_dashboard_token(args):
+    """Resolve the signed token carrier used by direct and LIFF dashboard entry."""
+    if "token" in args:
+        return args.get("token")
+
+    liff_state = args.get("liff.state")
+    if not isinstance(liff_state, str) or not liff_state.startswith("?"):
+        return None
+    try:
+        state_params = parse_qs(
+            liff_state[1:],
+            keep_blank_values=True,
+            strict_parsing=True,
+        )
+    except ValueError:
+        return None
+    tokens = state_params.get("token", [])
+    if len(tokens) != 1 or not tokens[0]:
+        return None
+    return tokens[0]
 
 
 def create_supporter_token(supporter_user_id):
@@ -274,7 +297,7 @@ def build_dashboard(user_id=None, include_learner_navigation=False):
 
 @goukaku_ui.route("/goukaku-no-michi")
 def home():
-    token = request.args.get("token")
+    token = learner_dashboard_token(request.args)
     user_id = authorized_dashboard_learner(token)
     dashboard = build_dashboard(user_id, include_learner_navigation=True)
     navigation = dashboard.get("learner_navigation") or {}

--- a/tests/test_dashboard_link_authentication.py
+++ b/tests/test_dashboard_link_authentication.py
@@ -45,3 +45,56 @@ def test_dashboard_route_remains_fail_closed():
     client = app.test_client()
     assert client.get("/goukaku-no-michi").status_code == 403
     assert client.get("/goukaku-no-michi?token=invalid").status_code == 403
+
+
+def test_liff_state_recovers_signed_dashboard_token():
+    token = app_module.create_dashboard_token("liff-state-user")
+
+    response = app.test_client().get(
+        "/goukaku-no-michi",
+        query_string={"liff.state": f"?token={token}"},
+    )
+
+    assert response.status_code == 200
+    assert f'data-dashboard-token="{token}"' in response.get_data(as_text=True)
+
+
+def test_liff_state_remains_fail_closed_for_invalid_missing_and_malformed_token():
+    client = app.test_client()
+    states = (
+        "?token=invalid",
+        "?foo=bar",
+        "not-a-query",
+        "?token",
+        "?token=",
+        "?token=one&token=two",
+    )
+
+    for state in states:
+        assert client.get(
+            "/goukaku-no-michi",
+            query_string={"liff.state": state},
+        ).status_code == 403
+
+
+def test_top_level_token_has_priority_over_invalid_liff_state():
+    token = app_module.create_dashboard_token("top-level-user")
+
+    response = app.test_client().get(
+        "/goukaku-no-michi",
+        query_string={"token": token, "liff.state": "?token=invalid&broken"},
+    )
+
+    assert response.status_code == 200
+    assert f'data-dashboard-token="{token}"' in response.get_data(as_text=True)
+
+
+def test_invalid_top_level_token_is_not_replaced_by_valid_liff_state():
+    liff_token = app_module.create_dashboard_token("liff-state-user")
+
+    response = app.test_client().get(
+        "/goukaku-no-michi",
+        query_string={"token": "invalid", "liff.state": f"?token={liff_token}"},
+    )
+
+    assert response.status_code == 403


### PR DESCRIPTION
## Production regression
After #139/#140, Render logs showed the LINE LIFF entry reaching the learner dashboard as:

`/goukaku-no-michi?liff.state=%3Ftoken%3D<signed-dashboard-token>`

Flask therefore receives the signed token inside decoded `liff.state="?token=..."`, while the route previously read only the top-level `token` parameter and failed closed with 403.

## Fix
- Add a small learner-entry token resolver using `urllib.parse.parse_qs`.
- Prefer a top-level `token` whenever that parameter is present.
- Only when it is absent, extract exactly one non-empty `token` from a query-shaped `liff.state`.
- Pass the recovered value through the unchanged `authorized_dashboard_learner()` / signed-token validation.
- Reject missing, invalid, tokenless, malformed, blank, or duplicate-token LIFF state with 403.

## Guardrails
- Existing #139 fail-closed behavior remains.
- Supporter/internal authentication is untouched.
- No selector, Recent Cooldown, repair evidence, Safety, Phase 11, Question Bank, DB, payment, Render environment, learner progress, or recommendation changes.

## Tests
- Focused learner-entry/supporter regression: 58 passed.
- Full CI-equivalent: 875 passed, 125 subtests passed, 1 repository-documented unmanaged UTF fixture deselected.
- Only the existing four LINE SDK deprecation warnings remain.