### PR TITLE
Fix monitor mini-dashboard overlap on latest main

### DIFF
--- a/preview-pc/trust-support.css
+++ b/preview-pc/trust-support.css
@@ -117,3 +117,11 @@
 /* Give the larger copy enough vertical room. */
 .preview-card{min-height:310px}
 .principles-card,.support-card{min-height:325px}
+
+/* Keep the monitor mini-dashboard labels and graphics in separate zones. */
+.monitor-card .mini-board{height:142px!important;position:absolute}
+.monitor-card .mini-board small{display:block;width:92px!important;white-space:normal;position:relative;z-index:2}
+.monitor-card .mini-bars{top:66px!important;height:36px!important}
+.monitor-card .mini-bars i{max-height:34px}
+.monitor-card .mini-board>b{top:48px!important;width:50px!important;height:50px!important;border-width:7px!important;font-size:14px!important}
+.monitor-card .mini-board p{bottom:8px!important;white-space:nowrap}


### PR DESCRIPTION
Reapplies the monitor mini-dashboard layout fix on top of the latest main after #175 merged.

Changes:
- separates the `※画面イメージ` label from the bar/ring graphics
- moves the bar chart lower
- keeps the 72% ring and day-count inside the compact card

Scope is PC presentation only. No payment, DB, LINE, mobile, or learning-engine changes.