### PR TITLE
Refine learner navigation to one primary CTA

### DIFF
--- a/static/goukaku/learner-navigation-v02.css
+++ b/static/goukaku/learner-navigation-v02.css
@@ -1,0 +1,4 @@
+.dashboard-grid>.learner-navigation~.learning-overview .guidance-stack>.weak-card,
+.dashboard-grid>.learner-navigation~.learning-overview .guidance-stack>.recommend-card {
+  display: none;
+}

--- a/templates/goukaku/base.html
+++ b/templates/goukaku/base.html
@@ -6,6 +6,7 @@
   <meta name="theme-color" content="#ffffff">
   <title>{% block title %}合格への道{% endblock %}</title>
   <link rel="stylesheet" href="{{ url_for('static', filename='goukaku/goukaku.css', v='20260830-fixed-demo-cleanup1-20260903-dashboard-layout1') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='goukaku/learner-navigation-v02.css', v='20260903-single-cta1') }}">
   <style>.dashboard-grid>.learner-navigation{grid-column:1/-1}</style>
 </head>
 <body>

--- a/tests/test_learner_navigation_v02_single_cta.py
+++ b/tests/test_learner_navigation_v02_single_cta.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_learner_navigation_v02_styles_are_loaded():
+    base = (ROOT / "templates/goukaku/base.html").read_text(encoding="utf-8")
+    assert "goukaku/learner-navigation-v02.css" in base
+    assert "20260903-single-cta1" in base
+
+
+def test_learner_navigation_hides_only_duplicate_legacy_guidance_cards():
+    css = (ROOT / "static/goukaku/learner-navigation-v02.css").read_text(encoding="utf-8")
+    assert ".dashboard-grid>.learner-navigation~.learning-overview .guidance-stack>.weak-card" in css
+    assert ".dashboard-grid>.learner-navigation~.learning-overview .guidance-stack>.recommend-card" in css
+    assert ".gensan-card" not in css


### PR DESCRIPTION
Item 12 v0.2 polish after #96/#127.

Problem: authenticated learner `合格への道` already has the validated top learner-navigation (`現在地` + `今日やること` + evidence-backed attention), but the legacy lower-page `苦手分野 TOP3` and `今日のおすすめ学習` cards are still visible. That leaves two competing learner guidance/CTA systems on one page.

Change:
- add a learner-navigation-only stylesheet
- when `.learner-navigation` is present, hide only the legacy `.weak-card` and `.recommend-card` inside the lower guidance stack
- keep 源さん, learning facts, field detail, supporter/read-only paths unchanged
- no selector, readiness, Phase11, DB, auth, or Question Bank behavior changes

This preserves the Item 12 contract that the learner should have one deterministic primary next action while avoiding a large template rewrite without Codex.