### PR TITLE
Add Stripe sandbox webhook adapter

### DIFF
--- a/docs/stripe-sandbox-v01.md
+++ b/docs/stripe-sandbox-v01.md
@@ -1,0 +1,53 @@
+# Stripe sandbox v0.1
+
+Status: sandbox-only implementation boundary
+Issue: #154
+
+## Selected path
+
+- Account: `LicenseTownサンドボックス` only
+- Stripe-hosted Checkout (redirect)
+- one flat-rate monthly subscription at launch
+- useful free floor; no-card freemium before paid upgrade
+- Customer Portal for payment-method updates and cancellation
+- cancellation at period end
+- Stripe subscription webhook is durable entitlement authority
+- browser success redirect never activates paid access
+- LicenseTown account mapping is carried on subscription metadata as `lt_user_id`
+- `lt_product_key=licensetown_core_monthly`
+
+## Intentionally not enabled
+
+- live charging
+- Managed Payments
+- Stripe Tax collection
+- Stripe Invoicing
+- paid gating on learner routes
+- public price/checkout CTA
+
+## Webhook events used by v0.1
+
+- `customer.subscription.created`
+- `customer.subscription.updated`
+- `customer.subscription.deleted`
+
+Unsupported events are acknowledged without changing LicenseTown entitlement state.
+All accepted events must pass Stripe signature verification before normalization.
+Duplicate Stripe event IDs are idempotent in the provider-event ledger.
+
+## Status mapping
+
+- Stripe `active` -> LT `active`
+- Stripe `active` + `cancel_at_period_end=true` -> LT `cancel_at_period_end`
+- subscription deleted/canceled/unpaid/incomplete_expired -> LT `expired`
+- other non-active states -> LT `inactive` (fail closed; no implicit grace in v0.1)
+
+Paid access also requires a future `current_period_end`; malformed active data cannot fabricate access.
+
+## Rollout gate
+
+No live charging until sandbox proves:
+
+`checkout -> verified subscription webhook -> entitlement active -> portal cancel -> cancel_at_period_end -> period end/deleted -> expired`
+
+and #155 makes public HP/terms/privacy/特商法/cancellation copy consistent with the actual offer.

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ Werkzeug==2.3.8
 gunicorn==21.2.0
 line-bot-sdk==3.18.1
 openai>=1.0.0
+stripe>=12.0.0
 setuptools>=65.0.0
 wheel>=0.40.0
 build>=1.0.3

--- a/site_ui.py
+++ b/site_ui.py
@@ -79,9 +79,10 @@ def responsive_asset(filename):
     return send_from_directory(PREVIEW_RESPONSIVE_DIR, filename)
 
 
-# ``app.py`` already registers site_ui. Attach the developer-only boundary here
-# so the Flask entrypoint remains unchanged and the route/data concerns stay
-# outside the supporter blueprint.
+# ``app.py`` already registers site_ui. Attach small auxiliary boundaries here
+# so the Flask entrypoint remains unchanged while their logic stays isolated.
 from developer_ui import register_developer_routes
+from stripe_webhook_ui import stripe_webhook_ui
 
 register_developer_routes(site_ui)
+site_ui.register_blueprint(stripe_webhook_ui)

