### PR TITLE
Fix mobile support card text overlap

### DIFF
--- a/preview-responsive/mobile.css
+++ b/preview-responsive/mobile.css
@@ -2,19 +2,19 @@
 
 /* Public mobile parity pass: add the approved trust/support message without
    modifying the frozen 724px design source itself. */
-.page{height:2562px!important}
-.mobile-trust-support{position:relative;width:724px;height:390px;border-top:1px solid #e9e7e2;background:#fff;overflow:hidden}
+.page{height:2624px!important}
+.mobile-trust-support{position:relative;width:724px;height:452px;border-top:1px solid #e9e7e2;background:#fff;overflow:hidden}
 .mobile-principles-card,.mobile-support-card{position:absolute;left:42px;width:640px;border:1px solid #dce8de;border-radius:10px;background:#fff;padding:13px 18px;box-shadow:0 2px 7px rgba(44,55,46,.04)}
 .mobile-principles-card{top:12px;height:166px;background:linear-gradient(135deg,#f7fbf7,#fff)}
-.mobile-support-card{top:188px;height:188px}
+.mobile-support-card{top:188px;height:250px}
 .mobile-principles-card>span,.mobile-support-card>span{display:block;margin-bottom:5px;color:#176f50;font-size:10px;font-weight:700;letter-spacing:.02em}
 .mobile-principles-card h2,.mobile-support-card h2{margin:0 0 7px;font-family:"Yu Mincho","Hiragino Mincho ProN",serif;font-size:18px;line-height:24px;letter-spacing:.02em}
 .mobile-principles-card p,.mobile-support-card p{margin:0 0 6px;color:#2f3932;font-size:9px;font-weight:600;line-height:15px}
 .mobile-support-card p strong{font-weight:800}
 .mobile-principle-points{display:flex;gap:7px;margin-top:6px;white-space:nowrap}
 .mobile-principle-points b{padding:5px 8px;border-radius:12px;background:#eaf6eb;color:#155724;font-size:8px}
-.mobile-support-amounts{position:absolute;left:18px;top:115px;display:grid;grid-template-columns:repeat(4,83px);gap:7px}
-.mobile-support-amounts b{display:grid;place-items:center;height:26px;border:1px solid #b7d7bc;border-radius:6px;color:#176f50;font-size:9px}
-.mobile-support-cap{position:absolute;left:382px;top:112px;width:238px!important;margin:0!important;font-size:7px!important;line-height:12px!important}
-.mobile-support-card>a{position:absolute;left:18px;bottom:13px;display:grid;place-items:center;width:185px;height:29px;border:1px solid #168735;border-radius:6px;color:#176f50;font-size:9px;font-weight:700}
-.mobile-support-card>small{position:absolute;left:216px;bottom:18px;color:#69736b;font-size:7px;line-height:11px}
+.mobile-support-amounts{position:static;display:grid;grid-template-columns:repeat(4,1fr);gap:7px;margin-top:8px}
+.mobile-support-amounts b{display:grid;place-items:center;height:28px;border:1px solid #b7d7bc;border-radius:6px;color:#176f50;font-size:9px}
+.mobile-support-cap{position:static;width:auto!important;margin:8px 0 0!important;font-size:7px!important;line-height:12px!important}
+.mobile-support-card>a{position:static;display:grid;place-items:center;width:185px;height:29px;margin-top:9px;border:1px solid #168735;border-radius:6px;color:#176f50;font-size:9px;font-weight:700}
+.mobile-support-card>small{position:static;display:block;margin-top:7px;color:#69736b;font-size:7px;line-height:11px}

--- a/tests/test_site_ui.py
+++ b/tests/test_site_ui.py
@@ -131,11 +131,14 @@ def test_mobile_public_trust_support_is_stacked_before_final_cta_and_has_canvas_
     mobile_css = client.get("/site/preview-responsive/mobile.css").get_data(as_text=True)
 
     assert mobile_html.index('class="mobile-trust-support"') < mobile_html.index('class="final-cta"')
-    assert ".page{height:2562px!important}" in mobile_css
-    assert ".mobile-trust-support{position:relative;width:724px;height:390px" in mobile_css
+    assert ".page{height:2624px!important}" in mobile_css
+    assert ".mobile-trust-support{position:relative;width:724px;height:452px" in mobile_css
     assert ".mobile-principles-card{top:12px;height:166px" in mobile_css
-    assert ".mobile-support-card{top:188px;height:188px}" in mobile_css
-    assert ".mobile-support-amounts" in mobile_css
+    assert ".mobile-support-card{top:188px;height:250px}" in mobile_css
+    assert ".mobile-support-amounts{position:static" in mobile_css
+    assert ".mobile-support-cap{position:static" in mobile_css
+    assert ".mobile-support-card>a{position:static" in mobile_css
+    assert ".mobile-support-card>small{position:static" in mobile_css
 
 
 def test_site_keeps_724_canvas_scaling_and_pc_mobile_switch():


### PR DESCRIPTION
Fixes the only remaining mobile visual issue reported from real-device review: the development-support card content was colliding vertically.

Changes:
- replaces absolute positioning of the support amounts/cap/link/note with normal document flow inside the card
- gives the support card and mobile trust/support section enough vertical room
- extends the public 724px canvas accordingly
- keeps the frozen preview-724 source unchanged
- adds regression assertions so the mobile support elements remain flow-based

No payment enablement, DB, LINE, learning-engine, or PC changes.