### PR TITLE
Complete paid access boundary and sandbox Customer Portal

### DIFF
--- a/payment_access.py
+++ b/payment_access.py
@@ -1,0 +1,66 @@
+"""Centralized LicenseTown free/paid access policy.
+
+The policy is provider-agnostic: learning routes ask about LicenseTown feature
+keys, never Stripe state. Public enforcement remains rollout-gated until the
+sale-safe launch work is complete.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from payment_entitlement import can_use_paid_core
+
+
+FREE_FIRST_FIVE = "study_first_five"
+FREE_NEXT_ACTION = "next_action"
+PAID_ADAPTIVE_FULL = "adaptive_learning_full"
+PAID_DASHBOARD_FULL = "dashboard_full"
+PAID_SUPPORTER_FULL = "supporter_full"
+
+_FREE_FEATURES = {FREE_FIRST_FIVE, FREE_NEXT_ACTION}
+_PAID_FEATURES = {PAID_ADAPTIVE_FULL, PAID_DASHBOARD_FULL, PAID_SUPPORTER_FULL}
+
+
+def paid_access_enforcement_enabled() -> bool:
+    """Return whether the commercial access boundary is actively enforced."""
+    return str(os.getenv("ENABLE_PAID_ACCESS_ENFORCEMENT") or "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def access_decision(
+    user_id: str,
+    feature: str,
+    *,
+    enforce: bool | None = None,
+) -> dict[str, Any]:
+    """Return one auditable access decision without provider conditionals.
+
+    Unknown features fail closed when enforcement is active. Before launch,
+    enforcement defaults off so existing learners are not accidentally locked
+    out while the commercial contract is still being finalized.
+    """
+    user_id = str(user_id or "").strip()
+    feature = str(feature or "").strip()
+    if not user_id:
+        return {"allowed": False, "feature": feature, "reason": "missing_user"}
+    if feature in _FREE_FEATURES:
+        return {"allowed": True, "feature": feature, "reason": "free_floor"}
+
+    active = paid_access_enforcement_enabled() if enforce is None else bool(enforce)
+    if not active:
+        return {"allowed": True, "feature": feature, "reason": "rollout_disabled"}
+    if feature not in _PAID_FEATURES:
+        return {"allowed": False, "feature": feature, "reason": "unknown_feature"}
+    if can_use_paid_core(user_id):
+        return {"allowed": True, "feature": feature, "reason": "paid_entitlement"}
+    return {"allowed": False, "feature": feature, "reason": "paid_required"}
+
+
+def can_access(user_id: str, feature: str, *, enforce: bool | None = None) -> bool:
+    return bool(access_decision(user_id, feature, enforce=enforce)["allowed"])

--- a/stripe_checkout_service.py
+++ b/stripe_checkout_service.py
@@ -15,6 +15,10 @@ from payment_entitlement import CORE_PRODUCT_KEY, get_entitlement
 from stripe_entitlement_adapter import STRIPE_SANDBOX_PROVIDER
 
 
+_PORTAL_CONFIG_METADATA_KEY = "lt_purpose"
+_PORTAL_CONFIG_METADATA_VALUE = "licensetown_sandbox_v01"
+
+
 def _required_env(name: str) -> str:
     value = str(os.getenv(name) or "").strip()
     if not value:
@@ -73,6 +77,76 @@ def _checkout_line_item(price_id: str | None = None) -> dict[str, Any]:
     }
 
 
+def _object_id(value: Any) -> str | None:
+    if isinstance(value, dict):
+        object_id = value.get("id")
+    else:
+        object_id = getattr(value, "id", None)
+    object_id = str(object_id or "").strip()
+    return object_id or None
+
+
+def _object_metadata(value: Any) -> dict[str, Any]:
+    if isinstance(value, dict):
+        metadata = value.get("metadata") or {}
+    else:
+        metadata = getattr(value, "metadata", None) or {}
+    if isinstance(metadata, dict):
+        return metadata
+    try:
+        return dict(metadata)
+    except (TypeError, ValueError):
+        return {}
+
+
+def ensure_sandbox_portal_configuration() -> str:
+    """Return the dedicated LT sandbox portal configuration, creating it once.
+
+    We do not reuse arbitrary active portal configurations because cancellation
+    semantics are part of LicenseTown's paid-access contract. The sandbox portal
+    must cancel at period end and must not expose plan switching.
+    """
+    key = _stripe_secret_key()
+    configurations = stripe.billing_portal.Configuration.list(
+        api_key=key,
+        active=True,
+        limit=100,
+    )
+    rows = configurations.get("data", []) if isinstance(configurations, dict) else getattr(
+        configurations, "data", []
+    )
+    for configuration in rows or []:
+        metadata = _object_metadata(configuration)
+        if metadata.get(_PORTAL_CONFIG_METADATA_KEY) == _PORTAL_CONFIG_METADATA_VALUE:
+            configuration_id = _object_id(configuration)
+            if configuration_id:
+                return configuration_id
+
+    configuration = stripe.billing_portal.Configuration.create(
+        api_key=key,
+        features={
+            "customer_update": {"enabled": False, "allowed_updates": []},
+            "invoice_history": {"enabled": True},
+            "payment_method_update": {"enabled": True},
+            "subscription_cancel": {
+                "enabled": True,
+                "mode": "at_period_end",
+                "proration_behavior": "none",
+            },
+            "subscription_update": {
+                "enabled": False,
+                "default_allowed_updates": [],
+                "proration_behavior": "none",
+            },
+        },
+        metadata={_PORTAL_CONFIG_METADATA_KEY: _PORTAL_CONFIG_METADATA_VALUE},
+    )
+    configuration_id = _object_id(configuration)
+    if not configuration_id:
+        raise RuntimeError("Stripe sandbox portal configuration id is missing")
+    return configuration_id
+
+
 def create_subscription_checkout_session(
     user_id: str,
     *,
@@ -119,8 +193,10 @@ def create_customer_portal_session(user_id: str, *, return_url: str) -> Any:
     if not customer_id:
         raise ValueError("Stripe sandbox customer mapping is not available")
 
+    configuration_id = ensure_sandbox_portal_configuration()
     return stripe.billing_portal.Session.create(
         api_key=_stripe_secret_key(),
         customer=customer_id,
+        configuration=configuration_id,
         return_url=return_url,
     )

--- a/tests/test_payment_access.py
+++ b/tests/test_payment_access.py
@@ -1,0 +1,88 @@
+from datetime import datetime, timedelta, timezone
+
+import payment_access
+import payment_entitlement
+
+
+def setup_function():
+    payment_entitlement.reset_local_payment_state_for_tests()
+
+
+def _entitle(status="active", *, user_id="learner-1"):
+    now = datetime.now(timezone.utc)
+    payment_entitlement.apply_verified_provider_event(
+        {
+            "verified": True,
+            "provider": "stripe_sandbox",
+            "provider_event_id": f"evt_{status}",
+            "event_type": "customer.subscription.updated",
+            "user_id": user_id,
+            "product_key": payment_entitlement.CORE_PRODUCT_KEY,
+            "provider_customer_id": "cus_1",
+            "provider_subscription_id": "sub_1",
+            "status": status,
+            "current_period_start": now - timedelta(days=1),
+            "current_period_end": now + timedelta(days=29),
+            "provider_event_created_at": now,
+        }
+    )
+
+
+def test_free_floor_remains_available_without_entitlement():
+    assert payment_access.can_access("learner-1", payment_access.FREE_FIRST_FIVE, enforce=True)
+    assert payment_access.can_access("learner-1", payment_access.FREE_NEXT_ACTION, enforce=True)
+
+
+def test_inactive_user_is_denied_paid_feature_when_enforced():
+    decision = payment_access.access_decision(
+        "learner-1", payment_access.PAID_ADAPTIVE_FULL, enforce=True
+    )
+    assert decision == {
+        "allowed": False,
+        "feature": payment_access.PAID_ADAPTIVE_FULL,
+        "reason": "paid_required",
+    }
+
+
+def test_active_entitlement_allows_paid_features_when_enforced():
+    _entitle("active")
+    assert payment_access.can_access(
+        "learner-1", payment_access.PAID_ADAPTIVE_FULL, enforce=True
+    )
+    assert payment_access.can_access(
+        "learner-1", payment_access.PAID_DASHBOARD_FULL, enforce=True
+    )
+    assert payment_access.can_access(
+        "learner-1", payment_access.PAID_SUPPORTER_FULL, enforce=True
+    )
+
+
+def test_cancel_at_period_end_keeps_paid_access_until_period_end():
+    _entitle("cancel_at_period_end")
+    assert payment_access.can_access(
+        "learner-1", payment_access.PAID_DASHBOARD_FULL, enforce=True
+    )
+
+
+def test_expired_entitlement_is_denied_paid_feature():
+    _entitle("expired")
+    assert not payment_access.can_access(
+        "learner-1", payment_access.PAID_SUPPORTER_FULL, enforce=True
+    )
+
+
+def test_unknown_feature_fails_closed_when_enforced():
+    decision = payment_access.access_decision("learner-1", "future_unknown", enforce=True)
+    assert decision["allowed"] is False
+    assert decision["reason"] == "unknown_feature"
+
+
+def test_rollout_defaults_off_to_preserve_existing_access(monkeypatch):
+    monkeypatch.delenv("ENABLE_PAID_ACCESS_ENFORCEMENT", raising=False)
+    decision = payment_access.access_decision("learner-1", payment_access.PAID_ADAPTIVE_FULL)
+    assert decision["allowed"] is True
+    assert decision["reason"] == "rollout_disabled"
+
+
+def test_missing_user_fails_closed_even_before_rollout():
+    assert not payment_access.can_access("", payment_access.FREE_FIRST_FIVE, enforce=False)

--- a/tests/test_stripe_checkout_service.py
+++ b/tests/test_stripe_checkout_service.py
@@ -147,6 +147,63 @@ def test_portal_requires_existing_stripe_customer(monkeypatch):
         raise AssertionError("portal must not guess a Stripe customer")
 
 
+def test_portal_configuration_reuses_dedicated_active_configuration(monkeypatch):
+    monkeypatch.setenv("STRIPE_SECRET_KEY", "sk_test_license_town")
+    existing = SimpleNamespace(
+        id="bpc_existing",
+        metadata={service._PORTAL_CONFIG_METADATA_KEY: service._PORTAL_CONFIG_METADATA_VALUE},
+    )
+    monkeypatch.setattr(
+        service.stripe.billing_portal.Configuration,
+        "list",
+        lambda **params: SimpleNamespace(data=[existing]),
+    )
+
+    def unexpected_create(**params):
+        raise AssertionError("matching portal configuration should be reused")
+
+    monkeypatch.setattr(
+        service.stripe.billing_portal.Configuration,
+        "create",
+        unexpected_create,
+    )
+
+    assert service.ensure_sandbox_portal_configuration() == "bpc_existing"
+
+
+def test_portal_configuration_creates_period_end_cancel_contract(monkeypatch):
+    monkeypatch.setenv("STRIPE_SECRET_KEY", "sk_test_license_town")
+    monkeypatch.setattr(
+        service.stripe.billing_portal.Configuration,
+        "list",
+        lambda **params: SimpleNamespace(data=[]),
+    )
+    captured = {}
+
+    def fake_create(**params):
+        captured.update(params)
+        return SimpleNamespace(id="bpc_new")
+
+    monkeypatch.setattr(
+        service.stripe.billing_portal.Configuration,
+        "create",
+        fake_create,
+    )
+
+    assert service.ensure_sandbox_portal_configuration() == "bpc_new"
+    features = captured["features"]
+    assert features["subscription_cancel"] == {
+        "enabled": True,
+        "mode": "at_period_end",
+        "proration_behavior": "none",
+    }
+    assert features["subscription_update"]["enabled"] is False
+    assert features["payment_method_update"]["enabled"] is True
+    assert captured["metadata"] == {
+        service._PORTAL_CONFIG_METADATA_KEY: service._PORTAL_CONFIG_METADATA_VALUE
+    }
+
+
 def test_portal_uses_durable_sandbox_customer_mapping(monkeypatch):
     monkeypatch.setenv("STRIPE_SECRET_KEY", "sk_test_license_town")
     payment_entitlement.apply_verified_provider_event(
@@ -162,6 +219,7 @@ def test_portal_uses_durable_sandbox_customer_mapping(monkeypatch):
             "status": "active",
         }
     )
+    monkeypatch.setattr(service, "ensure_sandbox_portal_configuration", lambda: "bpc_1")
     captured = {}
     monkeypatch.setattr(
         service.stripe.billing_portal.Session,
@@ -176,4 +234,5 @@ def test_portal_uses_durable_sandbox_customer_mapping(monkeypatch):
 
     assert portal.url == "https://billing.stripe.test/portal"
     assert captured["customer"] == "cus_1"
+    assert captured["configuration"] == "bpc_1"
     assert captured["return_url"] == "https://example.test/return"


### PR DESCRIPTION
Continues #154 after the real sandbox webhook lifecycle passed.

Scope:
- adds a centralized provider-agnostic free/paid access policy
- keeps the free floor available for the first 5 questions and meaningful next action
- adds rollout-gated paid feature keys for full adaptive learning, dashboard, and supporter views
- unknown paid features fail closed once enforcement is enabled
- keeps enforcement OFF by default until public sale-safe rollout is approved
- makes Stripe sandbox Customer Portal self-configuring
- portal configuration is dedicated to LicenseTown sandbox via metadata
- cancellation is fixed to end-of-period with no proration
- plan switching is disabled; payment method update remains available
- portal session uses the durable Stripe customer mapping and explicit configuration id
- tests cover inactive/active/cancel_at_period_end/expired access behavior and portal configuration semantics

No live Stripe account access or real charging is enabled. Existing production learner access is unchanged because paid enforcement remains disabled by default.