### PR TITLE
Bind public CTA and question count to verified sources

### DIFF
--- a/site_ui.py
+++ b/site_ui.py
@@ -1,5 +1,9 @@
+import json
 import os
+import re
+from html import escape
 from pathlib import Path
+from urllib.parse import urlparse
 
 from flask import Blueprint, Response, render_template, send_from_directory, url_for
 
@@ -10,10 +14,39 @@ ROOT = Path(__file__).resolve().parent
 PREVIEW_PC_DIR = ROOT / "preview-pc"
 PREVIEW_724_DIR = ROOT / "preview-724"
 PREVIEW_RESPONSIVE_DIR = ROOT / "preview-responsive"
+QUESTION_BANK_PATH = ROOT / "data" / "question_bank" / "questions.json"
 
-# Public copy is deliberately centralized so the published figure can be
-# updated without editing the page layout.
-QUESTION_COUNT_LABEL = os.getenv("SITE_QUESTION_COUNT_LABEL", "1,500問以上収録")
+
+def _question_count_label() -> str:
+    """Return one factual public question-count label from the formal bank.
+
+    A deliberate environment override remains available for conservative public
+    copy, but the default cannot silently drift away from the formal bank.
+    """
+    override = os.getenv("SITE_QUESTION_COUNT_LABEL", "").strip()
+    if override:
+        return override
+    try:
+        payload = json.loads(QUESTION_BANK_PATH.read_text(encoding="utf-8"))
+        count = len(payload)
+    except (OSError, ValueError, TypeError):
+        return "問題を収録"
+    return f"{count}問収録"
+
+
+def _public_onboarding_url() -> str:
+    """Return a verified HTTPS onboarding URL or fail closed to contact.
+
+    Public CTA must never guess a LINE destination. Until the operator supplies
+    the intended HTTPS onboarding URL, the CTA resolves to LicenseTown contact.
+    """
+    candidate = os.getenv("SITE_ONBOARDING_URL", "").strip()
+    if not candidate:
+        return "/site/legal/contact"
+    parsed = urlparse(candidate)
+    if parsed.scheme != "https" or not parsed.netloc:
+        return "/site/legal/contact"
+    return candidate
 
 
 @site_ui.get("/site")
@@ -25,6 +58,25 @@ def home():
     )
 
 
+def _wire_primary_ctas(html: str) -> str:
+    target = escape(_public_onboarding_url(), quote=True)
+
+    def replace_anchor(match):
+        attrs = match.group("attrs") or ""
+        label = match.group("label")
+        if re.search(r'\shref="[^"]*"', attrs):
+            attrs = re.sub(r'\shref="[^"]*"', f' href="{target}"', attrs, count=1)
+        else:
+            attrs += f' href="{target}"'
+        return f"<a{attrs}>{label}</a>"
+
+    return re.sub(
+        r'<a(?P<attrs>[^>]*)>(?P<label>まずは使ってみる(?:　›)?)</a>',
+        replace_anchor,
+        html,
+    )
+
+
 def _sale_safe_html(html: str) -> str:
     """Remove prototype claims that must not appear as factual sale copy yet.
 
@@ -33,6 +85,7 @@ def _sale_safe_html(html: str) -> str:
     views cannot advertise stale counts, a nonexistent free period, or demo
     dashboard values without an explicit image label.
     """
+    count_label = _question_count_label()
     stats = (
         '<section class="stats"><div class="container"><div><i>▰</i><span><small>新規問題</small>'
         '<b>1000<em>問</em></b></span></div><div><i>▤</i><span><small>過去問</small>'
@@ -41,10 +94,18 @@ def _sale_safe_html(html: str) -> str:
     )
     safe_stats = (
         '<section class="stats"><div class="container"><div><i>▥</i><span>'
-        f'<small>問題演習</small><b>{QUESTION_COUNT_LABEL}</b>'
+        f'<small>問題演習</small><b>{count_label}</b>'
         '</span></div></div></section>'
     )
     html = html.replace(stats, safe_stats)
+    html = re.sub(
+        r'(合計</small><b>)\d+(<em>問収録</em>)',
+        lambda match: f"{match.group(1)}{count_label.removesuffix('問収録')}{match.group(2)}"
+        if count_label.endswith("問収録") and count_label[:-3].isdigit()
+        else f"{match.group(1)}{escape(count_label)}{match.group(2)}",
+        html,
+    )
+    html = html.replace("1,500問以上収録", count_label)
     html = html.replace('<li>現在無料</li>', '<li>提供条件を準備中</li>')
     html = html.replace('無料期間実施中！', '料金・提供条件は公開準備中')
     html = html.replace(
@@ -77,7 +138,7 @@ def _sale_safe_html(html: str) -> str:
         '<a>お問い合わせ</a>',
         '<a href="/site/legal/contact">お問い合わせ</a>',
     )
