### PR TITLE
Make public source views sale-safe too

### DIFF
--- a/preview-pc/index.html
+++ b/preview-pc/index.html
@@ -8,8 +8,8 @@
 </head>
 <body>
   <header class="header"><div class="container header-row">
-    <a class="logo" href="#top"><span class="logo-mark">▥</span><span><b>ライセンスタウン</b><small>合格への最短ルートを、いっしょに。</small></span></a>
-    <nav class="nav"><a href="#features">特長</a><a href="#road">合格への道</a><a href="#gensan">教えて源さん</a><a href="#watch">見守り機能</a><a href="#bottom">料金プラン</a><a href="#faq">よくある質問</a></nav>
+    <a class="logo" href="#top"><span class="logo-mark">▥</span><span><b>ライセンスタウン</b><small>合格への道を、いっしょに。</small></span></a>
+    <nav class="nav"><a href="#features">特長</a><a href="#road">合格への道</a><a href="#gensan">教えて源さん</a><a href="#watch">見守り機能</a><a href="#bottom">ご利用案内</a><a href="#faq">よくある質問</a></nav>
     <div class="header-actions"><a class="btn login">ログイン</a><a class="btn primary" href="#try">まずは使ってみる</a></div>
   </div></header>
 
@@ -19,28 +19,28 @@
       <aside class="hero-list"><p>学習が続く仕組み</p><p>弱点がわかる分析機能</p><p>合格までの道筋をナビゲート</p><p>親御さんも安心の見守り機能</p></aside>
     </div></section>
 
-    <section class="stats"><div class="container"><div><i>▰</i><span><small>新規問題</small><b>1000<em>問</em></b></span></div><div><i>▤</i><span><small>過去問</small><b>1000<em>問</em></b></span></div><div><i>▥</i><span><small>合計</small><b>2000<em>問収録</em></b></span></div></div></section>
+    <section class="stats"><div class="container"><div><i>▰</i><span><small>新規問題</small><b>643<em>問</em></b></span></div><div><i>▤</i><span><small>過去問</small><b>1094<em>問</em></b></span></div><div><i>▥</i><span><small>合計</small><b>1737<em>問収録</em></b></span></div></div></section>
 
     <section class="feature-one" id="features"><div class="container three-grid">
       <article class="feature-card line-card"><div class="card-copy"><h2><span>LINE</span>で学習が完結</h2><p>いつものLINEで、<br>スキマ時間にサクッと学習。<br>通知で学習リズムも<br>しっかりサポート。</p></div><div class="line-visual"><small>今日の5問を<br>始めますか？</small><b>はい、<br>始めます！</b><em>LINE</em></div></article>
-      <article class="feature-card route-card"><div class="card-copy"><h2><span>合格への道</span>で迷わない</h2><p>あなた専用の学習プランを自動生成。<br>今やるべきことがひと目でわかり、<br>合格までの道筋をしっかりナビゲート。</p></div><div class="route-visual"><i></i><b>⚑</b></div></article>
-      <article class="feature-card monitor-card"><div class="card-copy"><h2>親御さんの見守り機能</h2><p>学習状況や理解度をいつでも確認。<br>離れていても、<br>お子さんのがんばりを<br>しっかり応援できます。</p></div><div class="mini-board"><small>総合達成度</small><div class="mini-bars"><i></i><i></i><i></i><i></i><i></i></div><b>72%</b><p>連続学習日数　<strong>3日</strong></p></div></article>
+      <article class="feature-card route-card"><div class="card-copy"><h2><span>合格への道</span>で迷わない</h2><p>学習状況に合わせて次の学習を提案。<br>今やるべきことがひと目でわかり、<br>日々の学習をしっかりナビゲート。</p></div><div class="route-visual"><i></i><b>⚑</b></div></article>
+      <article class="feature-card monitor-card"><div class="card-copy"><h2>親御さんの見守り機能</h2><p>学習状況や理解度をいつでも確認。<br>離れていても、<br>お子さんのがんばりを<br>しっかり応援できます。</p></div><div class="mini-board"><small>総合達成度<br>※画面イメージ</small><div class="mini-bars"><i></i><i></i><i></i><i></i><i></i></div><b>72%</b><p>連続学習日数　<strong>3日</strong></p></div></article>
     </div></section>
 
     <section class="feature-two"><div class="container two-grid">
       <article class="gensan-card" id="gensan"><img src="../preview-724/assets/gensan-main.png" alt="教えて源さん"><div class="gensan-copy"><h2>教えて源さん</h2><p>学習の悩みや、つまずきポイントを<br>源さんがやさしく解説！<br>モチベーションも上がります。</p><a>源さんに質問してみる</a></div><ul><li>苦手な分野を<br>どう克服すればいい？</li><li>勉強が続かないときは<br>どうしたらいい？</li><li>試験直前の過ごし方は？</li></ul></article>
