### PR TITLE
Add pure Trial100 evidence contract

### DIFF
--- a/tests/test_trial100_evidence.py
+++ b/tests/test_trial100_evidence.py
@@ -1,0 +1,82 @@
+from datetime import date
+
+import pytest
+
+from trial100_evidence import normalize_trial100_record
+
+
+def _record(**overrides):
+    record = {
+        "user_id": "learner-1",
+        "test_date": "2026-09-03",
+        "source_version": "trial100-2026-09-a",
+        "total_questions": 100,
+        "correct_count": 72,
+        "completion_status": "completed",
+        "duration_minutes": 155,
+    }
+    record.update(overrides)
+    return record
+
+
+def test_completed_100_question_attempt_within_160_minutes_is_full_format():
+    result = normalize_trial100_record(_record())
+    assert result["timed_full_format"] is True
+    assert result["score_rate"] == 0.72
+    assert result["supportive"] is False
+
+
+def test_supportive_is_never_inferred_from_score():
+    result = normalize_trial100_record(_record(correct_count=100))
+    assert result["supportive"] is False
+    explicit = normalize_trial100_record(_record(correct_count=100, supportive=True))
+    assert explicit["supportive"] is True
+
+
+def test_over_time_limit_is_recorded_but_not_full_format():
+    result = normalize_trial100_record(_record(duration_minutes=161))
+    assert result["timed_full_format"] is False
+    assert result["correct_count"] == 72
+
+
+def test_missing_duration_is_not_claimed_as_timed_full_format():
+    result = normalize_trial100_record(_record(duration_minutes=None))
+    assert result["timed_full_format"] is False
+
+
+def test_incomplete_attempt_is_not_full_format_even_with_time_recorded():
+    result = normalize_trial100_record(_record(completion_status="incomplete", duration_minutes=120))
+    assert result["timed_full_format"] is False
+
+
+def test_non_100_question_ordinary_aggregate_cannot_be_full_format():
+    result = normalize_trial100_record(_record(total_questions=30, correct_count=25, duration_minutes=40))
+    assert result["timed_full_format"] is False
+
+
+def test_source_version_is_required_for_auditable_trial_identity():
+    with pytest.raises(ValueError, match="source_version"):
+        normalize_trial100_record(_record(source_version=""))
+
+
+def test_score_bounds_are_validated():
+    with pytest.raises(ValueError, match="correct_count"):
+        normalize_trial100_record(_record(correct_count=101))
+    with pytest.raises(ValueError, match="correct_count"):
+        normalize_trial100_record(_record(correct_count=-1))
+
+
+def test_supportive_requires_boolean_not_truthy_string():
+    with pytest.raises(ValueError, match="supportive"):
+        normalize_trial100_record(_record(supportive="yes"))
+
+
+def test_optional_breakdowns_are_preserved_without_interpretation():
+    result = normalize_trial100_record(_record(
+        test_date=date(2026, 9, 3),
+        field_breakdown={"神経医学": {"correct": 8, "total": 10}},
+        review_summary={"confident_wrong": 2},
+    ))
+    assert result["test_date"] == "2026-09-03"
+    assert result["field_breakdown"]["神経医学"]["correct"] == 8
+    assert result["review_summary"]["confident_wrong"] == 2

