### PR TITLE
Fix public preview lower-card copy and FAQ spacing

### DIFF
--- a/preview-pc/index.html
+++ b/preview-pc/index.html
@@ -46,7 +46,7 @@
     </div></section>
 
     <section class="bottom" id="bottom"><div class="container bottom-grid">
-      <article class="brand-panel"><h2>ライセンスタウンは、あなたの「合格したい」を全力で応援します。</h2><p>理学療法士国家試験の学習を支える伴走型学習サービス</p><div><span>▣<b>資格に特化した<br>豊富な問題</b></span><span>◉<b>弱点を分析する<br>AI学習サポート</b></span><span>✓<b>続けられる仕組みで<br>学習習慣化</b></span><span>♜<b>安心のサポート体制</b></span></div></article>
+      <article class="brand-panel"><h2>ライセンスタウンは、あなたの「合格したい」を応援します。</h2><p>理学療法士国家試験の学習を支える伴走型学習サービス</p><div><span>▣<b>資格に特化した<br>豊富な問題</b></span><span>◉<b>弱点を分析する<br>AI学習サポート</b></span><span>✓<b>続けられる仕組みで<br>学習習慣化</b></span><span>♜<b>安心のサポート体制</b></span></div></article>
       <article class="faq-panel" id="faq"><h2>よくある質問</h2><p>ライセンスタウンの使い方を教えてください <b>›</b></p><p>どんな機能が使えますか？ <b>›</b></p><p>利用開始の方法を教えてください <b>›</b></p><p>解約・退会の方法を教えてください <b>›</b></p><a>その他の質問はこちら　›</a></article>
       <article class="try-panel" id="try"><h2>サービス提供準備中</h2><p>正式な料金・提供条件は、公開前にこのページでご案内します。</p><a>まずは使ってみる　›</a></article>
     </div></section>

--- a/preview-pc/trust-support.css
+++ b/preview-pc/trust-support.css
@@ -129,4 +129,6 @@
 /* Give the entire lower trio a little more vertical breathing room. */
 .bottom{min-height:210px!important;padding-top:14px!important;padding-bottom:24px!important}
 .brand-panel,.faq-panel,.try-panel{height:190px!important;min-height:190px!important}
-.faq-panel{overflow:visible!important;padding-bottom:12px!important}
+.brand-panel h2{font-size:17px!important;line-height:1.4;letter-spacing:-.01em;white-space:nowrap}
+.faq-panel{overflow:visible!important;padding-bottom:16px!important}
+.faq-panel>a{margin-top:6px!important;padding-bottom:2px}

--- a/tests/test_site_ui.py
+++ b/tests/test_site_ui.py
@@ -5,6 +5,7 @@ os.environ.setdefault("CHANNEL_ACCESS_TOKEN", "test-token")
 os.environ.setdefault("CHANNEL_SECRET", "test-secret")
 
 from app import app
+from site_ui import PREVIEW_PC_DIR
 
 
 def test_site_route_renders_without_changing_existing_root():
@@ -79,6 +80,19 @@ def test_site_sources_match_completed_pc_and_mobile_pages():
     assert 'class="steps"' in mobile_html
     assert "寺子屋のような場所へ。" in mobile_html
     assert 'class="final-cta"' in mobile_html
+
+
+def test_pc_lower_cards_keep_heading_on_one_line_and_faq_link_visible():
+    html = (PREVIEW_PC_DIR / "index.html").read_text(encoding="utf-8")
+    css = (PREVIEW_PC_DIR / "trust-support.css").read_text(encoding="utf-8")
+
+    assert "ライセンスタウンは、あなたの「合格したい」を応援します。" in html
+    assert "「合格したい」を全力で応援します。" not in html
+    assert "その他の質問はこちら" in html
+    assert ".brand-panel h2{" in css
+    assert "white-space:nowrap" in css
+    assert ".faq-panel{overflow:visible!important;padding-bottom:16px!important}" in css
+    assert ".faq-panel>a{margin-top:6px!important;padding-bottom:2px}" in css
 
 
 def test_site_keeps_724_canvas_scaling_and_pc_mobile_switch():


### PR DESCRIPTION
Public preview lower-card polish from real-device review.

Changes:
- shortens the lower-left heading to `ライセンスタウンは、あなたの「合格したい」を応援します。`
- keeps the heading on one line for PC
- increases FAQ lower spacing so `その他の質問はこちら` is fully visible
- updates site UI tests accordingly

Validation reported from the working tree:
- focused: 13 passed
- full: 970 passed / 125 subtests passed / 1 deselected
- git diff check: PASS

Scope is public preview PC lower-card presentation only. No mobile source, payment, DB, LINE, or learning-engine changes.