### PR TITLE
Separate Stripe sandbox and live entitlement namespaces

### DIFF
--- a/stripe_checkout_service.py
+++ b/stripe_checkout_service.py
@@ -12,6 +12,7 @@ from typing import Any
 import stripe
 
 from payment_entitlement import CORE_PRODUCT_KEY, get_entitlement
+from stripe_entitlement_adapter import STRIPE_SANDBOX_PROVIDER
 
 
 def _required_env(name: str) -> str:
@@ -41,7 +42,7 @@ def _stripe_secret_key() -> str:
 
 def _existing_stripe_customer(user_id: str) -> str | None:
     entitlement = get_entitlement(user_id)
-    if str(entitlement.get("provider") or "").strip() != "stripe":
+    if str(entitlement.get("provider") or "").strip() != STRIPE_SANDBOX_PROVIDER:
         return None
     customer_id = str(entitlement.get("provider_customer_id") or "").strip()
     return customer_id or None
@@ -110,13 +111,13 @@ def create_subscription_checkout_session(
 
 
 def create_customer_portal_session(user_id: str, *, return_url: str) -> Any:
-    """Create a self-service portal session for an entitled LT account."""
+    """Create a self-service portal session for an entitled LT sandbox account."""
     user_id = str(user_id or "").strip()
     if not user_id:
         raise ValueError("user_id is required")
     customer_id = _existing_stripe_customer(user_id)
     if not customer_id:
-        raise ValueError("Stripe customer mapping is not available")
+        raise ValueError("Stripe sandbox customer mapping is not available")
 
     return stripe.billing_portal.Session.create(
         api_key=_stripe_secret_key(),

--- a/stripe_entitlement_adapter.py
+++ b/stripe_entitlement_adapter.py
@@ -15,7 +15,8 @@ import stripe
 from payment_entitlement import CORE_PRODUCT_KEY, apply_verified_provider_event
 
 
-STRIPE_PROVIDER = "stripe"
+STRIPE_LIVE_PROVIDER = "stripe"
+STRIPE_SANDBOX_PROVIDER = "stripe_sandbox"
 _SUPPORTED_SUBSCRIPTION_EVENTS = {
     "customer.subscription.created",
     "customer.subscription.updated",
@@ -101,6 +102,15 @@ def _entitlement_status(event_type: str, subscription: Mapping[str, Any]) -> str
     return "inactive"
 
 
+def _provider_for_event(event: Mapping[str, Any]) -> str:
+    livemode = event.get("livemode")
+    if livemode is True:
+        return STRIPE_LIVE_PROVIDER
+    if livemode is False:
+        return STRIPE_SANDBOX_PROVIDER
+    raise ValueError("Stripe event livemode is required")
+
+
 def normalize_verified_stripe_event(event: Mapping[str, Any]) -> dict[str, Any] | None:
     """Normalize a verified Stripe subscription event for payment_entitlement.
 
@@ -115,6 +125,7 @@ def normalize_verified_stripe_event(event: Mapping[str, Any]) -> dict[str, Any] 
     if not event_id:
         raise ValueError("Stripe event id is required")
 
+    provider = _provider_for_event(event)
     data = event.get("data") or {}
     subscription = data.get("object") if isinstance(data, Mapping) else None
     if not isinstance(subscription, Mapping):
@@ -133,7 +144,7 @@ def normalize_verified_stripe_event(event: Mapping[str, Any]) -> dict[str, Any] 
 
     return {
         "verified": True,
-        "provider": STRIPE_PROVIDER,
+        "provider": provider,
         "provider_event_id": event_id,
         "event_type": event_type,
         "provider_event_created_at": _timestamp(event.get("created")),

--- a/tests/test_stripe_checkout_service.py
+++ b/tests/test_stripe_checkout_service.py
@@ -54,13 +54,13 @@ def test_checkout_uses_signed_account_mapping_metadata(monkeypatch):
     assert "customer" not in captured
 
 
-def test_checkout_reuses_existing_stripe_customer(monkeypatch):
+def test_checkout_reuses_existing_stripe_sandbox_customer(monkeypatch):
     monkeypatch.setenv("STRIPE_SECRET_KEY", "sk_test_license_town")
     monkeypatch.setenv("STRIPE_SANDBOX_PRICE_ID", "price_test_monthly")
     payment_entitlement.apply_verified_provider_event(
         {
             "verified": True,
-            "provider": "stripe",
+            "provider": service.STRIPE_SANDBOX_PROVIDER,
             "provider_event_id": "evt_existing",
             "event_type": "customer.subscription.deleted",
             "user_id": "learner-1",
@@ -86,9 +86,42 @@ def test_checkout_reuses_existing_stripe_customer(monkeypatch):
     assert captured["customer"] == "cus_existing"
 
 
+def test_checkout_does_not_reuse_live_stripe_customer_in_sandbox(monkeypatch):
+    monkeypatch.setenv("STRIPE_SECRET_KEY", "sk_test_license_town")
+    monkeypatch.setenv("STRIPE_SANDBOX_PRICE_ID", "price_test_monthly")
+    payment_entitlement.apply_verified_provider_event(
+        {
+            "verified": True,
+            "provider": "stripe",
+            "provider_event_id": "evt_live_existing",
+            "event_type": "customer.subscription.deleted",
+            "user_id": "learner-1",
+            "product_key": payment_entitlement.CORE_PRODUCT_KEY,
+            "provider_customer_id": "cus_live",
+            "provider_subscription_id": "sub_live",
+            "status": "expired",
+        }
+    )
+    captured = {}
+    monkeypatch.setattr(
+        service.stripe.checkout.Session,
+        "create",
+        lambda **params: captured.update(params) or SimpleNamespace(id="cs_test_3", url="x"),
+    )
+
+    service.create_subscription_checkout_session(
+        "learner-1",
+        success_url="https://example.test/success",
+        cancel_url="https://example.test/cancel",
+    )
+
+    assert "customer" not in captured
+
+
 def test_checkout_requires_configured_price(monkeypatch):
     monkeypatch.setenv("STRIPE_SECRET_KEY", "sk_test_license_town")
     monkeypatch.delenv("STRIPE_SANDBOX_PRICE_ID", raising=False)
+    monkeypatch.delenv("STRIPE_SANDBOX_MONTHLY_AMOUNT_JPY", raising=False)
     try:
         service.create_subscription_checkout_session(
             "learner-1",
@@ -114,12 +147,12 @@ def test_portal_requires_existing_stripe_customer(monkeypatch):
         raise AssertionError("portal must not guess a Stripe customer")
 
 
-def test_portal_uses_durable_customer_mapping(monkeypatch):
+def test_portal_uses_durable_sandbox_customer_mapping(monkeypatch):
     monkeypatch.setenv("STRIPE_SECRET_KEY", "sk_test_license_town")
     payment_entitlement.apply_verified_provider_event(
         {
             "verified": True,
-            "provider": "stripe",
+            "provider": service.STRIPE_SANDBOX_PROVIDER,
             "provider_event_id": "evt_active",
             "event_type": "customer.subscription.updated",
             "user_id": "learner-1",

--- a/tests/test_stripe_entitlement_adapter.py
+++ b/tests/test_stripe_entitlement_adapter.py
@@ -18,11 +18,13 @@ def _subscription_event(
     period_start=1_788_400_000,
     period_end=1_791_079_200,
     user_id="learner-1",
+    livemode=False,
 ):
     return {
         "id": event_id,
         "type": event_type,
         "created": created,
+        "livemode": livemode,
         "data": {
             "object": {
                 "id": "sub_1",
@@ -40,16 +42,32 @@ def _subscription_event(
     }
 
 
-def test_normalize_active_subscription_event():
+def test_normalize_sandbox_subscription_event_uses_separate_provider_namespace():
     normalized = adapter.normalize_verified_stripe_event(_subscription_event())
 
     assert normalized["verified"] is True
-    assert normalized["provider"] == "stripe"
+    assert normalized["provider"] == adapter.STRIPE_SANDBOX_PROVIDER
     assert normalized["user_id"] == "learner-1"
     assert normalized["provider_customer_id"] == "cus_1"
     assert normalized["provider_subscription_id"] == "sub_1"
     assert normalized["status"] == "active"
     assert normalized["current_period_end"].tzinfo == timezone.utc
+
+
+def test_normalize_live_subscription_event_uses_live_provider_namespace():
+    normalized = adapter.normalize_verified_stripe_event(_subscription_event(livemode=True))
+    assert normalized["provider"] == adapter.STRIPE_LIVE_PROVIDER
+
+
+def test_missing_livemode_fails_closed():
+    event = _subscription_event()
+    event.pop("livemode")
+    try:
+        adapter.normalize_verified_stripe_event(event)
+    except ValueError as exc:
+        assert "livemode" in str(exc)
+    else:
+        raise AssertionError("Stripe environment must be explicit")
 
 
 def test_cancel_at_period_end_maps_to_retained_paid_access_state():
@@ -132,6 +150,7 @@ def test_process_verified_event_updates_provider_agnostic_entitlement(monkeypatc
     assert result["handled"] is True
     entitlement = payment_entitlement.get_entitlement("learner-1")
     assert entitlement["status"] == "active"
+    assert entitlement["provider"] == adapter.STRIPE_SANDBOX_PROVIDER
     assert payment_entitlement.entitlement_allows(
         entitlement,
         payment_entitlement.CORE_PAID_FEATURE,


### PR DESCRIPTION
Safety hardening before the first end-to-end sandbox payment test for #154.

Scope:
- Stripe webhook events now require explicit `livemode`
- sandbox events persist as provider `stripe_sandbox`
- live events persist as provider `stripe`
- sandbox Checkout/Portal only reuse `stripe_sandbox` customer mappings
- live Stripe customer mappings are never reused by sandbox plumbing
- tests cover sandbox/live namespace separation and fail-closed missing `livemode`

Why:
Without an environment-specific provider namespace, a sandbox subscription could be indistinguishable from a future live Stripe entitlement in durable state. This PR removes that ambiguity before any sandbox lifecycle is written for a real LicenseTown account.

No live charging is enabled. No Production learner/payment rows are modified by this PR.