### PR TITLE
Add optional LicenseTown development-support page

### DIFF
--- a/site_legal_ui.py
+++ b/site_legal_ui.py
@@ -68,7 +68,7 @@ def _layout(title: str, body_html: str):
 <style>
 body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;margin:0;background:#f7faf7;color:#18331f}
 main{max-width:820px;margin:40px auto;padding:0 20px 60px}.card{background:#fff;border:1px solid #dce8de;border-radius:18px;padding:28px}
-a{color:#087d2c}.notice{padding:14px 16px;background:#eef8ef;border-radius:12px;margin-bottom:24px}h1{font-size:28px}h2{margin-top:28px;font-size:20px}dt{font-weight:700;margin-top:14px}dd{margin:4px 0 0}footer{margin-top:32px;font-size:13px;color:#66756a}
+a{color:#087d2c}.notice{padding:14px 16px;background:#eef8ef;border-radius:12px;margin-bottom:24px}h1{font-size:28px}h2{margin-top:28px;font-size:20px}dt{font-weight:700;margin-top:14px}dd{margin:4px 0 0}footer{margin-top:32px;font-size:13px;color:#66756a}.support-note{padding:16px;background:#f3f8f3;border-radius:12px}.muted{color:#66756a}
 </style></head><body><main><div class="card"><div class="notice">{{ status }}</div>
 <h1>{{ title }}</h1>{{ body|safe }}<footer><a href="/site">LicenseTown公式サイトへ戻る</a></footer>
 </div></main></body></html>
@@ -133,6 +133,25 @@ def terms():
 def operator():
     rows = _operator_rows()
     return _layout("運営者情報", f"<dl>{rows}<dt>サービス名</dt><dd>LicenseTown</dd></dl>")
+
+
+@site_legal_ui.get("/site/support")
+def support():
+    body = """
+<p><strong>LicenseTownは現在、より多くの方に使っていただき、改善を重ねることを優先しています。</strong></p>
+<p>使いにくいところ、わかりにくいところ、もっとこうしてほしいという声を集めながら、少しずつ良いサービスに育てていきます。</p>
+<h2>もっと良くしたいこと</h2>
+<p>レスポンスをもっと速くすること。スマートフォンでもっと使いやすくすること。将来はアプリとして使えるようにすること。問題・分析・学習提案をさらに磨くこと。</p>
+<p>そのためには、サーバー代、AI利用料、開発や運営のための費用がかかります。</p>
+<div class="support-note">
+<strong>もし「これからも続いてほしい」「少し応援してもいい」と思っていただけたら、無理のない範囲で開発支援をいただけると嬉しいです。</strong>
+<p>支援する・しないは完全に任意です。支援の有無で、現在提供している学習機能に差をつける予定はありません。</p>
+</div>
+<h2>いただいた支援について</h2>
+<p>LicenseTownの運営、レスポンス改善、AI利用、機能改善、将来のアプリ化など、サービスを良くするために活用します。</p>
+<p class="muted">現在は支援受付の準備中です。決済機能はまだ公開していません。</p>
+"""
+    return _layout("LicenseTownを応援する", body)
 
 
 @site_legal_ui.get("/site/legal/contact")

--- a/site_ui.py
+++ b/site_ui.py
@@ -136,7 +136,7 @@ def _sale_safe_html(html: str) -> str:
     )
     html = html.replace(
         '<a>お問い合わせ</a>',
-        '<a href="/site/legal/contact">お問い合わせ</a>',
+        '<a href="/site/legal/contact">お問い合わせ</a><a href="/site/support">LicenseTownを応援する</a>',
     )
     return _wire_primary_ctas(html)
 

--- a/tests/test_site_legal_ui.py
+++ b/tests/test_site_legal_ui.py
@@ -1,3 +1,5 @@
+from flask import Flask
+
 import site_legal_ui
 from site_ui import _sale_safe_html
 
@@ -27,13 +29,11 @@ def test_operator_brand_is_optional_and_rendered_when_configured(monkeypatch):
 
 
 def test_support_page_is_optional_and_sale_safe():
-    app = site_legal_ui.site_legal_ui
-    rules = {rule.rule: rule.endpoint for rule in app.url_map.iter_rules()}
-    assert "/site/support" in rules
-
-    with app.test_request_context("/site/support"):
-        response = site_legal_ui.support()
-    html = response if isinstance(response, str) else response.get_data(as_text=True)
+    app = Flask(__name__)
+    app.register_blueprint(site_legal_ui.site_legal_ui)
+    response = app.test_client().get("/site/support")
+    assert response.status_code == 200
+    html = response.get_data(as_text=True)
     assert "LicenseTownを応援する" in html
     assert "支援する・しないは完全に任意" in html
     assert "現在提供している学習機能に差をつける予定はありません" in html

--- a/tests/test_site_legal_ui.py
+++ b/tests/test_site_legal_ui.py
@@ -26,6 +26,21 @@ def test_operator_brand_is_optional_and_rendered_when_configured(monkeypatch):
     assert "myforest" in rows
 
 
+def test_support_page_is_optional_and_sale_safe():
+    app = site_legal_ui.site_legal_ui
+    rules = {rule.rule: rule.endpoint for rule in app.url_map.iter_rules()}
+    assert "/site/support" in rules
+
+    with app.test_request_context("/site/support"):
+        response = site_legal_ui.support()
+    html = response if isinstance(response, str) else response.get_data(as_text=True)
+    assert "LicenseTownを応援する" in html
+    assert "支援する・しないは完全に任意" in html
+    assert "現在提供している学習機能に差をつける予定はありません" in html
+    assert "現在は支援受付の準備中" in html
+    assert "決済機能はまだ公開していません" in html
+
+
 def test_public_footer_links_are_wired():
     html = "<a>特定商取引法に基づく表記</a><a>プライバシーポリシー</a><a>利用規約</a><a>運営会社</a><a>お問い合わせ</a>"
     safe = _sale_safe_html(html)
@@ -34,3 +49,5 @@ def test_public_footer_links_are_wired():
     assert '/site/legal/terms' in safe
     assert '/site/legal/operator' in safe
     assert '/site/legal/contact' in safe
+    assert '/site/support' in safe
+    assert 'LicenseTownを応援する' in safe


### PR DESCRIPTION
Continues #155 with the agreed temporary operating model: broad free use for feedback and improvement, with optional development support later.

Scope:
- adds `/site/support` as a public support/explanation page
- explicitly states support is optional
- explicitly states current learning functionality is not differentiated by support status
- explains intended use of support funds: operations, response improvements, AI usage, product improvements, future app work
- keeps support collection disabled; no payment button or live charging path is exposed
- links the public footer to `LicenseTownを応援する`
- adds regression coverage

This does not enable Stripe live mode, paid enforcement, or public collection of funds. The future monthly price candidate remains separate from the current free-use phase.