### PR TITLE
Refine PC feature previews and trust/support sections

### DIFF
--- a/preview-pc/index.html
+++ b/preview-pc/index.html
@@ -5,11 +5,12 @@
   <meta name="viewport" content="width=1499">
   <title>LicenseTown PC Preview</title>
   <link rel="stylesheet" href="styles.css">
+  <link rel="stylesheet" href="trust-support.css">
 </head>
 <body>
   <header class="header"><div class="container header-row">
     <a class="logo" href="#top"><span class="logo-mark">▥</span><span><b>ライセンスタウン</b><small>合格への道を、いっしょに。</small></span></a>
-    <nav class="nav"><a href="#features">特長</a><a href="#road">合格への道</a><a href="#gensan">教えて源さん</a><a href="#watch">見守り機能</a><a href="#bottom">ご利用案内</a><a href="#faq">よくある質問</a></nav>
+    <nav class="nav"><a href="#features">特長</a><a href="#road">合格への道</a><a href="#gensan">教えて源さん</a><a href="#watch">見守り機能</a><a href="#principles">大切にしていること</a><a href="#faq">よくある質問</a></nav>
     <div class="header-actions"><a class="btn login">ログイン</a><a class="btn primary" href="#try">まずは使ってみる</a></div>
   </div></header>
 
@@ -28,11 +29,21 @@
     </div></section>
 
     <section class="feature-two"><div class="container two-grid">
-      <article class="gensan-card" id="gensan"><img src="../preview-724/assets/gensan-main.png" alt="教えて源さん"><div class="gensan-copy"><h2>教えて源さん</h2><p>学習の悩みや、つまずきポイントを<br>源さんがやさしく解説！<br>モチベーションも上がります。</p><a>源さんに質問してみる</a></div><ul><li>苦手な分野を<br>どう克服すればいい？</li><li>勉強が続かないときは<br>どうしたらいい？</li><li>試験直前の過ごし方は？</li></ul></article>
-      <article class="road-card" id="road"><div class="road-copy"><h2>合格への道</h2><p>現在の学習状況から、次に取り組む内容を提示。<br>日々の学習で、着実にステップアップ。</p><small>※表示数値は画面イメージです</small><a>詳しく見る</a></div><div class="road-score"><h3>合格まで あと <b>123</b>日</h3><small>総合達成度</small><div class="ring">68%</div></div><div class="week-task"><h3>今週の学習タスク</h3><p>基礎問題を解く <i style="--w:76%"></i><small>20/30問</small></p><p>単語分野の練習 <i style="--w:62%"></i><small>2/3セット</small></p><p>過去問演習 <i style="--w:48%"></i><small>1/2回</small></p></div></article>
+      <article class="gensan-card" id="gensan"><img src="../preview-724/assets/gensan-main.png" alt="教えて源さん"><div class="gensan-copy"><h2>教えて源さん</h2><p>学習の悩みや、つまずきポイントを<br>源さんがやさしく解説！<br>モチベーションも上がります。</p><a href="#feature-preview">源さんに質問してみる</a><small class="card-image-note">※画面イメージです</small></div><ul><li>苦手な分野を<br>どう克服すればいい？</li><li>勉強が続かないときは<br>どうしたらいい？</li><li>試験直前の過ごし方は？</li></ul></article>
+      <article class="road-card" id="road"><div class="road-copy"><h2>合格への道</h2><p>現在の学習状況から、次に取り組む内容を提示。<br>日々の学習で、着実にステップアップ。</p><small>※表示内容・数値は画面イメージです</small><a href="#feature-preview">詳しく見る</a></div><div class="road-score"><h3>学習ナビ <em>（画面イメージ）</em></h3><small>総合達成度</small><div class="ring">68%</div></div><div class="week-task"><h3>今週の学習タスク</h3><p>基礎問題を解く <i style="--w:76%"></i><small>20/30問</small></p><p>単語分野の練習 <i style="--w:62%"></i><small>2/3セット</small></p><p>過去問演習 <i style="--w:48%"></i><small>1/2回</small></p></div></article>
     </div></section>
 
