### PR TITLE
Bundle learner dashboard reads and wire Trial100

### DIFF
--- a/dashboard_read_bundle.py
+++ b/dashboard_read_bundle.py
@@ -1,0 +1,103 @@
+"""Read bundle for the learner dashboard.
+
+Production uses one Neon connection for legacy dashboard aggregates, durable
+question attempts, and Trial100 evidence.  This keeps item-12 factual inputs
+consistent without adding another serverless connection just for Trial100.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import database
+from trial100_store import get_trial100_records
+
+
+_ATTEMPT_COLUMNS = (
+    "event_key",
+    "user_id",
+    "question_id",
+    "knowledge_node_id",
+    "mode",
+    "selected_answers",
+    "is_correct",
+    "confidence",
+    "answered_at",
+    "attempt_position",
+)
+
+
+def _attempts_with_connection(user_id: str, connection) -> list[dict[str, Any]]:
+    with connection.cursor() as cur:
+        cur.execute(
+            """
+            SELECT event_key, user_id, question_id, knowledge_node_id,
+                   mode, selected_answers, is_correct, confidence,
+                   answered_at, attempt_position
+            FROM question_attempts
+            WHERE user_id = %s
+            ORDER BY answered_at, event_key, attempt_position
+            """,
+            (user_id,),
+        )
+        attempts = [dict(zip(_ATTEMPT_COLUMNS, row)) for row in cur.fetchall()]
+    for attempt in attempts:
+        attempt["answer_status"] = (
+            "unknown" if not attempt.get("selected_answers") else "answered"
+        )
+    return attempts
+
+
+def get_dashboard_read_bundle(
+    user_id: str,
+    *,
+    include_attempts: bool = False,
+    include_trial100: bool = False,
+) -> dict[str, Any]:
+    """Return dashboard facts and optional formal evidence with shared DB I/O."""
+    user_id = str(user_id or "").strip()
+    if not user_id:
+        return {
+            "learning_data": {
+                "summary": {},
+                "activity": {},
+                "fields": [],
+                "unique_question_count": 0,
+            },
+            "attempts": [],
+            "trial100_records": [],
+        }
+
+    if not database.database_is_available():
+        return {
+            "learning_data": database.get_dashboard_learning_data(user_id),
+            "attempts": database.get_question_attempts(user_id) if include_attempts else [],
+            "trial100_records": get_trial100_records(user_id) if include_trial100 else [],
+        }
+
+    with database.get_db_connection() as conn:
+        question_rows = database._get_question_result_rows(user_id, conn)
+        learning_data = {
+            "summary": database.get_learning_summary(user_id, _connection=conn),
+            "activity": database.get_learning_activity(user_id, _connection=conn),
+            "fields": database.get_field_learning_summary(
+                user_id,
+                _connection=conn,
+                _question_result_rows=question_rows,
+            ),
+            "unique_question_count": database.get_unique_answered_question_count(
+                user_id,
+                _connection=conn,
+                _question_result_rows=question_rows,
+            ),
+        }
+        attempts = _attempts_with_connection(user_id, conn) if include_attempts else []
+        trial100_records = (
+            get_trial100_records(user_id, connection=conn) if include_trial100 else []
+        )
+
+    return {
+        "learning_data": learning_data,
+        "attempts": attempts,
+        "trial100_records": trial100_records,
+    }

--- a/goukaku_ui.py
+++ b/goukaku_ui.py
@@ -6,7 +6,6 @@ from itsdangerous import BadSignature, URLSafeSerializer, URLSafeTimedSerializer
 
 from database import (
     calculate_overall_progress,
-    get_dashboard_learning_data,
     get_field_learning_summary,
     get_learning_activity,
     get_question_attempts,
@@ -15,6 +14,7 @@ from database import (
     get_supported_learner_ids,
     user_names,
 )
+from dashboard_read_bundle import get_dashboard_read_bundle
 from learning_analysis import build_gensan_comment, build_learning_guidance
 from supporter_report import build_supporter_report
 from pilot_diagnostics import build_pilot_diagnostics
@@ -194,7 +194,27 @@ def build_dashboard(user_id=None, include_learner_navigation=False):
         "gensan_comment": "今日はまだ来てねぇな。5問だけやるか？＾＾",
     }
     if user_id:
-        learning_data = get_dashboard_learning_data(user_id)
+        field_preview = field_progress_ui_enabled()
+        overall_preview = overall_progress_ui_enabled()
+        shadow_preview = dashboard_real_data_shadow_enabled()
+        # The legacy Phase12 preview is diagnostics-only once formal learner
+        # navigation is active.  This structurally prevents a second learner CTA.
+        phase12_preview = (
+            phase12_guidance_preview_enabled() and not include_learner_navigation
+        )
+        needs_attempts = bool(
+            field_preview
+            or overall_preview
+            or shadow_preview
+            or phase12_preview
+            or include_learner_navigation
+        )
+        bundle = get_dashboard_read_bundle(
+            user_id,
+            include_attempts=needs_attempts,
+            include_trial100=include_learner_navigation,
+        )
+        learning_data = bundle["learning_data"]
         dashboard.update(learning_data["summary"])
         dashboard.update(learning_data["activity"])
         dashboard["unique_answered_questions"] = learning_data["unique_question_count"]
@@ -205,15 +225,10 @@ def build_dashboard(user_id=None, include_learner_navigation=False):
         )
         fields = learning_data["fields"]
         dashboard["field_stats"] = [item for item in fields if item["learned"]]
-        field_preview = field_progress_ui_enabled()
-        overall_preview = overall_progress_ui_enabled()
-        shadow_preview = dashboard_real_data_shadow_enabled()
-        phase12_preview = phase12_guidance_preview_enabled()
-        attempts = None
+        attempts = bundle["attempts"] if needs_attempts else None
         evidence = None
         progress = None
-        if field_preview or overall_preview or shadow_preview or phase12_preview or include_learner_navigation:
-            attempts = get_question_attempts(user_id)
+        if needs_attempts:
             evidence = build_field_evidence(attempts)
         if field_preview or overall_preview or shadow_preview or include_learner_navigation:
             progress = build_field_progress(evidence)
@@ -251,6 +266,7 @@ def build_dashboard(user_id=None, include_learner_navigation=False):
                 attempts,
                 field_evidence=evidence,
                 progress=progress,
+                trial100_records=bundle["trial100_records"],
             )
             dashboard["learner_navigation_enabled"] = True
             dashboard["learner_navigation"] = build_learner_readiness_presentation(

--- a/goukaku_ui.py
+++ b/goukaku_ui.py
@@ -6,6 +6,8 @@ from itsdangerous import BadSignature, URLSafeSerializer, URLSafeTimedSerializer
 
 from database import (
     calculate_overall_progress,
+    database_is_available,
+    get_dashboard_learning_data,
     get_field_learning_summary,
     get_learning_activity,
     get_question_attempts,
@@ -14,7 +16,8 @@ from database import (
     get_supported_learner_ids,
     user_names,
 )
-from dashboard_read_bundle import get_dashboard_read_bundle
+from dashboard_read_bundle import get_dashboard_read_bundle as _get_production_dashboard_read_bundle
+from trial100_store import get_trial100_records
 from learning_analysis import build_gensan_comment, build_learning_guidance
 from supporter_report import build_supporter_report
 from pilot_diagnostics import build_pilot_diagnostics
@@ -155,6 +158,21 @@ def authorized_supporter_learner(token, requested_learner_id=None):
     return supporter_id, learner_ids[0]
 
 
+def _dashboard_read_bundle(user_id, *, include_attempts=False, include_trial100=False):
+    """Use the shared Production read path while preserving local/test hooks."""
+    if database_is_available():
+        return _get_production_dashboard_read_bundle(
+            user_id,
+            include_attempts=include_attempts,
+            include_trial100=include_trial100,
+        )
+    return {
+        "learning_data": get_dashboard_learning_data(user_id),
+        "attempts": get_question_attempts(user_id) if include_attempts else [],
+        "trial100_records": get_trial100_records(user_id) if include_trial100 else [],
+    }
+
+
 def build_dashboard(user_id=None, include_learner_navigation=False):
     today = tokyo_today()
     exam_date = get_effective_exam_date(user_id)
@@ -197,11 +215,7 @@ def build_dashboard(user_id=None, include_learner_navigation=False):
         field_preview = field_progress_ui_enabled()
         overall_preview = overall_progress_ui_enabled()
         shadow_preview = dashboard_real_data_shadow_enabled()
-        # The legacy Phase12 preview is diagnostics-only once formal learner
-        # navigation is active.  This structurally prevents a second learner CTA.
-        phase12_preview = (
-            phase12_guidance_preview_enabled() and not include_learner_navigation
-        )
+        phase12_preview = phase12_guidance_preview_enabled()
         needs_attempts = bool(
             field_preview
             or overall_preview
@@ -209,7 +223,7 @@ def build_dashboard(user_id=None, include_learner_navigation=False):
             or phase12_preview
             or include_learner_navigation
         )
-        bundle = get_dashboard_read_bundle(
+        bundle = _dashboard_read_bundle(
             user_id,
             include_attempts=needs_attempts,
             include_trial100=include_learner_navigation,

--- a/tests/test_dashboard_read_bundle.py
+++ b/tests/test_dashboard_read_bundle.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import dashboard_read_bundle
+
+
+def test_local_bundle_preserves_existing_read_contract(monkeypatch):
+    learning = {
+        "summary": {"total_answers": 5},
+        "activity": {"streak_days": 1},
+        "fields": [],
+        "unique_question_count": 5,
+    }
+    attempts = [{"question_id": "Q1"}]
+    trial100 = [{"source_version": "trial100-v1"}]
+
+    monkeypatch.setattr(
+        dashboard_read_bundle.database, "database_is_available", lambda: False
+    )
+    monkeypatch.setattr(
+        dashboard_read_bundle.database,
+        "get_dashboard_learning_data",
+        lambda user_id: learning,
+    )
+    monkeypatch.setattr(
+        dashboard_read_bundle.database,
+        "get_question_attempts",
+        lambda user_id: attempts,
+    )
+    monkeypatch.setattr(
+        dashboard_read_bundle,
+        "get_trial100_records",
+        lambda user_id, **kwargs: trial100,
+    )
+
+    result = dashboard_read_bundle.get_dashboard_read_bundle(
+        "learner", include_attempts=True, include_trial100=True
+    )
+
+    assert result["learning_data"] is learning
+    assert result["attempts"] is attempts
+    assert result["trial100_records"] is trial100
+
+
+def test_optional_evidence_reads_are_skipped(monkeypatch):
+    monkeypatch.setattr(
+        dashboard_read_bundle.database, "database_is_available", lambda: False
+    )
+    monkeypatch.setattr(
+        dashboard_read_bundle.database,
+        "get_dashboard_learning_data",
+        lambda user_id: {
+            "summary": {}, "activity": {}, "fields": [], "unique_question_count": 0
+        },
+    )
+    monkeypatch.setattr(
+        dashboard_read_bundle.database,
+        "get_question_attempts",
+        lambda user_id: (_ for _ in ()).throw(AssertionError("attempt read not expected")),
+    )
+    monkeypatch.setattr(
+        dashboard_read_bundle,
+        "get_trial100_records",
+        lambda user_id, **kwargs: (_ for _ in ()).throw(
+            AssertionError("Trial100 read not expected")
+        ),
+    )
+
+    result = dashboard_read_bundle.get_dashboard_read_bundle("learner")
+
+    assert result["attempts"] == []
+    assert result["trial100_records"] == []
+
+
+def test_attempt_rows_match_formal_database_shape():
+    class Cursor:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def execute(self, sql, params):
+            assert "FROM question_attempts" in sql
+            assert params == ("learner",)
+
+        def fetchall(self):
+            return [
+                (
+                    "event-1",
+                    "learner",
+                    "Q1",
+                    "KN0001",
+                    "study",
+                    [],
+                    False,
+                    None,
+                    "2026-09-04T00:00:00+00:00",
+                    1,
+                )
+            ]
+
+    class Connection:
+        def cursor(self):
+            return Cursor()
+
+    attempts = dashboard_read_bundle._attempts_with_connection(
+        "learner", Connection()
+    )
+
+    assert attempts[0]["question_id"] == "Q1"
+    assert attempts[0]["answer_status"] == "unknown"


### PR DESCRIPTION
Item 12 v0.2 completion + Issue #106 latency-safe evidence wiring.

Changes:
- add `dashboard_read_bundle.py`
- Production learner dashboard reuses one Neon connection for legacy dashboard aggregates, durable `question_attempts`, and Trial100 records
- pass real Trial100 records into `build_pass_readiness`, so the existing learner Trial100 message can reflect durable evidence when records exist
- preserve existing local/test hooks and legacy Phase12 feature-flag behavior
- keep optional evidence reads off for supporter/legacy paths that do not need them
- no selector, cooldown, auth, readiness threshold, or Trial100 score-policy change

Performance intent:
- Trial100 is wired without adding a separate Neon connection
- learner navigation no longer needs an independent `get_question_attempts` connection after dashboard aggregates

No Production migration is included; the Trial100 table already exists from the explicit #102 migration.