### PR TITLE
Fix Stripe webhook Event object handling

### DIFF
--- a/stripe_entitlement_adapter.py
+++ b/stripe_entitlement_adapter.py
@@ -38,12 +38,25 @@ def _text(value: Any) -> str | None:
     return text or None
 
 
+def _as_mapping(value: Any) -> Mapping[str, Any]:
+    """Convert Stripe SDK resources to plain mappings before normalization."""
+    if isinstance(value, Mapping):
+        return value
+    for method_name in ("to_dict_recursive", "to_dict"):
+        method = getattr(value, method_name, None)
+        if callable(method):
+            converted = method()
+            if isinstance(converted, Mapping):
+                return converted
+    raise ValueError("Stripe event payload is not mapping-compatible")
+
+
 def verify_stripe_webhook(
     payload: bytes,
     signature_header: str,
     *,
     webhook_secret: str | None = None,
-) -> Mapping[str, Any]:
+) -> Any:
     """Verify one Stripe webhook with Stripe's official signing helper.
 
     The webhook secret must be supplied explicitly or through
@@ -170,9 +183,10 @@ def process_stripe_webhook(
         signature_header,
         webhook_secret=webhook_secret,
     )
-    normalized = normalize_verified_stripe_event(verified_event)
+    event_mapping = _as_mapping(verified_event)
+    normalized = normalize_verified_stripe_event(event_mapping)
     if normalized is None:
-        return {"handled": False, "event_type": _text(verified_event.get("type"))}
+        return {"handled": False, "event_type": _text(event_mapping.get("type"))}
     result = apply_verified_provider_event(normalized)
     return {
         "handled": True,

--- a/tests/test_stripe_entitlement_adapter.py
+++ b/tests/test_stripe_entitlement_adapter.py
@@ -42,6 +42,14 @@ def _subscription_event(
     }
 
 
+class _StripeEventLike:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def to_dict_recursive(self):
+        return self.payload
+
+
 def test_normalize_sandbox_subscription_event_uses_separate_provider_namespace():
     normalized = adapter.normalize_verified_stripe_event(_subscription_event())
 
@@ -156,6 +164,22 @@ def test_process_verified_event_updates_provider_agnostic_entitlement(monkeypatc
         payment_entitlement.CORE_PAID_FEATURE,
         now=datetime.fromtimestamp(1_788_487_200, tz=timezone.utc),
     )
+
+
+def test_process_accepts_stripe_event_resource_object(monkeypatch):
+    monkeypatch.setattr(
+        adapter,
+        "verify_stripe_webhook",
+        lambda payload, signature_header, webhook_secret=None: _StripeEventLike(
+            _subscription_event(cancel_at_period_end=True)
+        ),
+    )
+
+    result = adapter.process_stripe_webhook(b"{}", "sig", webhook_secret="whsec_test")
+
+    assert result["handled"] is True
+    assert result["entitlement"]["provider"] == adapter.STRIPE_SANDBOX_PROVIDER
+    assert result["entitlement"]["status"] == "cancel_at_period_end"
 
 
 def test_duplicate_webhook_is_idempotent(monkeypatch):


### PR DESCRIPTION
Fixes the first real sandbox webhook failure observed during #154 lifecycle validation.

Root cause:
- stripe-python `Webhook.construct_event` returns a Stripe `Event` resource object.
- the adapter treated it as a plain mapping and called `.get()`, causing HTTP 500.

Changes:
- convert Stripe SDK resources to a plain mapping before normalization
- prefer `to_dict_recursive()` with `to_dict()` fallback
- keep fail-closed behavior for unsupported payload types
- add a regression test using an Event-like resource object

No live charging is enabled. Sandbox/live provider namespaces remain separated.