--- a/stripe_entitlement_adapter.py
+++ b/stripe_entitlement_adapter.py
@@ -1,0 +1,172 @@
+"""Stripe -> LicenseTown entitlement adapter.
+
+Only verified Stripe webhook payloads may reach the provider-agnostic
+``payment_entitlement`` service. Browser redirects are never authoritative.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from typing import Any, Mapping
+
+import stripe
+
+from payment_entitlement import CORE_PRODUCT_KEY, apply_verified_provider_event
+
+
+STRIPE_PROVIDER = "stripe"
+_SUPPORTED_SUBSCRIPTION_EVENTS = {
+    "customer.subscription.created",
+    "customer.subscription.updated",
+    "customer.subscription.deleted",
+}
+
+
+def _timestamp(value: Any) -> datetime | None:
+    if value is None:
+        return None
+    try:
+        return datetime.fromtimestamp(int(value), tz=timezone.utc)
+    except (TypeError, ValueError, OSError):
+        return None
+
+
+def _text(value: Any) -> str | None:
+    text = str(value or "").strip()
+    return text or None
+
+
+def verify_stripe_webhook(
+    payload: bytes,
+    signature_header: str,
+    *,
+    webhook_secret: str | None = None,
+) -> Mapping[str, Any]:
+    """Verify one Stripe webhook with Stripe's official signing helper.
+
+    The webhook secret must be supplied explicitly or through
+    ``STRIPE_WEBHOOK_SECRET``. Missing secrets fail closed.
+    """
+    secret = _text(webhook_secret) or _text(os.getenv("STRIPE_WEBHOOK_SECRET"))
+    if not secret:
+        raise RuntimeError("STRIPE_WEBHOOK_SECRET is not configured")
+    if not signature_header:
+        raise ValueError("Stripe-Signature header is required")
+    return stripe.Webhook.construct_event(payload, signature_header, secret)
+
+
+def _period_bounds(subscription: Mapping[str, Any]) -> tuple[datetime | None, datetime | None]:
+    start = _timestamp(subscription.get("current_period_start"))
+    end = _timestamp(subscription.get("current_period_end"))
+    if start and end:
+        return start, end
+
+    items = subscription.get("items") or {}
+    rows = items.get("data") if isinstance(items, Mapping) else None
+    if isinstance(rows, list) and rows:
+        first = rows[0] if isinstance(rows[0], Mapping) else {}
+        start = start or _timestamp(first.get("current_period_start"))
+        end = end or _timestamp(first.get("current_period_end"))
+    return start, end
+
+
+def _license_town_metadata(subscription: Mapping[str, Any]) -> tuple[str, str]:
+    metadata = subscription.get("metadata") or {}
+    if not isinstance(metadata, Mapping):
+        raise ValueError("Stripe subscription metadata is invalid")
+    user_id = _text(metadata.get("lt_user_id"))
+    product_key = _text(metadata.get("lt_product_key")) or CORE_PRODUCT_KEY
+    if not user_id:
+        raise ValueError("Stripe subscription is missing lt_user_id metadata")
+    if product_key != CORE_PRODUCT_KEY:
+        raise ValueError("Stripe subscription product mapping is not supported")
+    return user_id, product_key
+
+
+def _entitlement_status(event_type: str, subscription: Mapping[str, Any]) -> str:
+    if event_type == "customer.subscription.deleted":
+        return "expired"
+
+    stripe_status = _text(subscription.get("status")) or ""
+    if stripe_status == "active":
+        if bool(subscription.get("cancel_at_period_end")):
+            return "cancel_at_period_end"
+        return "active"
+
+    # v0.1 has no implicit payment-failure grace. Anything other than a fully
+    # active paid subscription fails closed at the paid-access boundary.
+    if stripe_status in {"canceled", "unpaid", "incomplete_expired"}:
+        return "expired"
+    return "inactive"
+
+
+def normalize_verified_stripe_event(event: Mapping[str, Any]) -> dict[str, Any] | None:
+    """Normalize a verified Stripe subscription event for payment_entitlement.
+
+    Unsupported event types are intentionally ignored. The returned mapping is
+    safe to pass to ``apply_verified_provider_event``.
+    """
+    event_type = _text(event.get("type"))
+    if event_type not in _SUPPORTED_SUBSCRIPTION_EVENTS:
+        return None
+
+    event_id = _text(event.get("id"))
+    if not event_id:
+        raise ValueError("Stripe event id is required")
+
+    data = event.get("data") or {}
+    subscription = data.get("object") if isinstance(data, Mapping) else None
+    if not isinstance(subscription, Mapping):
+        raise ValueError("Stripe subscription payload is missing")
+
+    user_id, product_key = _license_town_metadata(subscription)
+    subscription_id = _text(subscription.get("id"))
+    customer_id = _text(subscription.get("customer"))
+    if not subscription_id or not customer_id:
+        raise ValueError("Stripe subscription/customer mapping is incomplete")
+
+    period_start, period_end = _period_bounds(subscription)
+    status = _entitlement_status(event_type, subscription)
+    if status in {"active", "cancel_at_period_end"} and period_end is None:
+        raise ValueError("active Stripe subscription is missing current_period_end")
+
+    return {
+        "verified": True,
+        "provider": STRIPE_PROVIDER,
+        "provider_event_id": event_id,
+        "event_type": event_type,
+        "provider_event_created_at": _timestamp(event.get("created")),
+        "user_id": user_id,
+        "product_key": product_key,
+        "provider_customer_id": customer_id,
+        "provider_subscription_id": subscription_id,
+        "status": status,
+        "current_period_start": period_start,
+        "current_period_end": period_end,
+    }
+
+
+def process_stripe_webhook(
+    payload: bytes,
+    signature_header: str,
+    *,
+    webhook_secret: str | None = None,
+) -> dict[str, Any]:
+    """Verify, normalize, and durably apply one Stripe webhook event."""
+    verified_event = verify_stripe_webhook(
+        payload,
+        signature_header,
+        webhook_secret=webhook_secret,
+    )
+    normalized = normalize_verified_stripe_event(verified_event)
+    if normalized is None:
+        return {"handled": False, "event_type": _text(verified_event.get("type"))}
+    result = apply_verified_provider_event(normalized)
+    return {
+        "handled": True,
+        "event_type": normalized["event_type"],
+        "duplicate": bool(result.get("duplicate")),
+        "stale": bool(result.get("stale")),
+        "entitlement": result.get("entitlement"),
+    }

--- a/stripe_webhook_ui.py
+++ b/stripe_webhook_ui.py
@@ -1,0 +1,45 @@
+"""Minimal Stripe webhook HTTP boundary for LicenseTown.
+
+This blueprint performs no checkout creation and exposes no paid gating. It only
+accepts signed Stripe webhook POSTs and delegates trusted subscription events to
+the provider-agnostic entitlement service.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from flask import Blueprint, jsonify, request
+from stripe.error import SignatureVerificationError
+
+from stripe_entitlement_adapter import process_stripe_webhook
+
+
+logger = logging.getLogger(__name__)
+stripe_webhook_ui = Blueprint("stripe_webhook_ui", __name__)
+
+
+@stripe_webhook_ui.post("/stripe/webhook")
+def stripe_webhook():
+    payload = request.get_data(cache=False)
+    signature = request.headers.get("Stripe-Signature", "")
+    try:
+        result = process_stripe_webhook(payload, signature)
+    except (SignatureVerificationError, ValueError) as exc:
+        logger.warning("Stripe webhook rejected: %s", type(exc).__name__)
+        return jsonify({"ok": False}), 400
+    except RuntimeError:
+        logger.exception("Stripe webhook is not configured")
+        return jsonify({"ok": False}), 503
+    except Exception:
+        logger.exception("Stripe webhook processing failed")
+        return jsonify({"ok": False}), 500
+
+    return jsonify(
+        {
+            "ok": True,
+            "handled": bool(result.get("handled")),
+            "duplicate": bool(result.get("duplicate", False)),
+            "stale": bool(result.get("stale", False)),
+        }
+    )