-    <section class="watch" id="watch"><div class="container watch-row"><div class="family-icon">♟♟</div><div class="watch-copy"><h2>親御さん向け見守り</h2><p>学習の進捗や理解度、取り組み状況をダッシュボードで確認。<br>がんばりを見える化して、適切なサポートができます。<br><small>※表示数値は画面イメージです</small></p></div><a class="detail">詳しく見る</a><div class="watch-metric"><small>学習時間（今週）</small><b>7<em>時間</em>45<em>分</em></b></div><div class="watch-metric"><small>課題達成率</small><b>72<em>%</em></b></div><div class="watch-metric"><small>正答率</small><b>68<em>%</em></b></div><div class="topics"><b>最近の学習トピック</b><p>・法令分野の正答率が上がっています！<br>・苦手な計算問題に取り組みましょう。</p></div></div></section>
+    <section class="watch" id="watch"><div class="container watch-row"><div class="family-icon">♟♟</div><div class="watch-copy"><h2>親御さん向け見守り</h2><p>学習の進捗や理解度、取り組み状況をダッシュボードで確認。<br>がんばりを見える化して、適切なサポートができます。<br><small>※表示内容・数値は画面イメージです</small></p></div><a class="detail">詳しく見る</a><div class="watch-metric"><small>学習時間（今週）</small><b>7<em>時間</em>45<em>分</em></b></div><div class="watch-metric"><small>課題達成率</small><b>72<em>%</em></b></div><div class="watch-metric"><small>正答率</small><b>68<em>%</em></b></div><div class="topics"><b>最近の学習トピック</b><p>・法令分野の正答率が上がっています！<br>・苦手な計算問題に取り組みましょう。</p></div></div></section>
+
+    <section class="feature-preview" id="feature-preview"><div class="container preview-grid">
+      <article class="preview-card"><div class="preview-heading"><span>画面イメージ</span><h2>源さんに質問してみる</h2><p>勉強の悩みや、わからないところをそのまま相談できます。</p></div><div class="chat-sample"><p class="user-bubble">酸塩基平衡がどうしても混乱します。</p><p class="gensan-bubble"><b>源さん</b>まず「pH → PaCO₂ → HCO₃⁻」の順で見てみよう。どこで迷ったか一緒に整理しようか。</p></div><small>※実際の回答内容・表示は利用状況により異なります。</small></article>
+      <article class="preview-card"><div class="preview-heading"><span>画面イメージ</span><h2>「合格への道」を詳しく見る</h2><p>今の状態だけでなく、次にやるべき学習までわかる画面を目指しています。</p></div><div class="road-detail-sample"><div><b>現在の到達度</b><strong>68%</strong></div><p><span>安定している分野</span>安全管理・基礎運動学</p><p><span>修復中</span>酸塩基平衡の判別</p><p><span>未確認</span>循環器の一部領域</p><p class="today-task"><span>今日やること</span>修復確認5問 → 未確認領域5問</p></div><small>※表示内容・数値は画面イメージです。</small></article>
+    </div></section>
+
+    <section class="trust-support" id="principles"><div class="container trust-support-grid">
+      <article class="principles-card"><span class="eyebrow">LicenseTownが大切にしていること</span><h2>迷ったときは、「それは誠実か？」で考える。</h2><p>学ぶ人にとって本当に役に立つか。誤解を招く表現になっていないか。自分の家族にも勧められるか。LicenseTownは、利益より先に信頼を積み重ねることを大切にします。</p><div class="principle-points"><span>利益より先に信頼</span><span>売るより先に役に立つ</span><span>胸を張れるものを届ける</span></div></article>
+      <article class="support-card"><span class="eyebrow">LicenseTownを応援する</span><h2>いまは、まず使ってもらい、良くしていく。</h2><p>現在は多くの方に使っていただき、改善の声を集めることを優先しています。開発支援は完全に任意で、支援の有無で現在の学習機能に差はありません。</p><div class="support-amounts"><span>100円</span><span>300円</span><span>500円</span><span>1,000円</span></div><p class="support-cap">1回あたり1,000円まで。それ以上の金額は、今は受け取りません。</p><a href="/site/support">開発支援について詳しく見る　›</a><small>※現在は支援受付の準備中です。決済機能はまだ公開していません。</small></article>
+    </div></section>
 
     <section class="bottom" id="bottom"><div class="container bottom-grid">
       <article class="brand-panel"><h2>ライセンスタウンは、あなたの「合格したい」を全力で応援します。</h2><p>理学療法士国家試験の学習を支える伴走型学習サービス</p><div><span>▣<b>資格に特化した<br>豊富な問題</b></span><span>◉<b>弱点を分析する<br>AI学習サポート</b></span><span>✓<b>続けられる仕組みで<br>学習習慣化</b></span><span>♜<b>安心のサポート体制</b></span></div></article>

