### PR TITLE
Carry trust and support message into mobile public view

### DIFF
--- a/preview-responsive/mobile.css
+++ b/preview-responsive/mobile.css
@@ -1,1 +1,20 @@
 /* The completed 724px layout is scaled as a single fixed canvas. */
+
+/* Public mobile parity pass: add the approved trust/support message without
+   modifying the frozen 724px design source itself. */
+.page{height:2562px!important}
+.mobile-trust-support{position:relative;width:724px;height:390px;border-top:1px solid #e9e7e2;background:#fff;overflow:hidden}
+.mobile-principles-card,.mobile-support-card{position:absolute;left:42px;width:640px;border:1px solid #dce8de;border-radius:10px;background:#fff;padding:13px 18px;box-shadow:0 2px 7px rgba(44,55,46,.04)}
+.mobile-principles-card{top:12px;height:166px;background:linear-gradient(135deg,#f7fbf7,#fff)}
+.mobile-support-card{top:188px;height:188px}
+.mobile-principles-card>span,.mobile-support-card>span{display:block;margin-bottom:5px;color:#176f50;font-size:10px;font-weight:700;letter-spacing:.02em}
+.mobile-principles-card h2,.mobile-support-card h2{margin:0 0 7px;font-family:"Yu Mincho","Hiragino Mincho ProN",serif;font-size:18px;line-height:24px;letter-spacing:.02em}
+.mobile-principles-card p,.mobile-support-card p{margin:0 0 6px;color:#2f3932;font-size:9px;font-weight:600;line-height:15px}
+.mobile-support-card p strong{font-weight:800}
+.mobile-principle-points{display:flex;gap:7px;margin-top:6px;white-space:nowrap}
+.mobile-principle-points b{padding:5px 8px;border-radius:12px;background:#eaf6eb;color:#155724;font-size:8px}
+.mobile-support-amounts{position:absolute;left:18px;top:115px;display:grid;grid-template-columns:repeat(4,83px);gap:7px}
+.mobile-support-amounts b{display:grid;place-items:center;height:26px;border:1px solid #b7d7bc;border-radius:6px;color:#176f50;font-size:9px}
+.mobile-support-cap{position:absolute;left:382px;top:112px;width:238px!important;margin:0!important;font-size:7px!important;line-height:12px!important}
+.mobile-support-card>a{position:absolute;left:18px;bottom:13px;display:grid;place-items:center;width:185px;height:29px;border:1px solid #168735;border-radius:6px;color:#176f50;font-size:9px;font-weight:700}
+.mobile-support-card>small{position:absolute;left:216px;bottom:18px;color:#69736b;font-size:7px;line-height:11px}

--- a/site_ui.py
+++ b/site_ui.py
@@ -77,6 +77,44 @@ def _wire_primary_ctas(html: str) -> str:
     )
 
 
+def _inject_mobile_trust_support(html: str) -> str:
+    """Add the approved trust/support message to the public 724px mobile view.
+
+    The original 724px design source stays frozen. Public rendering receives the
+    same operating stance already approved on PC, stacked for the narrow canvas.
+    """
+    if 'class="story-faq"' not in html or 'class="mobile-trust-support"' in html:
+        return html
+
+    section = (
+        '<section class="mobile-trust-support" id="mobile-principles">'
+        '<article class="mobile-principles-card">'
+        '<span>LicenseTownが大切にしていること</span>'
+        '<h2>迷ったときは、「それは誠実か？」で考える。</h2>'
+        '<p>LicenseTownは、まだ完成したサービスだとは考えていません。'
+        'まずは実際に使っていただき、改善の声を集めながら少しずつ良くしていきます。</p>'
+        '<p>十分に胸を張って「料金をいただける」と思えるまでは、月額料金をお願いしません。'
+        '学ぶ人に本当に役に立つか、自分の家族にも勧められるか。これからも「誠実」を判断基準にします。</p>'
+        '<div class="mobile-principle-points"><b>利益より先に信頼</b><b>売るより先に役に立つ</b><b>胸を張れるものを届ける</b></div>'
+        '</article>'
+        '<article class="mobile-support-card">'
+        '<span>LicenseTownを応援する</span>'
+        '<h2>いまは、まず使ってもらい、良くしていく。</h2>'
+        '<p>もっとレスポンスを速くしたい。スマホでも、もっと使いやすくしたい。'
+        '学習機能や見守り機能も、もっと良くしたい。そのための開発費が必要なのも事実です。</p>'
+        '<p>「少し応援してもいいな」と思っていただけたら、100円からの開発支援で応援していただけると嬉しいです。'
+        '<strong>支援は完全に任意で、支援の有無で現在の学習機能に差はありません。</strong></p>'
+        '<div class="mobile-support-amounts"><b>100円</b><b>300円</b><b>500円</b><b>1,000円</b></div>'
+        '<p class="mobile-support-cap">1回あたり1,000円まで。それ以上の金額は、今は受け取りません。'
+        'いただいた支援は、LicenseTownの改善・運営・開発のために使います。</p>'
+        '<a href="/site/support">開発支援について詳しく見る　›</a>'
+        '<small>※現在は支援受付の準備中です。決済機能はまだ公開していません。</small>'
+        '</article>'
+        '</section>'
+    )
+    return html.replace('<section class="final-cta"', section + '<section class="final-cta"', 1)
+
+
 def _sale_safe_html(html: str) -> str:
     """Remove prototype claims that must not appear as factual sale copy yet.
 
@@ -138,6 +176,7 @@ def _sale_safe_html(html: str) -> str:
         '<a>お問い合わせ</a>',
         '<a href="/site/legal/contact">お問い合わせ</a><a href="/site/support">LicenseTownを応援する</a>',
     )
+    html = _inject_mobile_trust_support(html)
     return _wire_primary_ctas(html)
 
 

--- a/site_ui.py
+++ b/site_ui.py
@@ -83,7 +83,7 @@ def _inject_mobile_trust_support(html: str) -> str:
     The original 724px design source stays frozen. Public rendering receives the
     same operating stance already approved on PC, stacked for the narrow canvas.
     """
-    if 'class="story-faq"' not in html or 'class="mobile-trust-support"' in html:
+    if 'class="section story-faq"' not in html or 'class="mobile-trust-support"' in html:
         return html
 
     section = (

--- a/tests/test_site_ui.py
+++ b/tests/test_site_ui.py
@@ -5,7 +5,7 @@ os.environ.setdefault("CHANNEL_ACCESS_TOKEN", "test-token")
 os.environ.setdefault("CHANNEL_SECRET", "test-secret")
 
 from app import app
-from site_ui import PREVIEW_PC_DIR
+from site_ui import PREVIEW_724_DIR, PREVIEW_PC_DIR
 
 
 def test_site_route_renders_without_changing_existing_root():
@@ -106,6 +106,36 @@ def test_pc_trust_support_copy_states_current_free_and_optional_support_policy()
     assert "支援は完全に任意です" in html
     assert "支援の有無で、現在の学習機能に差はありません" in html
     assert "LicenseTownの改善・運営・開発のために使います" in html
+
+
+def test_mobile_public_view_gets_trust_support_copy_without_mutating_frozen_724_source():
+    client = app.test_client()
+    mobile_html = client.get("/site/view/mobile").get_data(as_text=True)
+    raw_724_html = (PREVIEW_724_DIR / "index.html").read_text(encoding="utf-8")
+
+    assert 'class="mobile-trust-support"' in mobile_html
+    assert "迷ったときは、「それは誠実か？」で考える。" in mobile_html
+    assert "まだ完成したサービスだとは考えていません" in mobile_html
+    assert "月額料金をお願いしません" in mobile_html
+    assert "100円からの開発支援" in mobile_html
+    assert "1回あたり1,000円まで" in mobile_html
+    assert "支援は完全に任意" in mobile_html
+    assert "支援の有無で現在の学習機能に差はありません" in mobile_html
+    assert "LicenseTownの改善・運営・開発のために使います" in mobile_html
+    assert 'class="mobile-trust-support"' not in raw_724_html
+
+
+def test_mobile_public_trust_support_is_stacked_before_final_cta_and_has_canvas_room():
+    client = app.test_client()
+    mobile_html = client.get("/site/view/mobile").get_data(as_text=True)
+    mobile_css = client.get("/site/preview-responsive/mobile.css").get_data(as_text=True)
+
+    assert mobile_html.index('class="mobile-trust-support"') < mobile_html.index('class="final-cta"')
+    assert ".page{height:2562px!important}" in mobile_css
+    assert ".mobile-trust-support{position:relative;width:724px;height:390px" in mobile_css
+    assert ".mobile-principles-card{top:12px;height:166px" in mobile_css
+    assert ".mobile-support-card{top:188px;height:188px}" in mobile_css
+    assert ".mobile-support-amounts" in mobile_css
 
 
 def test_site_keeps_724_canvas_scaling_and_pc_mobile_switch():


### PR DESCRIPTION
Mobile parity pass after the PC public page was accepted.

Changes:
- keeps the frozen 724px design source unchanged
- injects the approved `誠実` / development-support message only at the public rendering boundary
- stacks the two messages vertically for the 724px mobile canvas
- preserves the current policy: no monthly fee until the service can be offered with confidence, support fully optional, no current feature difference, 100/300/500/1,000 yen, 1,000 yen max, funds used for improvement/operations/development
- keeps support acceptance and payment unpublished
- extends the public mobile canvas height and adds regression coverage

No payment enablement, DB, LINE, learning-engine, or frozen preview-724 source change.