-      <article class="road-card" id="road"><div class="road-copy"><h2>合格への道</h2><p>現在の実力から、合格までの最短ルートを提示。<br>日々の学習で、着実にステップアップ！</p><a>詳しく見る</a></div><div class="road-score"><h3>合格まで あと <b>123</b>日</h3><small>総合達成度</small><div class="ring">68%</div></div><div class="week-task"><h3>今週の学習タスク</h3><p>基礎問題を解く <i style="--w:76%"></i><small>20/30問</small></p><p>単語分野の練習 <i style="--w:62%"></i><small>2/3セット</small></p><p>過去問演習 <i style="--w:48%"></i><small>1/2回</small></p></div></article>
+      <article class="road-card" id="road"><div class="road-copy"><h2>合格への道</h2><p>現在の学習状況から、次に取り組む内容を提示。<br>日々の学習で、着実にステップアップ。</p><small>※表示数値は画面イメージです</small><a>詳しく見る</a></div><div class="road-score"><h3>合格まで あと <b>123</b>日</h3><small>総合達成度</small><div class="ring">68%</div></div><div class="week-task"><h3>今週の学習タスク</h3><p>基礎問題を解く <i style="--w:76%"></i><small>20/30問</small></p><p>単語分野の練習 <i style="--w:62%"></i><small>2/3セット</small></p><p>過去問演習 <i style="--w:48%"></i><small>1/2回</small></p></div></article>
     </div></section>
 
-    <section class="watch" id="watch"><div class="container watch-row"><div class="family-icon">♟♟</div><div class="watch-copy"><h2>親御さん向け見守り</h2><p>学習の進捗や理解度、取り組み状況をダッシュボードで確認。<br>がんばりを見える化して、適切なサポートができます。</p></div><a class="detail">詳しく見る</a><div class="watch-metric"><small>学習時間（今週）</small><b>7<em>時間</em>45<em>分</em></b></div><div class="watch-metric"><small>課題達成率</small><b>72<em>%</em></b></div><div class="watch-metric"><small>正答率</small><b>68<em>%</em></b></div><div class="topics"><b>最近の学習トピック</b><p>・法令分野の正答率が上がっています！<br>・苦手な計算問題に取り組みましょう。</p></div></div></section>
+    <section class="watch" id="watch"><div class="container watch-row"><div class="family-icon">♟♟</div><div class="watch-copy"><h2>親御さん向け見守り</h2><p>学習の進捗や理解度、取り組み状況をダッシュボードで確認。<br>がんばりを見える化して、適切なサポートができます。<br><small>※表示数値は画面イメージです</small></p></div><a class="detail">詳しく見る</a><div class="watch-metric"><small>学習時間（今週）</small><b>7<em>時間</em>45<em>分</em></b></div><div class="watch-metric"><small>課題達成率</small><b>72<em>%</em></b></div><div class="watch-metric"><small>正答率</small><b>68<em>%</em></b></div><div class="topics"><b>最近の学習トピック</b><p>・法令分野の正答率が上がっています！<br>・苦手な計算問題に取り組みましょう。</p></div></div></section>
 
     <section class="bottom" id="bottom"><div class="container bottom-grid">
-      <article class="brand-panel"><h2>ライセンスタウンは、あなたの「合格したい」を全力で応援します。</h2><p>医療・福祉系資格に特化した学習プラットフォーム</p><div><span>▣<b>資格に特化した<br>豊富な問題</b></span><span>◉<b>弱点を分析する<br>AI学習サポート</b></span><span>✓<b>続けられる仕組みで<br>学習習慣化</b></span><span>♜<b>安心のサポート体制</b></span></div></article>
-      <article class="faq-panel" id="faq"><h2>よくある質問</h2><p>ライセンスタウンの使い方を教えてください <b>›</b></p><p>料金プランについて知りたい <b>›</b></p><p>お試しで使える期間を教えてください <b>›</b></p><p>解約・退会の方法を教えてください <b>›</b></p><a>その他の質問はこちら　›</a></article>
-      <article class="try-panel" id="try"><h2>無料期間実施中！</h2><p>すべての機能を無料で体験できます。</p><a>まずは使ってみる　›</a></article>
+      <article class="brand-panel"><h2>ライセンスタウンは、あなたの「合格したい」を全力で応援します。</h2><p>理学療法士国家試験の学習を支える伴走型学習サービス</p><div><span>▣<b>資格に特化した<br>豊富な問題</b></span><span>◉<b>弱点を分析する<br>AI学習サポート</b></span><span>✓<b>続けられる仕組みで<br>学習習慣化</b></span><span>♜<b>安心のサポート体制</b></span></div></article>
+      <article class="faq-panel" id="faq"><h2>よくある質問</h2><p>ライセンスタウンの使い方を教えてください <b>›</b></p><p>どんな機能が使えますか？ <b>›</b></p><p>利用開始の方法を教えてください <b>›</b></p><p>解約・退会の方法を教えてください <b>›</b></p><a>その他の質問はこちら　›</a></article>
+      <article class="try-panel" id="try"><h2>サービス提供準備中</h2><p>正式な料金・提供条件は、公開前にこのページでご案内します。</p><a>まずは使ってみる　›</a></article>
     </div></section>
   </main>
 