--- a/stripe_webhook_ui.py
+++ b/stripe_webhook_ui.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import logging
 
 from flask import Blueprint, jsonify, request
-from stripe.error import SignatureVerificationError
+import stripe
 
 from stripe_entitlement_adapter import process_stripe_webhook
 
@@ -25,7 +25,7 @@ def stripe_webhook():
     signature = request.headers.get("Stripe-Signature", "")
     try:
         result = process_stripe_webhook(payload, signature)
-    except (SignatureVerificationError, ValueError) as exc:
+    except (stripe.SignatureVerificationError, ValueError) as exc:
         logger.warning("Stripe webhook rejected: %s", type(exc).__name__)
         return jsonify({"ok": False}), 400
     except RuntimeError:

--- a/tests/test_stripe_entitlement_adapter.py
+++ b/tests/test_stripe_entitlement_adapter.py
@@ -1,0 +1,186 @@
+from datetime import datetime, timezone
+
+import payment_entitlement
+import stripe_entitlement_adapter as adapter
+
+
+def setup_function():
+    payment_entitlement.reset_local_payment_state_for_tests()
+
+
+def _subscription_event(
+    *,
+    event_id="evt_1",
+    event_type="customer.subscription.updated",
+    status="active",
+    cancel_at_period_end=False,
+    created=1_788_487_200,
+    period_start=1_788_400_000,
+    period_end=1_791_079_200,
+    user_id="learner-1",
+):
+    return {
+        "id": event_id,
+        "type": event_type,
+        "created": created,
+        "data": {
+            "object": {
+                "id": "sub_1",
+                "customer": "cus_1",
+                "status": status,
+                "cancel_at_period_end": cancel_at_period_end,
+                "current_period_start": period_start,
+                "current_period_end": period_end,
+                "metadata": {
+                    "lt_user_id": user_id,
+                    "lt_product_key": payment_entitlement.CORE_PRODUCT_KEY,
+                },
+            }
+        },
+    }
+
+
+def test_normalize_active_subscription_event():
+    normalized = adapter.normalize_verified_stripe_event(_subscription_event())
+
+    assert normalized["verified"] is True
+    assert normalized["provider"] == "stripe"
+    assert normalized["user_id"] == "learner-1"
+    assert normalized["provider_customer_id"] == "cus_1"
+    assert normalized["provider_subscription_id"] == "sub_1"
+    assert normalized["status"] == "active"
+    assert normalized["current_period_end"].tzinfo == timezone.utc
+
+
+def test_cancel_at_period_end_maps_to_retained_paid_access_state():
+    normalized = adapter.normalize_verified_stripe_event(
+        _subscription_event(cancel_at_period_end=True)
+    )
+    assert normalized["status"] == "cancel_at_period_end"
+
+
+def test_deleted_subscription_maps_to_expired():
+    normalized = adapter.normalize_verified_stripe_event(
+        _subscription_event(
+            event_type="customer.subscription.deleted",
+            status="canceled",
+            period_start=None,
+            period_end=None,
+        )
+    )
+    assert normalized["status"] == "expired"
+
+
+def test_non_active_subscription_fails_closed():
+    normalized = adapter.normalize_verified_stripe_event(
+        _subscription_event(status="past_due")
+    )
+    assert normalized["status"] == "inactive"
+
+
+def test_active_subscription_requires_period_end():
+    event = _subscription_event(period_end=None)
+    try:
+        adapter.normalize_verified_stripe_event(event)
+    except ValueError as exc:
+        assert "current_period_end" in str(exc)
+    else:
+        raise AssertionError("missing paid period must fail closed")
+
+
+def test_missing_internal_account_mapping_is_rejected():
+    event = _subscription_event()
+    event["data"]["object"]["metadata"].pop("lt_user_id")
+    try:
+        adapter.normalize_verified_stripe_event(event)
+    except ValueError as exc:
+        assert "lt_user_id" in str(exc)
+    else:
+        raise AssertionError("unmapped Stripe subscription must be rejected")
+
+
+def test_unsupported_event_is_ignored():
+    event = _subscription_event(event_type="checkout.session.completed")
+    assert adapter.normalize_verified_stripe_event(event) is None
+
+
+def test_period_bounds_support_subscription_item_shape():
+    event = _subscription_event(period_start=None, period_end=None)
+    subscription = event["data"]["object"]
+    subscription["items"] = {
+        "data": [
+            {
+                "current_period_start": 1_788_400_000,
+                "current_period_end": 1_791_079_200,
+            }
+        ]
+    }
+    normalized = adapter.normalize_verified_stripe_event(event)
+    assert normalized["current_period_start"].tzinfo == timezone.utc
+    assert normalized["current_period_end"].tzinfo == timezone.utc
+
+
+def test_process_verified_event_updates_provider_agnostic_entitlement(monkeypatch):
+    monkeypatch.setattr(
+        adapter,
+        "verify_stripe_webhook",
+        lambda payload, signature_header, webhook_secret=None: _subscription_event(),
+    )
+
+    result = adapter.process_stripe_webhook(b"{}", "sig", webhook_secret="whsec_test")
+
+    assert result["handled"] is True
+    entitlement = payment_entitlement.get_entitlement("learner-1")
+    assert entitlement["status"] == "active"
+    assert payment_entitlement.entitlement_allows(
+        entitlement,
+        payment_entitlement.CORE_PAID_FEATURE,
+        now=datetime.fromtimestamp(1_788_487_200, tz=timezone.utc),
+    )
+
+
+def test_duplicate_webhook_is_idempotent(monkeypatch):
+    event = _subscription_event()
+    monkeypatch.setattr(
+        adapter,
+        "verify_stripe_webhook",
+        lambda payload, signature_header, webhook_secret=None: event,
+    )
+
+    first = adapter.process_stripe_webhook(b"{}", "sig", webhook_secret="whsec_test")
+    second = adapter.process_stripe_webhook(b"{}", "sig", webhook_secret="whsec_test")
+
+    assert first["duplicate"] is False
+    assert second["duplicate"] is True
+
+
+def test_webhook_secret_is_required(monkeypatch):
+    monkeypatch.delenv("STRIPE_WEBHOOK_SECRET", raising=False)
+    try:
+        adapter.verify_stripe_webhook(b"{}", "sig")
+    except RuntimeError as exc:
+        assert "STRIPE_WEBHOOK_SECRET" in str(exc)
+    else:
+        raise AssertionError("missing webhook secret must fail closed")
+
+
+def test_official_stripe_signature_helper_is_used(monkeypatch):
+    captured = {}
+
+    def fake_construct(payload, signature, secret):
+        captured.update(payload=payload, signature=signature, secret=secret)
+        return {"id": "evt_x", "type": "noop"}
+
+    monkeypatch.setattr(adapter.stripe.Webhook, "construct_event", fake_construct)
+    result = adapter.verify_stripe_webhook(
+        b"payload",
+        "t=1,v1=sig",
+        webhook_secret="whsec_test",
+    )
+
+    assert result["id"] == "evt_x"
+    assert captured == {
+        "payload": b"payload",
+        "signature": "t=1,v1=sig",
+        "secret": "whsec_test",
+    }

