### PR TITLE
Make public preview claims sale-safe

### DIFF
--- a/site_ui.py
+++ b/site_ui.py
@@ -25,8 +25,44 @@ def home():
     )
 
 
+def _sale_safe_html(html: str) -> str:
+    """Remove prototype claims that must not appear as factual sale copy yet.
+
+    This is intentionally a presentation boundary only. The original preview
+    assets remain available for design regression, while the public rendered
+    views cannot advertise stale counts, a nonexistent free period, or demo
+    dashboard values without an explicit image label.
+    """
+    stats = (
+        '<section class="stats"><div class="container"><div><i>▰</i><span><small>新規問題</small>'
+        '<b>1000<em>問</em></b></span></div><div><i>▤</i><span><small>過去問</small>'
+        '<b>1000<em>問</em></b></span></div><div><i>▥</i><span><small>合計</small>'
+        '<b>2000<em>問収録</em></b></span></div></div></section>'
+    )
+    safe_stats = (
+        '<section class="stats"><div class="container"><div><i>▥</i><span>'
+        f'<small>問題演習</small><b>{QUESTION_COUNT_LABEL}</b>'
+        '</span></div></div></section>'
+    )
+    html = html.replace(stats, safe_stats)
+    html = html.replace('<li>現在無料</li>', '<li>提供条件を準備中</li>')
+    html = html.replace('無料期間実施中！', '料金・提供条件は公開準備中')
+    html = html.replace(
+        'すべての機能を無料で体験できます。',
+        '正式な料金・無料範囲は公開前にこのページで案内します。',
+    )
+    html = html.replace(
+        '金融内容（個別のやり取り）は共有されません。',
+        '相談内容（個別のやり取り）は共有されません。',
+    )
+    html = html.replace('総合達成度</small>', '総合達成度 <em>（画面イメージ）</em></small>')
+    html = html.replace('合格まで あと <b>123</b>日', '学習ナビ <em>（画面イメージ）</em>')
+    return html
+
+
 def _preview_document(source_path, base_url, extra_stylesheet_url):
     html = source_path.read_text(encoding="utf-8")
+    html = _sale_safe_html(html)
     html = html.replace("<head>", f'<head><base href="{base_url}">', 1)
     html = html.replace(
         "</head>",

--- a/tests/test_site_sale_safe.py
+++ b/tests/test_site_sale_safe.py
@@ -2,9 +2,17 @@ from site_ui import _sale_safe_html
 
 
 def test_pc_demo_claims_are_sanitized():
-    html = "新規問題</small><b>1000<em>問</em></b> 過去問</small><b>1000<em>問</em></b> 合計</small><b>2000<em>問収録</em></b> 無料期間実施中！ すべての機能を無料で体験できます。 合格まで あと <b>123</b>日 総合達成度"
+    html = (
+        '<section class="stats"><div class="container"><div><i>▰</i><span><small>新規問題</small>'
+        '<b>1000<em>問</em></b></span></div><div><i>▤</i><span><small>過去問</small>'
+        '<b>1000<em>問</em></b></span></div><div><i>▥</i><span><small>合計</small>'
+        '<b>2000<em>問収録</em></b></span></div></div></section>'
+        ' 無料期間実施中！ すべての機能を無料で体験できます。 '
+        '合格まで あと <b>123</b>日 総合達成度</small>'
+    )
     safe = _sale_safe_html(html)
     assert "2000<em>問収録</em>" not in safe
+    assert "1000<em>問</em>" not in safe
     assert "無料期間実施中！" not in safe
     assert "すべての機能を無料で体験できます。" not in safe
     assert "画面イメージ" in safe

--- a/tests/test_site_sale_safe.py
+++ b/tests/test_site_sale_safe.py
@@ -1,0 +1,19 @@
+from site_ui import _sale_safe_html
+
+
+def test_pc_demo_claims_are_sanitized():
+    html = "新規問題</small><b>1000<em>問</em></b> 過去問</small><b>1000<em>問</em></b> 合計</small><b>2000<em>問収録</em></b> 無料期間実施中！ すべての機能を無料で体験できます。 合格まで あと <b>123</b>日 総合達成度"
+    safe = _sale_safe_html(html)
+    assert "2000<em>問収録</em>" not in safe
+    assert "無料期間実施中！" not in safe
+    assert "すべての機能を無料で体験できます。" not in safe
+    assert "画面イメージ" in safe
+
+
+def test_mobile_copy_typo_and_free_claim_are_sanitized():
+    html = "<li>現在無料</li><li>LINEで使える</li><li>1,500問以上収録</li> 金融内容（個別のやり取り）は共有されません。"
+    safe = _sale_safe_html(html)
+    assert "現在無料" not in safe
+    assert "金融内容" not in safe
+    assert "相談内容（個別のやり取り）は共有されません。" in safe
+    assert "1,500問以上収録" in safe


### PR DESCRIPTION
Partial completion of #155 without changing the established visual layout.

Scope:
- sanitizes stale PC `1000 + 1000 = 2000` problem-count claim at the public render boundary
- uses centralized `SITE_QUESTION_COUNT_LABEL` for the published total label
- removes the unsupported `現在無料` / `無料期間実施中` claims from public rendered views
- marks illustrative dashboard/progress values as `画面イメージ`
- removes the misleading fixed `合格まであと123日` presentation
- fixes the mobile `金融内容` typo to `相談内容`
- adds regression tests for the sale-safe sanitizer

This does not enable public charging, paid gating, or live Stripe. Legal/operator pages and final CTA destination remain separate #155 work and should not be treated as complete by this PR.