### PR TITLE
Add explicit Trial100 storage adapter

### DIFF
--- a/migrations/20260904_trial100_attempts.sql
+++ b/migrations/20260904_trial100_attempts.sql
@@ -1,0 +1,26 @@
+CREATE TABLE trial100_attempts (
+    id BIGSERIAL PRIMARY KEY,
+    user_id TEXT NOT NULL,
+    test_date DATE NOT NULL,
+    source_version TEXT NOT NULL,
+    total_questions INTEGER NOT NULL,
+    correct_count INTEGER NOT NULL,
+    completion_status TEXT NOT NULL DEFAULT 'completed',
+    duration_minutes INTEGER,
+    supportive BOOLEAN NOT NULL DEFAULT FALSE,
+    field_breakdown JSONB,
+    review_summary JSONB,
+    recorded_by TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (user_id, test_date, source_version),
+    CHECK (length(btrim(user_id)) > 0),
+    CHECK (length(btrim(source_version)) > 0),
+    CHECK (total_questions > 0),
+    CHECK (correct_count BETWEEN 0 AND total_questions),
+    CHECK (completion_status IN ('completed', 'incomplete')),
+    CHECK (duration_minutes IS NULL OR duration_minutes > 0)
+);
+
+CREATE INDEX trial100_attempts_user_date_idx
+ON trial100_attempts (user_id, test_date DESC);

--- a/tests/test_trial100_store.py
+++ b/tests/test_trial100_store.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import pytest
+
+import trial100_store
+
+
+def _record(**overrides):
+    record = {
+        "user_id": "trial100-user",
+        "test_date": "2026-09-04",
+        "source_version": "trial100-v1",
+        "total_questions": 100,
+        "correct_count": 78,
+        "completion_status": "completed",
+        "duration_minutes": 155,
+        "supportive": False,
+        "field_breakdown": {"内科学": {"answered": 10, "correct": 7}},
+        "review_summary": {"note": "paper test"},
+    }
+    record.update(overrides)
+    return record
+
+
+def setup_function():
+    trial100_store._local_trial100_attempts.clear()
+
+
+def teardown_function():
+    trial100_store._local_trial100_attempts.clear()
+
+
+def test_save_and_read_local_trial100_record(monkeypatch):
+    monkeypatch.setattr(trial100_store.database, "database_is_available", lambda: False)
+
+    saved = trial100_store.save_trial100_record(_record(), recorded_by="supporter")
+    rows = trial100_store.get_trial100_records("trial100-user")
+
+    assert saved["score_rate"] == 0.78
+    assert saved["timed_full_format"] is True
+    assert saved["supportive"] is False
+    assert saved["recorded_by"] == "supporter"
+    assert rows == [saved]
+
+
+def test_duplicate_identity_is_rejected_locally(monkeypatch):
+    monkeypatch.setattr(trial100_store.database, "database_is_available", lambda: False)
+    trial100_store.save_trial100_record(_record())
+
+    with pytest.raises(ValueError, match="duplicate Trial100 record"):
+        trial100_store.save_trial100_record(_record(correct_count=80))
+
+
+def test_store_uses_evidence_validation_before_persistence(monkeypatch):
+    monkeypatch.setattr(trial100_store.database, "database_is_available", lambda: False)
+
+    with pytest.raises(ValueError, match="correct_count"):
+        trial100_store.save_trial100_record(_record(correct_count=101))
+
+    assert trial100_store.get_trial100_records("trial100-user") == []
+
+
+def test_records_are_returned_newest_first(monkeypatch):
+    monkeypatch.setattr(trial100_store.database, "database_is_available", lambda: False)
+    trial100_store.save_trial100_record(_record(test_date="2026-08-01", source_version="aug"))
+    trial100_store.save_trial100_record(_record(test_date="2026-09-01", source_version="sep"))
+
+    rows = trial100_store.get_trial100_records("trial100-user")
+
+    assert [item["source_version"] for item in rows] == ["sep", "aug"]
+
+
+def test_missing_user_returns_empty_without_db_access(monkeypatch):
+    monkeypatch.setattr(trial100_store.database, "database_is_available", lambda: True)
+    monkeypatch.setattr(
+        trial100_store.database,
+        "get_db_connection",
+        lambda: (_ for _ in ()).throw(AssertionError("DB should not be opened")),
+    )
+
+    assert trial100_store.get_trial100_records("") == []