--- a/trial100_evidence.py
+++ b/trial100_evidence.py
@@ -1,0 +1,99 @@
+"""Pure Trial100 evidence contract for readiness input.
+
+This module validates and normalizes paper-based full-format Trial100 results.
+It does not persist data and does not infer a passing probability or invent a
+score threshold for "supportive" evidence.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Any, Mapping
+
+
+TRIAL100_TOTAL_QUESTIONS = 100
+TRIAL100_TIME_LIMIT_MINUTES = 160
+_ALLOWED_COMPLETION_STATUS = {"completed", "incomplete"}
+
+
+def _iso_date(value: Any) -> str:
+    if isinstance(value, datetime):
+        return value.date().isoformat()
+    if isinstance(value, date):
+        return value.isoformat()
+    text = str(value or "").strip()
+    if not text:
+        raise ValueError("test_date is required")
+    try:
+        return date.fromisoformat(text).isoformat()
+    except ValueError as exc:
+        raise ValueError("test_date must be ISO YYYY-MM-DD") from exc
+
+
+def normalize_trial100_record(record: Mapping[str, Any]) -> dict[str, Any]:
+    """Return a validated, readiness-compatible Trial100 evidence record.
+
+    `supportive` is accepted only as an explicit boolean assessment.  This
+    contract intentionally does not derive supportive evidence from score alone.
+    """
+    user_id = str(record.get("user_id") or "").strip()
+    source_version = str(record.get("source_version") or "").strip()
+    if not user_id:
+        raise ValueError("user_id is required")
+    if not source_version:
+        raise ValueError("source_version is required")
+
+    total_questions = int(record.get("total_questions", TRIAL100_TOTAL_QUESTIONS))
+    correct_count = int(record.get("correct_count", -1))
+    if total_questions <= 0:
+        raise ValueError("total_questions must be positive")
+    if correct_count < 0 or correct_count > total_questions:
+        raise ValueError("correct_count must be between 0 and total_questions")
+
+    completion_status = str(record.get("completion_status") or "completed").strip()
+    if completion_status not in _ALLOWED_COMPLETION_STATUS:
+        raise ValueError("completion_status must be completed or incomplete")
+
+    duration_value = record.get("duration_minutes")
+    duration_minutes = None if duration_value in (None, "") else int(duration_value)
+    if duration_minutes is not None and duration_minutes <= 0:
+        raise ValueError("duration_minutes must be positive when recorded")
+
+    supportive_value = record.get("supportive", False)
+    if not isinstance(supportive_value, bool):
+        raise ValueError("supportive must be an explicit boolean when provided")
+
+    timed_full_format = bool(
+        total_questions == TRIAL100_TOTAL_QUESTIONS
+        and completion_status == "completed"
+        and duration_minutes is not None
+        and duration_minutes <= TRIAL100_TIME_LIMIT_MINUTES
+    )
+
+    field_breakdown = record.get("field_breakdown")
+    if field_breakdown is not None and not isinstance(field_breakdown, Mapping):
+        raise ValueError("field_breakdown must be a mapping when provided")
+
+    review_summary = record.get("review_summary")
+    if review_summary is not None and not isinstance(review_summary, Mapping):
+        raise ValueError("review_summary must be a mapping when provided")
+
+    return {
+        "user_id": user_id,
+        "test_date": _iso_date(record.get("test_date")),
+        "source_version": source_version,
+        "total_questions": total_questions,
+        "correct_count": correct_count,
+        "score_rate": correct_count / total_questions,
+        "completion_status": completion_status,
+        "duration_minutes": duration_minutes,
+        "timed_full_format": timed_full_format,
+        "supportive": supportive_value,
+        "field_breakdown": dict(field_breakdown) if field_breakdown is not None else None,
+        "review_summary": dict(review_summary) if review_summary is not None else None,
+    }
+
+
+def normalize_trial100_records(records: list[Mapping[str, Any]] | tuple[Mapping[str, Any], ...]) -> list[dict[str, Any]]:
+    """Normalize records without changing order or synthesizing missing attempts."""
+    return [normalize_trial100_record(record) for record in records]


### PR DESCRIPTION
Issue #102 foundation only. Adds a pure, non-persistent Trial100 evidence contract and tests.

Scope:
- validate user/date/source/score/completion/duration fields
- derive only the factual `timed_full_format` flag from 100 questions + completed + recorded duration <= 160 minutes
- preserve score and optional field/review breakdowns
- never infer `supportive` from score; it must be explicitly supplied as a boolean
- require source_version so ordinary app aggregates cannot silently masquerade as Trial100

No database schema or Production DB write. No input UI. No selector/Phase11 behavior change. `pass_readiness.py` is unchanged and already accepts Trial100-compatible records. Persistence/UI remain a later #102 step.