--- a/tests/test_stripe_webhook_ui.py
+++ b/tests/test_stripe_webhook_ui.py
@@ -4,7 +4,7 @@ os.environ.setdefault("OPENAI_API_KEY", "test-key")
 os.environ.setdefault("CHANNEL_ACCESS_TOKEN", "test-token")
 os.environ.setdefault("CHANNEL_SECRET", "test-secret")
 
-from stripe.error import SignatureVerificationError
+import stripe
 
 from app import app
 import stripe_webhook_ui as webhook_module
@@ -38,7 +38,7 @@ def test_stripe_webhook_route_is_registered(monkeypatch):
 
 def test_invalid_stripe_signature_is_rejected(monkeypatch):
     def reject(payload, signature):
-        raise SignatureVerificationError("bad signature", signature)
+        raise stripe.SignatureVerificationError("bad signature", signature)
 
     monkeypatch.setattr(webhook_module, "process_stripe_webhook", reject)
 

--- a/tests/test_stripe_webhook_ui.py
+++ b/tests/test_stripe_webhook_ui.py
@@ -1,0 +1,68 @@
+import os
+
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
+os.environ.setdefault("CHANNEL_ACCESS_TOKEN", "test-token")
+os.environ.setdefault("CHANNEL_SECRET", "test-secret")
+
+from stripe.error import SignatureVerificationError
+
+from app import app
+import stripe_webhook_ui as webhook_module
+
+
+def test_stripe_webhook_route_is_registered(monkeypatch):
+    monkeypatch.setattr(
+        webhook_module,
+        "process_stripe_webhook",
+        lambda payload, signature: {
+            "handled": True,
+            "duplicate": False,
+            "stale": False,
+        },
+    )
+
+    response = app.test_client().post(
+        "/stripe/webhook",
+        data=b"{}",
+        headers={"Stripe-Signature": "t=1,v1=test"},
+    )
+
+    assert response.status_code == 200
+    assert response.get_json() == {
+        "ok": True,
+        "handled": True,
+        "duplicate": False,
+        "stale": False,
+    }
+
+
+def test_invalid_stripe_signature_is_rejected(monkeypatch):
+    def reject(payload, signature):
+        raise SignatureVerificationError("bad signature", signature)
+
+    monkeypatch.setattr(webhook_module, "process_stripe_webhook", reject)
+
+    response = app.test_client().post(
+        "/stripe/webhook",
+        data=b"{}",
+        headers={"Stripe-Signature": "bad"},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"ok": False}
+
+
+def test_unconfigured_webhook_fails_closed(monkeypatch):
+    def unconfigured(payload, signature):
+        raise RuntimeError("missing secret")
+
+    monkeypatch.setattr(webhook_module, "process_stripe_webhook", unconfigured)
+
+    response = app.test_client().post(
+        "/stripe/webhook",
+        data=b"{}",
+        headers={"Stripe-Signature": "t=1,v1=test"},
+    )
+
+    assert response.status_code == 503
+    assert response.get_json() == {"ok": False}


### PR DESCRIPTION
Sandbox-only continuation of #154.

This PR adds the Stripe-specific boundary on top of the provider-agnostic entitlement store already merged in #158.

Scope:
- Stripe Python SDK dependency
- official Stripe webhook signature verification
- normalization of customer.subscription.created/updated/deleted into LicenseTown entitlement events
- fail-closed mapping for non-active subscription states
- LT account mapping via subscription metadata (`lt_user_id`, `lt_product_key`)
- active subscription requires a valid future paid period boundary downstream
- duplicate/stale protection remains delegated to the provider-agnostic store
- minimal `/stripe/webhook` Flask boundary
- sandbox integration contract documentation
- regression tests for mapping, idempotency, missing metadata, missing secret, unsupported events, and HTTP boundary

Explicitly not included:
- live charging
- Checkout session creation
- Customer Portal creation
- paid gating
- Stripe Tax/Invoicing/Managed Payments
- Production webhook secret configuration

No live Stripe account access is used by this PR.