### PR TITLE
Fit PC FAQ without clipping

### DIFF
--- a/preview-responsive/middle.css
+++ b/preview-responsive/middle.css
@@ -11,10 +11,11 @@ html,body{min-width:0!important;overflow-x:hidden}.container{width:calc(100% - 3
 /* PC lower-page readability pass. Keep FAQ inside its card and avoid orphaned footer characters. */
 @media (min-width:1180px){
   .bottom-grid{grid-template-columns:1.45fr 1fr .8fr!important;gap:16px!important}
-  .brand-panel,.faq-panel,.try-panel{height:178px!important;min-height:178px!important}
-  .faq-panel{padding:11px 14px!important;overflow:hidden}
-  .faq-panel p{min-height:27px!important;padding:5px 4px!important;font-size:12px!important;white-space:nowrap}
-  .faq-panel>a{display:block;margin-top:5px!important;font-size:11px!important;white-space:nowrap}
+  .brand-panel,.faq-panel,.try-panel{height:190px!important;min-height:190px!important}
+  .faq-panel{padding:10px 14px 15px!important;overflow:visible!important}
+  .faq-panel h2{font-size:18px!important;line-height:1.25!important;margin-bottom:6px!important}
+  .faq-panel p{min-height:24px!important;padding:4px!important;font-size:11px!important;line-height:1.35!important;white-space:nowrap}
+  .faq-panel>a{display:block;margin-top:3px!important;padding-bottom:3px!important;font-size:11px!important;line-height:1.35!important;white-space:nowrap}
   .footer>.container{gap:16px}
   .footer-logo{flex:0 0 265px;width:265px!important}
   .footer nav{display:flex;flex:1 1 auto;gap:18px!important;margin-left:0!important;justify-content:center;white-space:nowrap}

--- a/tests/test_site_ui.py
+++ b/tests/test_site_ui.py
@@ -122,3 +122,8 @@ def test_site_keeps_724_canvas_scaling_and_pc_mobile_switch():
     assert "frame.srcdoc" not in js
     assert "fetch(" not in js
     assert "(min-width:724px) and (max-width:1179px)" in middle_css
+    assert ".brand-panel,.faq-panel,.try-panel{height:190px!important;min-height:190px!important}" in middle_css
+    assert ".faq-panel{padding:10px 14px 15px!important;overflow:visible!important}" in middle_css
+    assert ".faq-panel h2{font-size:18px!important" in middle_css
+    assert ".faq-panel p{min-height:24px!important;padding:4px!important;font-size:11px!important" in middle_css
+    assert ".faq-panel>a{display:block;margin-top:3px!important;padding-bottom:3px!important;font-size:11px!important" in middle_css


### PR DESCRIPTION
Final PC FAQ fit pass from real-device review.

Root cause:
- `preview-responsive/middle.css` loads after the PC stylesheet and was still forcing the lower cards back to 178px with `overflow:hidden`, overriding the newer 190px FAQ spacing rules.

Changes:
- keeps the lower three PC cards at 190px in the later-loaded responsive stylesheet
- removes the FAQ clipping override
- slightly reduces FAQ heading/body spacing and body text size
- preserves one-line FAQ rows and keeps the final `その他の質問はこちら` link inside the card
- adds regression assertions for the effective later-loaded PC rules

Scope is PC public layout only. No mobile, payment, DB, LINE, or learning-engine changes.