-    return html
+    return _wire_primary_ctas(html)
 
 
 def _preview_document(source_path, base_url, extra_stylesheet_url):

--- a/tests/test_site_sale_safe.py
+++ b/tests/test_site_sale_safe.py
@@ -1,4 +1,11 @@
-from site_ui import PREVIEW_724_DIR, PREVIEW_PC_DIR, _sale_safe_html, _sale_safe_source
+from site_ui import (
+    PREVIEW_724_DIR,
+    PREVIEW_PC_DIR,
+    _public_onboarding_url,
+    _question_count_label,
+    _sale_safe_html,
+    _sale_safe_source,
+)
 
 
 def test_pc_demo_claims_are_sanitized():
@@ -18,13 +25,35 @@ def test_pc_demo_claims_are_sanitized():
     assert "画面イメージ" in safe
 
 
-def test_mobile_copy_typo_and_free_claim_are_sanitized():
+def test_question_count_defaults_to_formal_bank(monkeypatch):
+    monkeypatch.delenv("SITE_QUESTION_COUNT_LABEL", raising=False)
+    assert _question_count_label() == "1737問収録"
+
+
+def test_mobile_copy_typo_free_claim_and_count_are_sanitized(monkeypatch):
+    monkeypatch.delenv("SITE_QUESTION_COUNT_LABEL", raising=False)
     html = "<li>現在無料</li><li>LINEで使える</li><li>1,500問以上収録</li> 金融内容（個別のやり取り）は共有されません。"
     safe = _sale_safe_html(html)
     assert "現在無料" not in safe
     assert "金融内容" not in safe
     assert "相談内容（個別のやり取り）は共有されません。" in safe
-    assert "1,500問以上収録" in safe
+    assert "1,500問以上収録" not in safe
+    assert "1737問収録" in safe
+
+
+def test_public_cta_fails_closed_until_verified_https_url(monkeypatch):
+    monkeypatch.delenv("SITE_ONBOARDING_URL", raising=False)
+    assert _public_onboarding_url() == "/site/legal/contact"
+    safe = _sale_safe_html('<a class="btn primary">まずは使ってみる　›</a>')
+    assert 'href="/site/legal/contact"' in safe
+
+    monkeypatch.setenv("SITE_ONBOARDING_URL", "javascript:alert(1)")
+    assert _public_onboarding_url() == "/site/legal/contact"
+
+    monkeypatch.setenv("SITE_ONBOARDING_URL", "https://example.test/line-entry")
+    assert _public_onboarding_url() == "https://example.test/line-entry"
+    safe = _sale_safe_html('<a class="header-cta" href="#try">まずは使ってみる</a>')
+    assert 'href="https://example.test/line-entry"' in safe
 
 
 def test_pc_source_asset_no_longer_contains_stale_2000_or_free_period():
@@ -34,9 +63,11 @@ def test_pc_source_asset_no_longer_contains_stale_2000_or_free_period():
     assert "1737" in html
 
 
-def test_public_mobile_source_response_is_sale_safe():
+def test_public_mobile_source_response_is_sale_safe(monkeypatch):
+    monkeypatch.delenv("SITE_QUESTION_COUNT_LABEL", raising=False)
     response = _sale_safe_source(PREVIEW_724_DIR / "index.html")
     html = response.get_data(as_text=True)
     assert "現在無料" not in html
     assert "金融内容" not in html
     assert "相談内容（個別のやり取り）は共有されません。" in html
+    assert "1737問収録" in html


### PR DESCRIPTION
Continues #155 with fail-closed public conversion plumbing.

Scope:
- derives the default public question-count label from the formal Question Bank (`data/question_bank/questions.json`) so the published total cannot silently drift
- keeps an explicit `SITE_QUESTION_COUNT_LABEL` override for deliberately conservative copy
- rewrites the mobile conservative count to the same source-of-truth label
- wires every `まずは使ってみる` primary anchor through one `SITE_ONBOARDING_URL` boundary
- accepts only a configured HTTPS onboarding URL; otherwise fails closed to `/site/legal/contact` rather than guessing a LINE destination
- adds regression tests for the 1737 formal-bank count, invalid URL rejection, valid HTTPS CTA wiring, and mobile/public-source consistency

This PR does not set the final LINE onboarding URL, final operator/legal fields, pricing, live Stripe, public charging, or paid enforcement.