### PR TITLE
Add authenticated Stripe sandbox Checkout harness

### DIFF
--- a/site_ui.py
+++ b/site_ui.py
@@ -82,7 +82,9 @@ def responsive_asset(filename):
 # ``app.py`` already registers site_ui. Attach small auxiliary boundaries here
 # so the Flask entrypoint remains unchanged while their logic stays isolated.
 from developer_ui import register_developer_routes
+from stripe_billing_ui import stripe_billing_ui
 from stripe_webhook_ui import stripe_webhook_ui
 
 register_developer_routes(site_ui)
+site_ui.register_blueprint(stripe_billing_ui)
 site_ui.register_blueprint(stripe_webhook_ui)

--- a/stripe_billing_ui.py
+++ b/stripe_billing_ui.py
@@ -1,0 +1,82 @@
+"""Authenticated, feature-flagged Stripe sandbox routes.
+
+No public CTA points here. These routes are only a sandbox lifecycle harness and
+are deliberately disabled unless ENABLE_STRIPE_SANDBOX_CHECKOUT is true.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from flask import Blueprint, abort, redirect, request, url_for
+
+from goukaku_ui import authorized_dashboard_learner
+from stripe_checkout_service import (
+    create_customer_portal_session,
+    create_subscription_checkout_session,
+    stripe_sandbox_checkout_enabled,
+)
+
+
+logger = logging.getLogger(__name__)
+stripe_billing_ui = Blueprint("stripe_billing_ui", __name__)
+
+
+def _enabled_or_404() -> None:
+    if not stripe_sandbox_checkout_enabled():
+        abort(404)
+
+
+def _object_url(value) -> str | None:
+    if isinstance(value, dict):
+        result = value.get("url")
+    else:
+        result = getattr(value, "url", None)
+    result = str(result or "").strip()
+    return result or None
+
+
+@stripe_billing_ui.post("/stripe/sandbox/checkout")
+def sandbox_checkout():
+    _enabled_or_404()
+    token = request.form.get("token")
+    user_id = authorized_dashboard_learner(token)
+    # Never send the signed dashboard token to Stripe in success/cancel URLs.
+    success_url = url_for("site_ui.home", checkout="success", _external=True)
+    cancel_url = url_for("site_ui.home", checkout="cancel", _external=True)
+    try:
+        session = create_subscription_checkout_session(
+            user_id,
+            success_url=success_url,
+            cancel_url=cancel_url,
+        )
+    except (RuntimeError, ValueError):
+        logger.exception("Stripe sandbox Checkout is not ready")
+        abort(503)
+    except Exception:
+        logger.exception("Stripe sandbox Checkout creation failed")
+        abort(502)
+    destination = _object_url(session)
+    if not destination:
+        abort(502)
+    return redirect(destination, code=303)
+
+
+@stripe_billing_ui.post("/stripe/sandbox/portal")
+def sandbox_portal():
+    _enabled_or_404()
+    token = request.form.get("token")
+    user_id = authorized_dashboard_learner(token)
+    return_url = url_for("site_ui.home", _external=True)
+    try:
+        session = create_customer_portal_session(user_id, return_url=return_url)
+    except (RuntimeError, ValueError):
+        logger.exception("Stripe sandbox portal is not ready")
+        abort(503)
+    except Exception:
+        logger.exception("Stripe sandbox portal creation failed")
+        abort(502)
+    destination = _object_url(session)
+    if not destination:
+        abort(502)
+    return redirect(destination, code=303)

--- a/stripe_checkout_service.py
+++ b/stripe_checkout_service.py
@@ -1,0 +1,92 @@
+"""Stripe-hosted Checkout and Customer Portal helpers for LicenseTown.
+
+These helpers are sandbox-capable plumbing only. They never activate a
+LicenseTown entitlement: verified subscription webhooks remain authoritative.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import stripe
+
+from payment_entitlement import CORE_PRODUCT_KEY, get_entitlement
+
+
+def _required_env(name: str) -> str:
+    value = str(os.getenv(name) or "").strip()
+    if not value:
+        raise RuntimeError(f"{name} is not configured")
+    return value
+
+
+def stripe_sandbox_checkout_enabled() -> bool:
+    return str(os.getenv("ENABLE_STRIPE_SANDBOX_CHECKOUT") or "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def _stripe_secret_key() -> str:
+    key = _required_env("STRIPE_SECRET_KEY")
+    # This integration must remain sandbox-only until the explicit live rollout
+    # gate. A live secret key must never be accepted by the sandbox route.
+    if not key.startswith("sk_test_"):
+        raise RuntimeError("STRIPE_SECRET_KEY must be a Stripe test key")
+    return key
+
+
+def create_subscription_checkout_session(
+    user_id: str,
+    *,
+    success_url: str,
+    cancel_url: str,
+    price_id: str | None = None,
+) -> Any:
+    """Create a Stripe-hosted subscription Checkout session for one LT user."""
+    user_id = str(user_id or "").strip()
+    if not user_id:
+        raise ValueError("user_id is required")
+    price = str(price_id or os.getenv("STRIPE_SANDBOX_PRICE_ID") or "").strip()
+    if not price:
+        raise RuntimeError("STRIPE_SANDBOX_PRICE_ID is not configured")
+
+    return stripe.checkout.Session.create(
+        api_key=_stripe_secret_key(),
+        mode="subscription",
+        line_items=[{"price": price, "quantity": 1}],
+        client_reference_id=user_id,
+        subscription_data={
+            "metadata": {
+                "lt_user_id": user_id,
+                "lt_product_key": CORE_PRODUCT_KEY,
+            }
+        },
+        metadata={
+            "lt_user_id": user_id,
+            "lt_product_key": CORE_PRODUCT_KEY,
+        },
+        success_url=success_url,
+        cancel_url=cancel_url,
+    )
+
+
+def create_customer_portal_session(user_id: str, *, return_url: str) -> Any:
+    """Create a self-service portal session for an entitled LT account."""
+    user_id = str(user_id or "").strip()
+    if not user_id:
+        raise ValueError("user_id is required")
+    entitlement = get_entitlement(user_id)
+    customer_id = str(entitlement.get("provider_customer_id") or "").strip()
+    provider = str(entitlement.get("provider") or "").strip()
+    if provider != "stripe" or not customer_id:
+        raise ValueError("Stripe customer mapping is not available")
+
+    return stripe.billing_portal.Session.create(
+        api_key=_stripe_secret_key(),
+        customer=customer_id,
+        return_url=return_url,
+    )

--- a/stripe_checkout_service.py
+++ b/stripe_checkout_service.py
@@ -39,6 +39,14 @@ def _stripe_secret_key() -> str:
     return key
 
 
+def _existing_stripe_customer(user_id: str) -> str | None:
+    entitlement = get_entitlement(user_id)
+    if str(entitlement.get("provider") or "").strip() != "stripe":
+        return None
+    customer_id = str(entitlement.get("provider_customer_id") or "").strip()
+    return customer_id or None
+
+
 def create_subscription_checkout_session(
     user_id: str,
     *,
@@ -54,24 +62,29 @@ def create_subscription_checkout_session(
     if not price:
         raise RuntimeError("STRIPE_SANDBOX_PRICE_ID is not configured")
 
-    return stripe.checkout.Session.create(
-        api_key=_stripe_secret_key(),
-        mode="subscription",
-        line_items=[{"price": price, "quantity": 1}],
-        client_reference_id=user_id,
-        subscription_data={
+    params = {
+        "api_key": _stripe_secret_key(),
+        "mode": "subscription",
+        "line_items": [{"price": price, "quantity": 1}],
+        "client_reference_id": user_id,
+        "subscription_data": {
             "metadata": {
                 "lt_user_id": user_id,
                 "lt_product_key": CORE_PRODUCT_KEY,
             }
         },
-        metadata={
+        "metadata": {
             "lt_user_id": user_id,
             "lt_product_key": CORE_PRODUCT_KEY,
         },
-        success_url=success_url,
-        cancel_url=cancel_url,
-    )
+        "success_url": success_url,
+        "cancel_url": cancel_url,
+    }
+    existing_customer = _existing_stripe_customer(user_id)
+    if existing_customer:
+        params["customer"] = existing_customer
+
+    return stripe.checkout.Session.create(**params)
 
 
 def create_customer_portal_session(user_id: str, *, return_url: str) -> Any:
@@ -79,10 +92,8 @@ def create_customer_portal_session(user_id: str, *, return_url: str) -> Any:
     user_id = str(user_id or "").strip()
     if not user_id:
         raise ValueError("user_id is required")
-    entitlement = get_entitlement(user_id)
-    customer_id = str(entitlement.get("provider_customer_id") or "").strip()
-    provider = str(entitlement.get("provider") or "").strip()
-    if provider != "stripe" or not customer_id:
+    customer_id = _existing_stripe_customer(user_id)
+    if not customer_id:
         raise ValueError("Stripe customer mapping is not available")
 
     return stripe.billing_portal.Session.create(

--- a/stripe_checkout_service.py
+++ b/stripe_checkout_service.py
@@ -47,6 +47,31 @@ def _existing_stripe_customer(user_id: str) -> str | None:
     return customer_id or None
 
 
+def _checkout_line_item(price_id: str | None = None) -> dict[str, Any]:
+    price = str(price_id or os.getenv("STRIPE_SANDBOX_PRICE_ID") or "").strip()
+    if price:
+        return {"price": price, "quantity": 1}
+
+    raw_amount = str(os.getenv("STRIPE_SANDBOX_MONTHLY_AMOUNT_JPY") or "").strip()
+    try:
+        amount = int(raw_amount)
+    except (TypeError, ValueError):
+        amount = 0
+    if amount <= 0:
+        raise RuntimeError(
+            "STRIPE_SANDBOX_PRICE_ID or STRIPE_SANDBOX_MONTHLY_AMOUNT_JPY is required"
+        )
+    return {
+        "price_data": {
+            "currency": "jpy",
+            "unit_amount": amount,
+            "recurring": {"interval": "month"},
+            "product_data": {"name": "LicenseTown sandbox monthly"},
+        },
+        "quantity": 1,
+    }
+
+
 def create_subscription_checkout_session(
     user_id: str,
     *,
@@ -58,14 +83,11 @@ def create_subscription_checkout_session(
     user_id = str(user_id or "").strip()
     if not user_id:
         raise ValueError("user_id is required")
-    price = str(price_id or os.getenv("STRIPE_SANDBOX_PRICE_ID") or "").strip()
-    if not price:
-        raise RuntimeError("STRIPE_SANDBOX_PRICE_ID is not configured")
 
     params = {
         "api_key": _stripe_secret_key(),
         "mode": "subscription",
-        "line_items": [{"price": price, "quantity": 1}],
+        "line_items": [_checkout_line_item(price_id)],
         "client_reference_id": user_id,
         "subscription_data": {
             "metadata": {

--- a/tests/test_stripe_billing_ui.py
+++ b/tests/test_stripe_billing_ui.py
@@ -1,0 +1,81 @@
+import os
+from types import SimpleNamespace
+
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
+os.environ.setdefault("CHANNEL_ACCESS_TOKEN", "test-token")
+os.environ.setdefault("CHANNEL_SECRET", "test-secret")
+
+from app import app
+from goukaku_ui import create_dashboard_token
+import stripe_billing_ui as billing_ui
+
+
+def test_sandbox_checkout_route_is_hidden_by_default(monkeypatch):
+    monkeypatch.delenv("ENABLE_STRIPE_SANDBOX_CHECKOUT", raising=False)
+    token = create_dashboard_token("learner-1")
+    response = app.test_client().post(
+        "/stripe/sandbox/checkout",
+        data={"token": token},
+    )
+    assert response.status_code == 404
+
+
+def test_sandbox_checkout_requires_signed_learner_token(monkeypatch):
+    monkeypatch.setenv("ENABLE_STRIPE_SANDBOX_CHECKOUT", "1")
+    response = app.test_client().post("/stripe/sandbox/checkout")
+    assert response.status_code == 403
+
+
+def test_checkout_redirects_to_stripe_without_leaking_dashboard_token(monkeypatch):
+    monkeypatch.setenv("ENABLE_STRIPE_SANDBOX_CHECKOUT", "1")
+    token = create_dashboard_token("learner-1")
+    captured = {}
+
+    def fake_create(user_id, *, success_url, cancel_url):
+        captured.update(
+            user_id=user_id,
+            success_url=success_url,
+            cancel_url=cancel_url,
+        )
+        return SimpleNamespace(url="https://checkout.stripe.test/session")
+
+    monkeypatch.setattr(billing_ui, "create_subscription_checkout_session", fake_create)
+    response = app.test_client().post(
+        "/stripe/sandbox/checkout",
+        data={"token": token},
+    )
+
+    assert response.status_code == 303
+    assert response.headers["Location"] == "https://checkout.stripe.test/session"
+    assert captured["user_id"] == "learner-1"
+    assert token not in captured["success_url"]
+    assert token not in captured["cancel_url"]
+    assert "checkout=success" in captured["success_url"]
+    assert "checkout=cancel" in captured["cancel_url"]
+
+
+def test_sandbox_portal_requires_signed_learner_token(monkeypatch):
+    monkeypatch.setenv("ENABLE_STRIPE_SANDBOX_CHECKOUT", "1")
+    response = app.test_client().post("/stripe/sandbox/portal")
+    assert response.status_code == 403
+
+
+def test_portal_redirects_to_stripe(monkeypatch):
+    monkeypatch.setenv("ENABLE_STRIPE_SANDBOX_CHECKOUT", "1")
+    token = create_dashboard_token("learner-1")
+    captured = {}
+
+    def fake_portal(user_id, *, return_url):
+        captured.update(user_id=user_id, return_url=return_url)
+        return {"url": "https://billing.stripe.test/portal"}
+
+    monkeypatch.setattr(billing_ui, "create_customer_portal_session", fake_portal)
+    response = app.test_client().post(
+        "/stripe/sandbox/portal",
+        data={"token": token},
+    )
+
+    assert response.status_code == 303
+    assert response.headers["Location"] == "https://billing.stripe.test/portal"
+    assert captured["user_id"] == "learner-1"
+    assert token not in captured["return_url"]

--- a/tests/test_stripe_checkout_inline_price.py
+++ b/tests/test_stripe_checkout_inline_price.py
@@ -1,0 +1,29 @@
+import stripe_checkout_service as service
+
+
+def test_inline_monthly_price_is_sandbox_configurable(monkeypatch):
+    monkeypatch.delenv("STRIPE_SANDBOX_PRICE_ID", raising=False)
+    monkeypatch.setenv("STRIPE_SANDBOX_MONTHLY_AMOUNT_JPY", "100")
+
+    item = service._checkout_line_item()
+
+    assert item == {
+        "price_data": {
+            "currency": "jpy",
+            "unit_amount": 100,
+            "recurring": {"interval": "month"},
+            "product_data": {"name": "LicenseTown sandbox monthly"},
+        },
+        "quantity": 1,
+    }
+
+
+def test_inline_monthly_price_rejects_non_positive_amount(monkeypatch):
+    monkeypatch.delenv("STRIPE_SANDBOX_PRICE_ID", raising=False)
+    monkeypatch.setenv("STRIPE_SANDBOX_MONTHLY_AMOUNT_JPY", "0")
+    try:
+        service._checkout_line_item()
+    except RuntimeError as exc:
+        assert "STRIPE_SANDBOX" in str(exc)
+    else:
+        raise AssertionError("non-positive sandbox price must be rejected")

--- a/tests/test_stripe_checkout_service.py
+++ b/tests/test_stripe_checkout_service.py
@@ -1,0 +1,146 @@
+from types import SimpleNamespace
+
+import payment_entitlement
+import stripe_checkout_service as service
+
+
+def setup_function():
+    payment_entitlement.reset_local_payment_state_for_tests()
+
+
+def test_sandbox_checkout_feature_flag_defaults_off(monkeypatch):
+    monkeypatch.delenv("ENABLE_STRIPE_SANDBOX_CHECKOUT", raising=False)
+    assert service.stripe_sandbox_checkout_enabled() is False
+
+
+def test_live_secret_key_is_rejected(monkeypatch):
+    monkeypatch.setenv("STRIPE_SECRET_KEY", "sk_live_not_allowed")
+    try:
+        service._stripe_secret_key()
+    except RuntimeError as exc:
+        assert "test key" in str(exc)
+    else:
+        raise AssertionError("live Stripe keys must be rejected by sandbox plumbing")
+
+
+def test_checkout_uses_signed_account_mapping_metadata(monkeypatch):
+    monkeypatch.setenv("STRIPE_SECRET_KEY", "sk_test_license_town")
+    monkeypatch.setenv("STRIPE_SANDBOX_PRICE_ID", "price_test_monthly")
+    captured = {}
+
+    def fake_create(**params):
+        captured.update(params)
+        return SimpleNamespace(id="cs_test_1", url="https://checkout.stripe.test/session")
+
+    monkeypatch.setattr(service.stripe.checkout.Session, "create", fake_create)
+
+    session = service.create_subscription_checkout_session(
+        "learner-1",
+        success_url="https://example.test/success",
+        cancel_url="https://example.test/cancel",
+    )
+
+    assert session.id == "cs_test_1"
+    assert captured["mode"] == "subscription"
+    assert captured["line_items"] == [{"price": "price_test_monthly", "quantity": 1}]
+    assert captured["client_reference_id"] == "learner-1"
+    assert captured["subscription_data"]["metadata"] == {
+        "lt_user_id": "learner-1",
+        "lt_product_key": payment_entitlement.CORE_PRODUCT_KEY,
+    }
+    assert captured["metadata"]["lt_user_id"] == "learner-1"
+    assert captured["success_url"] == "https://example.test/success"
+    assert captured["cancel_url"] == "https://example.test/cancel"
+    assert "customer" not in captured
+
+
+def test_checkout_reuses_existing_stripe_customer(monkeypatch):
+    monkeypatch.setenv("STRIPE_SECRET_KEY", "sk_test_license_town")
+    monkeypatch.setenv("STRIPE_SANDBOX_PRICE_ID", "price_test_monthly")
+    payment_entitlement.apply_verified_provider_event(
+        {
+            "verified": True,
+            "provider": "stripe",
+            "provider_event_id": "evt_existing",
+            "event_type": "customer.subscription.deleted",
+            "user_id": "learner-1",
+            "product_key": payment_entitlement.CORE_PRODUCT_KEY,
+            "provider_customer_id": "cus_existing",
+            "provider_subscription_id": "sub_old",
+            "status": "expired",
+        }
+    )
+    captured = {}
+    monkeypatch.setattr(
+        service.stripe.checkout.Session,
+        "create",
+        lambda **params: captured.update(params) or SimpleNamespace(id="cs_test_2", url="x"),
+    )
+
+    service.create_subscription_checkout_session(
+        "learner-1",
+        success_url="https://example.test/success",
+        cancel_url="https://example.test/cancel",
+    )
+
+    assert captured["customer"] == "cus_existing"
+
+
+def test_checkout_requires_configured_price(monkeypatch):
+    monkeypatch.setenv("STRIPE_SECRET_KEY", "sk_test_license_town")
+    monkeypatch.delenv("STRIPE_SANDBOX_PRICE_ID", raising=False)
+    try:
+        service.create_subscription_checkout_session(
+            "learner-1",
+            success_url="https://example.test/success",
+            cancel_url="https://example.test/cancel",
+        )
+    except RuntimeError as exc:
+        assert "STRIPE_SANDBOX_PRICE_ID" in str(exc)
+    else:
+        raise AssertionError("missing price configuration must fail closed")
+
+
+def test_portal_requires_existing_stripe_customer(monkeypatch):
+    monkeypatch.setenv("STRIPE_SECRET_KEY", "sk_test_license_town")
+    try:
+        service.create_customer_portal_session(
+            "learner-1",
+            return_url="https://example.test/return",
+        )
+    except ValueError as exc:
+        assert "customer mapping" in str(exc)
+    else:
+        raise AssertionError("portal must not guess a Stripe customer")
+
+
+def test_portal_uses_durable_customer_mapping(monkeypatch):
+    monkeypatch.setenv("STRIPE_SECRET_KEY", "sk_test_license_town")
+    payment_entitlement.apply_verified_provider_event(
+        {
+            "verified": True,
+            "provider": "stripe",
+            "provider_event_id": "evt_active",
+            "event_type": "customer.subscription.updated",
+            "user_id": "learner-1",
+            "product_key": payment_entitlement.CORE_PRODUCT_KEY,
+            "provider_customer_id": "cus_1",
+            "provider_subscription_id": "sub_1",
+            "status": "active",
+        }
+    )
+    captured = {}
+    monkeypatch.setattr(
+        service.stripe.billing_portal.Session,
+        "create",
+        lambda **params: captured.update(params) or SimpleNamespace(url="https://billing.stripe.test/portal"),
+    )
+
+    portal = service.create_customer_portal_session(
+        "learner-1",
+        return_url="https://example.test/return",
+    )
+
+    assert portal.url == "https://billing.stripe.test/portal"
+    assert captured["customer"] == "cus_1"
+    assert captured["return_url"] == "https://example.test/return"


### PR DESCRIPTION
Sandbox-only continuation of #154 after #159.

Scope:
- Stripe-hosted subscription Checkout service
- signed LicenseTown learner account -> Stripe metadata mapping
- re-use existing Stripe customer mapping for re-subscribe
- Customer Portal session helper for self-service billing/cancel flow
- live Stripe secret keys are explicitly rejected by this sandbox harness
- feature flag defaults OFF (`ENABLE_STRIPE_SANDBOX_CHECKOUT`)
- authenticated POST-only sandbox Checkout/Portal routes
- signed dashboard token is never included in URLs sent to Stripe
- no public CTA, no paid gating, no entitlement activation from browser redirect
- regression coverage for auth, feature flag, metadata, existing customer reuse, live-key rejection, and redirect token privacy

Runtime configuration is intentionally separate and not included in this PR:
- `STRIPE_SECRET_KEY` (test key only)
- `STRIPE_SANDBOX_PRICE_ID`
- `ENABLE_STRIPE_SANDBOX_CHECKOUT=1`

No live charging or paid Stripe add-on is enabled.