-  <footer class="footer"><div class="container"><a class="footer-logo"><b>▥　ライセンスタウン</b><small>合格への最短ルートを、いっしょに。</small></a><nav><a>特定商取引法に基づく表記</a><a>プライバシーポリシー</a><a>利用規約</a><a>運営会社</a><a>お問い合わせ</a></nav><small>© 2025 LicenseTown. All Rights Reserved.</small></div></footer>
+  <footer class="footer"><div class="container"><a class="footer-logo"><b>▥　ライセンスタウン</b><small>合格への道を、いっしょに。</small></a><nav><a>特定商取引法に基づく表記</a><a>プライバシーポリシー</a><a>利用規約</a><a>運営会社</a><a>お問い合わせ</a></nav><small>© 2025 LicenseTown. All Rights Reserved.</small></div></footer>
 </body>
 </html>

--- a/site_ui.py
+++ b/site_ui.py
@@ -92,6 +92,11 @@ def _preview_document(source_path, base_url, extra_stylesheet_url):
     return Response(html, mimetype="text/html")
 
 
+def _sale_safe_source(source_path):
+    html = source_path.read_text(encoding="utf-8")
+    return Response(_sale_safe_html(html), mimetype="text/html")
+
+
 @site_ui.get("/site/view/pc")
 def pc_view():
     return _preview_document(
@@ -112,12 +117,12 @@ def mobile_view():
 
 @site_ui.get("/site/source/pc")
 def pc_source():
-    return send_from_directory(PREVIEW_PC_DIR, "index.html")
+    return _sale_safe_source(PREVIEW_PC_DIR / "index.html")
 
 
 @site_ui.get("/site/source/mobile")
 def mobile_source():
-    return send_from_directory(PREVIEW_724_DIR, "index.html")
+    return _sale_safe_source(PREVIEW_724_DIR / "index.html")
 
 
 @site_ui.get("/site/preview-pc/<path:filename>")

--- a/tests/test_site_sale_safe.py
+++ b/tests/test_site_sale_safe.py
@@ -1,4 +1,4 @@
-from site_ui import _sale_safe_html
+from site_ui import PREVIEW_724_DIR, PREVIEW_PC_DIR, _sale_safe_html, _sale_safe_source
 
 
 def test_pc_demo_claims_are_sanitized():
@@ -25,3 +25,18 @@ def test_mobile_copy_typo_and_free_claim_are_sanitized():
     assert "金融内容" not in safe
     assert "相談内容（個別のやり取り）は共有されません。" in safe
     assert "1,500問以上収録" in safe
+
+
+def test_pc_source_asset_no_longer_contains_stale_2000_or_free_period():
+    html = (PREVIEW_PC_DIR / "index.html").read_text(encoding="utf-8")
+    assert "2000" not in html
+    assert "無料期間実施中" not in html
+    assert "1737" in html
+
+
+def test_public_mobile_source_response_is_sale_safe():
+    response = _sale_safe_source(PREVIEW_724_DIR / "index.html")
+    html = response.get_data(as_text=True)
+    assert "現在無料" not in html
+    assert "金融内容" not in html
+    assert "相談内容（個別のやり取り）は共有されません。" in html


### PR DESCRIPTION
Continues #155 by removing the remaining public-source escape hatch.

Scope:
- ports the already-reviewed PC sale-safe copy onto current main: 1737 total (643 original / 1094 past_exam), safer navigation/copy, demo-value labels, no fake free-period claim
- `/site/source/pc` and `/site/source/mobile` now return the same sale-safe sanitization as rendered preview views instead of bypassing it via raw send_from_directory
- adds regression coverage proving the PC source no longer contains stale `2000` / `無料期間実施中` and the mobile public source no longer exposes `現在無料` or the `金融内容` typo

No live charging, paid enforcement, or final public pricing is enabled.