--- a/trial100_store.py
+++ b/trial100_store.py
@@ -1,0 +1,153 @@
+"""Persistence adapter for Trial100 evidence.
+
+The schema is applied explicitly from migrations/20260904_trial100_attempts.sql.
+Importing this module never creates or alters Production tables.
+"""
+
+from __future__ import annotations
+
+import json
+from contextlib import contextmanager
+from typing import Any, Mapping
+
+import database
+from trial100_evidence import normalize_trial100_record
+
+
+_local_trial100_attempts: dict[tuple[str, str, str], dict[str, Any]] = {}
+
+
+@contextmanager
+def _connection_or_existing(connection=None):
+    if connection is not None:
+        yield connection
+        return
+    with database.get_db_connection() as created:
+        yield created
+
+
+def _local_key(record: Mapping[str, Any]) -> tuple[str, str, str]:
+    return (
+        str(record["user_id"]),
+        str(record["test_date"]),
+        str(record["source_version"]),
+    )
+
+
+def save_trial100_record(
+    record: Mapping[str, Any],
+    *,
+    recorded_by: str | None = None,
+    connection=None,
+) -> dict[str, Any]:
+    """Validate and store one real Trial100 result without inventing readiness."""
+    normalized = normalize_trial100_record(record)
+    actor = str(recorded_by or "").strip() or None
+
+    if not database.database_is_available():
+        key = _local_key(normalized)
+        if key in _local_trial100_attempts:
+            raise ValueError("duplicate Trial100 record")
+        stored = {**normalized, "recorded_by": actor}
+        _local_trial100_attempts[key] = stored
+        return dict(stored)
+
+    with _connection_or_existing(connection) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO trial100_attempts (
+                    user_id,
+                    test_date,
+                    source_version,
+                    total_questions,
+                    correct_count,
+                    completion_status,
+                    duration_minutes,
+                    supportive,
+                    field_breakdown,
+                    review_summary,
+                    recorded_by
+                )
+                VALUES (
+                    %s, %s, %s, %s, %s, %s, %s, %s,
+                    %s::jsonb, %s::jsonb, %s
+                )
+                RETURNING id
+                """,
+                (
+                    normalized["user_id"],
+                    normalized["test_date"],
+                    normalized["source_version"],
+                    normalized["total_questions"],
+                    normalized["correct_count"],
+                    normalized["completion_status"],
+                    normalized["duration_minutes"],
+                    normalized["supportive"],
+                    json.dumps(normalized["field_breakdown"], ensure_ascii=False)
+                    if normalized["field_breakdown"] is not None else None,
+                    json.dumps(normalized["review_summary"], ensure_ascii=False)
+                    if normalized["review_summary"] is not None else None,
+                    actor,
+                ),
+            )
+            row = cur.fetchone()
+    return {**normalized, "id": int(row[0]), "recorded_by": actor}
+
+
+def get_trial100_records(user_id: str, *, connection=None) -> list[dict[str, Any]]:
+    """Return readiness-compatible Trial100 records, newest first."""
+    user_id = str(user_id or "").strip()
+    if not user_id:
+        return []
+
+    if not database.database_is_available():
+        rows = [
+            dict(record)
+            for key, record in _local_trial100_attempts.items()
+            if key[0] == user_id
+        ]
+        rows.sort(key=lambda item: (item["test_date"], item["source_version"]), reverse=True)
+        return rows
+
+    with _connection_or_existing(connection) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT
+                    id,
+                    user_id,
+                    test_date,
+                    source_version,
+                    total_questions,
+                    correct_count,
+                    completion_status,
+                    duration_minutes,
+                    supportive,
+                    field_breakdown,
+                    review_summary,
+                    recorded_by
+                FROM trial100_attempts
+                WHERE user_id = %s
+                ORDER BY test_date DESC, id DESC
+                """,
+                (user_id,),
+            )
+            rows = cur.fetchall()
+
+    result = []
+    for row in rows:
+        normalized = normalize_trial100_record({
+            "user_id": row[1],
+            "test_date": row[2],
+            "source_version": row[3],
+            "total_questions": row[4],
+            "correct_count": row[5],
+            "completion_status": row[6],
+            "duration_minutes": row[7],
+            "supportive": row[8],
+            "field_breakdown": row[9],
+            "review_summary": row[10],
+        })
+        result.append({**normalized, "id": int(row[0]), "recorded_by": row[11]})
+    return result


### PR DESCRIPTION
Issue #102 next slice: add durable-storage code without applying Production DDL.

Changes:
- explicit migration SQL for `trial100_attempts` (not wired into `init_database()`)
- `trial100_store.py` save/read adapter using the existing pure `trial100_evidence` validator
- local fallback for tests/dev
- duplicate-safe identity `(user_id, test_date, source_version)`
- records returned in readiness-compatible normalized shape
- regression tests for validation, duplicate rejection, ordering, and no-DB empty-user behavior

Safety:
- importing/deploying this code does not create or alter Production tables
- no Production DB write/migration in this PR
- no Trial100 pass cutoff or pass probability
- no learner UI or readiness policy change

The same DDL has been applied and validated only on a temporary Neon migration branch; Production application remains a separate explicit decision.