### PR TITLE
Perf: reuse one connection for supporter latest reads

### DIFF
--- a/supporter_report.py
+++ b/supporter_report.py
@@ -13,6 +13,7 @@ from zoneinfo import ZoneInfo
 
 from database import (
     get_dashboard_learning_data,
+    get_db_connection,
     get_latest_activity_day_summary,
     get_latest_learning_day_summary,
     get_question_attempts,
@@ -165,10 +166,15 @@ def build_supporter_report(learner_user_id: str) -> dict:
         learned_fields = [item for item in all_fields if item["learned"]]
         with measure("python.learning_guidance"):
             guidance = build_learning_guidance(summary["total_answers"], all_fields)
-        with measure("db.latest_learning_day_summary"):
-            latest = _format_latest(get_latest_learning_day_summary(learner_user_id))
-        with measure("db.latest_activity_day_summary"):
-            latest_activity = _format_latest_activity(get_latest_activity_day_summary(learner_user_id))
+        with get_db_connection() as conn:
+            with measure("db.latest_learning_day_summary"):
+                latest = _format_latest(
+                    get_latest_learning_day_summary(learner_user_id, _connection=conn)
+                )
+            with measure("db.latest_activity_day_summary"):
+                latest_activity = _format_latest_activity(
+                    get_latest_activity_day_summary(learner_user_id, _connection=conn)
+                )
         with measure("db.question_attempts"):
             attempts = get_question_attempts(learner_user_id)
         with measure("python.parent_summary"):

--- a/supporter_report.py
+++ b/supporter_report.py
@@ -12,6 +12,7 @@ from datetime import timezone
 from zoneinfo import ZoneInfo
 
 from database import (
+    database_is_available,
     get_dashboard_learning_data,
     get_db_connection,
     get_latest_activity_day_summary,
@@ -166,14 +167,22 @@ def build_supporter_report(learner_user_id: str) -> dict:
         learned_fields = [item for item in all_fields if item["learned"]]
         with measure("python.learning_guidance"):
             guidance = build_learning_guidance(summary["total_answers"], all_fields)
-        with get_db_connection() as conn:
+        if database_is_available():
+            with get_db_connection() as conn:
+                with measure("db.latest_learning_day_summary"):
+                    latest = _format_latest(
+                        get_latest_learning_day_summary(learner_user_id, _connection=conn)
+                    )
+                with measure("db.latest_activity_day_summary"):
+                    latest_activity = _format_latest_activity(
+                        get_latest_activity_day_summary(learner_user_id, _connection=conn)
+                    )
+        else:
             with measure("db.latest_learning_day_summary"):
-                latest = _format_latest(
-                    get_latest_learning_day_summary(learner_user_id, _connection=conn)
-                )
+                latest = _format_latest(get_latest_learning_day_summary(learner_user_id))
             with measure("db.latest_activity_day_summary"):
                 latest_activity = _format_latest_activity(
-                    get_latest_activity_day_summary(learner_user_id, _connection=conn)
+                    get_latest_activity_day_summary(learner_user_id)
                 )
         with measure("db.question_attempts"):
             attempts = get_question_attempts(learner_user_id)


### PR DESCRIPTION
Issue #100 targeted experiment.

Production warm baseline shows `/supporter` median HTTP ~13.07s, with repeated Neon read calls dominating. This PR makes the smallest possible test of the connection-churn hypothesis:

- change only `supporter_report.py`
- reuse one `get_db_connection()` for `get_latest_learning_day_summary()` and `get_latest_activity_day_summary()` via their existing `_connection` contract
- leave dashboard aggregation, question-attempt read, auth, template, DB schema/data, selector, Phase11/12, and learner behavior unchanged

Expected result: remove one Neon connection setup from the serial supporter path. If production timing improves materially, follow-up can safely consolidate the remaining reads. If not, revert/stop and investigate with Codex tomorrow.

No Production DB writes or migrations.