### PR TITLE
Expose myforest operator brand on legal pages

### DIFF
--- a/site_legal_ui.py
+++ b/site_legal_ui.py
@@ -22,6 +22,8 @@ _REQUIRED_OPERATOR_ENV = {
     "お問い合わせ先": "SITE_SUPPORT_EMAIL",
 }
 
+_OPERATOR_BRAND_ENV = "SITE_OPERATOR_BRAND"
+
 
 def _env(name: str) -> str:
     return str(os.getenv(name) or "").strip()
@@ -31,7 +33,23 @@ def operator_details() -> dict[str, str]:
     return {label: _env(env_name) for label, env_name in _REQUIRED_OPERATOR_ENV.items()}
 
 
+def operator_brand() -> str:
+    return _env(_OPERATOR_BRAND_ENV)
+
+
+def _operator_rows(*, include_brand: bool = True) -> str:
+    rows: list[tuple[str, str]] = []
+    if include_brand and operator_brand():
+        rows.append(("運営ブランド", operator_brand()))
+    rows.extend(operator_details().items())
+    return "".join(
+        f"<dt>{escape(label)}</dt><dd>{escape(value) if value else '販売開始前に掲載'}</dd>"
+        for label, value in rows
+    )
+
+
 def sale_legal_ready() -> bool:
+    # Brand is a public-facing operating name, not a required legal identity field.
     return all(operator_details().values())
 
 
@@ -63,11 +81,7 @@ a{color:#087d2c}.notice{padding:14px 16px;background:#eef8ef;border-radius:12px;
 
 @site_legal_ui.get("/site/legal/commercial-transactions")
 def commercial_transactions():
-    details = operator_details()
-    rows = "".join(
-        f"<dt>{escape(label)}</dt><dd>{escape(value) if value else '販売開始前に掲載'}</dd>"
-        for label, value in details.items()
-    )
+    rows = _operator_rows()
     body = f"""
 <p>特定商取引法に基づく表記の公開先です。販売開始前に必要事項を確定します。</p>
 <dl>{rows}
@@ -117,12 +131,8 @@ def terms():
 
 @site_legal_ui.get("/site/legal/operator")
 def operator():
-    details = operator_details()
-    rows = "".join(
-        f"<dt>{escape(label)}</dt><dd>{escape(value) if value else '販売開始前に掲載'}</dd>"
-        for label, value in details.items()
-    )
-    return _layout("運営者情報", f"<dl>{rows}</dl>")
+    rows = _operator_rows()
+    return _layout("運営者情報", f"<dl>{rows}<dt>サービス名</dt><dd>LicenseTown</dd></dl>")
 
 
 @site_legal_ui.get("/site/legal/contact")

--- a/tests/test_site_legal_ui.py
+++ b/tests/test_site_legal_ui.py
@@ -5,6 +5,7 @@ from site_ui import _sale_safe_html
 def test_sale_legal_ready_requires_all_operator_fields(monkeypatch):
     for env_name in site_legal_ui._REQUIRED_OPERATOR_ENV.values():
         monkeypatch.delenv(env_name, raising=False)
+    monkeypatch.delenv(site_legal_ui._OPERATOR_BRAND_ENV, raising=False)
     assert site_legal_ui.sale_legal_ready() is False
 
     monkeypatch.setenv("SITE_SELLER_NAME", "LicenseTown operator")
@@ -12,6 +13,17 @@ def test_sale_legal_ready_requires_all_operator_fields(monkeypatch):
     monkeypatch.setenv("SITE_SELLER_PHONE", "000-0000-0000")
     monkeypatch.setenv("SITE_SUPPORT_EMAIL", "support@example.test")
     assert site_legal_ui.sale_legal_ready() is True
+
+
+def test_operator_brand_is_optional_and_rendered_when_configured(monkeypatch):
+    monkeypatch.delenv(site_legal_ui._OPERATOR_BRAND_ENV, raising=False)
+    assert site_legal_ui.operator_brand() == ""
+    assert "運営ブランド" not in site_legal_ui._operator_rows()
+
+    monkeypatch.setenv(site_legal_ui._OPERATOR_BRAND_ENV, "myforest")
+    rows = site_legal_ui._operator_rows()
+    assert "運営ブランド" in rows
+    assert "myforest" in rows
 
 
 def test_public_footer_links_are_wired():


### PR DESCRIPTION
Continues #155 after final operator/contact details were supplied.

Scope:
- adds optional `SITE_OPERATOR_BRAND` display on 特商法 and 運営者情報 pages
- keeps legal readiness based on the required legal seller/address/phone/contact fields only
- shows the operating brand separately from the legal seller identity
- preserves LicenseTown as the service name
- adds regression coverage for optional brand rendering

Runtime operator/contact/onboarding values are configured through Render environment variables; no personal details are committed to the repository.

No live Stripe charging, pricing decision, or paid enforcement change.