### PR TITLE
Fix learner navigation desktop grid span

### DIFF
--- a/templates/goukaku/base.html
+++ b/templates/goukaku/base.html
@@ -6,6 +6,7 @@
   <meta name="theme-color" content="#ffffff">
   <title>{% block title %}合格への道{% endblock %}</title>
   <link rel="stylesheet" href="{{ url_for('static', filename='goukaku/goukaku.css', v='20260830-fixed-demo-cleanup1-20260903-dashboard-layout1') }}">
+  <style>.dashboard-grid>.learner-navigation{grid-column:1/-1}</style>
 </head>
 <body>
   <main class="app-shell">{% block content %}{% endblock %}</main>


### PR DESCRIPTION
## Production issue
On PC, the learner navigation block is compressed into a single implicit column inside the 12-column `.dashboard-grid`, while mobile is normal.

## Root cause
`.learner-navigation` is a direct child of `.dashboard-grid` but has no `grid-column` span rule. Other major dashboard sections have explicit spans. This makes the learner navigation occupy only one grid track on desktop.

## Fix
Add only:

`.dashboard-grid>.learner-navigation{grid-column:1/-1}`

in the shared dashboard base template as a minimal hotfix.

No auth, learner logic, selector, DB, supporter, recommendation, or mobile layout changes.