### PR TITLE
Cap optional development support at 1,000 yen

### DIFF
--- a/site_legal_ui.py
+++ b/site_legal_ui.py
@@ -68,7 +68,7 @@ def _layout(title: str, body_html: str):
 <style>
 body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;margin:0;background:#f7faf7;color:#18331f}
 main{max-width:820px;margin:40px auto;padding:0 20px 60px}.card{background:#fff;border:1px solid #dce8de;border-radius:18px;padding:28px}
-a{color:#087d2c}.notice{padding:14px 16px;background:#eef8ef;border-radius:12px;margin-bottom:24px}h1{font-size:28px}h2{margin-top:28px;font-size:20px}dt{font-weight:700;margin-top:14px}dd{margin:4px 0 0}footer{margin-top:32px;font-size:13px;color:#66756a}.support-note{padding:16px;background:#f3f8f3;border-radius:12px}.muted{color:#66756a}
+a{color:#087d2c}.notice{padding:14px 16px;background:#eef8ef;border-radius:12px;margin-bottom:24px}h1{font-size:28px}h2{margin-top:28px;font-size:20px}dt{font-weight:700;margin-top:14px}dd{margin:4px 0 0}footer{margin-top:32px;font-size:13px;color:#66756a}.support-note{padding:16px;background:#f3f8f3;border-radius:12px}.muted{color:#66756a}.support-amounts{display:flex;gap:10px;flex-wrap:wrap;padding:0;list-style:none}.support-amounts li{padding:8px 12px;border:1px solid #cfe0d2;border-radius:999px;background:#fff;font-weight:700}
 </style></head><body><main><div class="card"><div class="notice">{{ status }}</div>
 <h1>{{ title }}</h1>{{ body|safe }}<footer><a href="/site">LicenseTown公式サイトへ戻る</a></footer>
 </div></main></body></html>
@@ -145,10 +145,15 @@ def support():
 <p>そのためには、サーバー代、AI利用料、開発や運営のための費用がかかります。</p>
 <div class="support-note">
 <strong>もし「これからも続いてほしい」「少し応援してもいい」と思っていただけたら、無理のない範囲で開発支援をいただけると嬉しいです。</strong>
-<p>支援する・しないは完全に任意です。支援の有無で、現在提供している学習機能に差をつける予定はありません。</p>
+<p>支援する・しないは完全に任意です。支援の有無で、現在提供している学習機能に差はつけません。</p>
+<p>当面の支援額は100円・300円・500円・1,000円の4つだけにし、1回あたり1,000円を上限とします。それ以上の金額は受け付けません。</p>
+<ul class="support-amounts"><li>100円</li><li>300円</li><li>500円</li><li>1,000円</li></ul>
 </div>
 <h2>いただいた支援について</h2>
 <p>LicenseTownの運営、レスポンス改善、AI利用、機能改善、将来のアプリ化など、サービスを良くするために活用します。</p>
+<h2>大切にすること</h2>
+<p><strong>LicenseTownは、これからも「誠実」であることを大切にします。</strong></p>
+<p>まだ胸を張って完成したと言える段階ではないからこそ、今は利用者の声を集め、改善を続けることを優先します。支援はサービス利用の条件ではなく、応援したいと思ってくださる方からのお気持ちとして受け取ります。</p>
 <p class="muted">現在は支援受付の準備中です。決済機能はまだ公開していません。</p>
 """
     return _layout("LicenseTownを応援する", body)

--- a/tests/test_site_legal_ui.py
+++ b/tests/test_site_legal_ui.py
@@ -36,7 +36,11 @@ def test_support_page_is_optional_and_sale_safe():
     html = response.get_data(as_text=True)
     assert "LicenseTownを応援する" in html
     assert "支援する・しないは完全に任意" in html
-    assert "現在提供している学習機能に差をつける予定はありません" in html
+    assert "現在提供している学習機能に差はつけません" in html
+    assert "100円・300円・500円・1,000円" in html
+    assert "1回あたり1,000円を上限" in html
+    assert "それ以上の金額は受け付けません" in html
+    assert "これからも「誠実」であることを大切にします" in html
     assert "現在は支援受付の準備中" in html
     assert "決済機能はまだ公開していません" in html
 


### PR DESCRIPTION
Continues the agreed temporary operating model for LicenseTown development support.

Scope:
- keeps support completely optional
- states current learning functionality is not differentiated by support status
- defines the initial one-time support amounts as ¥100 / ¥300 / ¥500 / ¥1,000
- caps one support payment at ¥1,000 and explicitly declines larger amounts for now
- adds an explicit public integrity statement that LicenseTown will continue to value 誠実
- keeps payment collection disabled; no live Stripe path or paid enforcement is enabled
- adds regression coverage for the amount cap and integrity copy

No charging, Stripe live-mode, or fee-incurring feature is enabled by this PR.