--- a/preview-pc/trust-support.css
+++ b/preview-pc/trust-support.css
@@ -1,0 +1,81 @@
+/* PC refinements for the final trust/support review pass. */
+.card-image-note{display:block;margin-top:4px;color:#69736b;font-size:10px;line-height:1.3}
+.road-card{overflow:hidden}
+.road-copy a{margin-top:7px}
+.road-score h3 em{display:block;margin-top:2px;color:#69736b;font-size:9px;font-style:normal;font-weight:500}
+.road-score .ring{margin-top:6px}
+
+/* Keep the feature cards fully inside their borders at compact desktop heights. */
+.feature-two{min-height:190px;height:auto;padding-bottom:12px}
+.feature-two .gensan-card,.feature-two .road-card{height:180px}
+.feature-two .gensan-card>img{height:166px}
+.feature-two .gensan-copy{top:14px}
+.feature-two .gensan-card ul{top:13px}
+.feature-two .road-copy{top:14px;width:220px}
+.feature-two .road-score{left:245px;top:13px;height:150px}
+.feature-two .week-task{top:13px;height:150px}
+
+/* The watch row is intentionally a little smaller than before so it never spills. */
+.watch{min-height:126px;height:auto;padding:8px 0 12px}
+.watch-row{height:110px;padding:10px 12px;gap:8px;overflow:hidden}
+.family-icon{flex:0 0 68px;width:68px;font-size:34px}
+.watch-copy{flex:0 0 286px;width:286px}
+.watch-copy h2{font-size:18px}
+.watch-copy p{font-size:11px;line-height:1.48}
+.watch-row>.detail{flex:0 0 76px;width:76px;height:30px;margin:0;font-size:11px}
+.watch-metric{flex:0 0 88px;width:88px;height:68px;margin:0;padding:6px}
+.watch-metric small{font-size:9px;white-space:nowrap}
+.watch-metric b{font-size:18px}
+.watch-metric em{font-size:9px}
+.topics{flex:1 1 auto;min-width:240px;width:auto;height:68px;margin:0;padding:8px 12px}
+.topics b{font-size:12px}
+.topics p{margin-top:5px;font-size:9px;line-height:1.45}
+
+/* Two explicit product-image samples make the feature descriptions concrete. */
+.feature-preview{padding:34px 0;background:#fafcf9;border-top:1px solid #edf0ed;border-bottom:1px solid #edf0ed}
+.preview-grid{display:grid;grid-template-columns:1fr 1fr;gap:22px}
+.preview-card{min-height:278px;padding:22px;border:1px solid #dfe7e0;border-radius:12px;background:#fff;box-shadow:0 4px 15px rgba(0,0,0,.035)}
+.preview-heading{position:relative;padding-right:105px}
+.preview-heading>span{position:absolute;right:0;top:0;padding:5px 8px;border-radius:999px;background:#eef8ef;color:var(--green);font-size:10px;font-weight:700}
+.preview-heading h2{margin:0 0 7px;font-size:21px}
+.preview-heading p{margin:0;color:#465149;font-size:12px;line-height:1.55}
+.preview-card>small{display:block;margin-top:10px;color:#69736b;font-size:10px}
+.chat-sample{margin-top:18px;padding:14px;border-radius:10px;background:#f5f8f4}
+.chat-sample p{max-width:78%;margin:0 0 10px;padding:10px 12px;border-radius:12px;font-size:11px;line-height:1.55}
+.user-bubble{margin-left:auto!important;background:#dcf8d2}
+.gensan-bubble{background:#fff;border:1px solid #e1e7e2}
+.gensan-bubble b{display:block;margin-bottom:4px;color:var(--green)}
+.road-detail-sample{margin-top:16px;padding:14px;border:1px solid #e2e8e3;border-radius:10px;background:#fff}
+.road-detail-sample>div{display:flex;align-items:center;justify-content:space-between;padding-bottom:8px;border-bottom:1px solid #edf0ed}
+.road-detail-sample strong{color:var(--green);font-size:25px}
+.road-detail-sample p{display:grid;grid-template-columns:125px 1fr;margin:0;padding:7px 0;border-bottom:1px solid #f0f2f0;font-size:11px}
+.road-detail-sample p span{font-weight:700}
+.road-detail-sample .today-task{margin-top:5px;padding:9px;border:0;border-radius:7px;background:#eef8ef;color:#18331f}
+
+/* Separate the operating principle from the optional support request. */
+.trust-support{padding:42px 0;background:#fff}
+.trust-support-grid{display:grid;grid-template-columns:1fr 1fr;gap:22px}
+.principles-card,.support-card{min-height:285px;padding:26px 28px;border-radius:14px}
+.principles-card{border:1px solid #dce8de;background:linear-gradient(135deg,#f7fbf7,#fff)}
+.support-card{border:1px solid #dce8de;background:#fff}
+.eyebrow{display:block;margin-bottom:9px;color:var(--green);font-size:12px;font-weight:700;letter-spacing:.03em}
+.principles-card h2,.support-card h2{margin:0 0 12px;font-size:23px;line-height:1.45}
+.principles-card p,.support-card p{margin:0;color:#3f4c43;font-size:13px;line-height:1.75}
+.principle-points{display:flex;gap:9px;margin-top:20px;flex-wrap:wrap}
+.principle-points span{padding:8px 11px;border-radius:999px;background:#eaf6eb;color:#155724;font-size:11px;font-weight:700}
+.support-amounts{display:grid;grid-template-columns:repeat(4,1fr);gap:8px;margin:17px 0 10px}
+.support-amounts span{display:grid;place-items:center;height:42px;border:1px solid #b7d7bc;border-radius:8px;color:var(--green);font-size:14px;font-weight:700}
+.support-card .support-cap{font-size:11px;font-weight:700}
+.support-card>a{display:grid;place-items:center;width:230px;height:38px;margin-top:15px;border:1px solid #168735;border-radius:6px;color:var(--green);font-size:12px;font-weight:700}
+.support-card>small{display:block;margin-top:9px;color:#69736b;font-size:10px}
+
+/* Give the lower content enough room now that the page has real explanatory sections. */
+.bottom{height:auto;min-height:185px;padding-top:12px;padding-bottom:20px}
+.footer{margin-top:0}
+
+@media(max-width:1366px){
+  .watch-copy{flex-basis:270px;width:270px}
+  .watch-metric{flex-basis:82px;width:82px}
+  .topics{min-width:220px}
+  .preview-grid,.trust-support-grid{gap:16px}
+}


### PR DESCRIPTION
Implements the agreed first-pass HP review changes for the PC view.

Scope:
- fixes the cramped/hanging `合格への道` card layout with dedicated override CSS
- reduces the parent-monitor row so all metrics stay inside the frame
- adds an explicit `源さんに質問してみる` screen-image sample
- adds an explicit `合格への道を詳しく見る` screen-image sample
- labels both as image/sample content rather than factual live learner data
- adds a separate `LicenseTownが大切にしていること` section centered on 誠実
- adds a separate optional development-support section with ¥100 / ¥300 / ¥500 / ¥1,000 and a ¥1,000-per-support cap
- keeps support collection disabled and links to the existing `/site/support` explanation page

This PR does not enable Stripe live mode, paid enforcement, or any fee-incurring feature. Mobile is intentionally unchanged in this first visual review pass so the desktop composition can be reviewed before responsive propagation.