### PR TITLE
Fix public site navigation and mobile FAQ interactions

### DIFF
--- a/preview-responsive/mobile.css
+++ b/preview-responsive/mobile.css
@@ -2,7 +2,7 @@
 
 /* Public mobile parity pass: add the approved trust/support message without
    modifying the frozen 724px design source itself. */
-.page{height:2624px!important}
+.page{height:2674px!important}
 .mobile-trust-support{position:relative;width:724px;height:452px;border-top:1px solid #e9e7e2;background:#fff;overflow:hidden}
 .mobile-principles-card,.mobile-support-card{position:absolute;left:42px;width:640px;border:1px solid #dce8de;border-radius:10px;background:#fff;padding:13px 18px;box-shadow:0 2px 7px rgba(44,55,46,.04)}
 .mobile-principles-card{top:12px;height:166px;background:linear-gradient(135deg,#f7fbf7,#fff)}
@@ -18,3 +18,13 @@
 .mobile-support-cap{position:static;width:auto!important;margin:8px 0 0!important;font-size:7px!important;line-height:12px!important}
 .mobile-support-card>a{position:static;display:grid;place-items:center;width:185px;height:29px;margin-top:9px;border:1px solid #168735;border-radius:6px;color:#176f50;font-size:9px;font-weight:700}
 .mobile-support-card>small{position:static;display:block;margin-top:7px;color:#69736b;font-size:7px;line-height:11px}
+
+/* The frozen 724px FAQ only contained empty details shells. Public rendering
+   supplies real answers; keep one open item readable without clipping. */
+.story-faq{height:286px!important;overflow:visible!important}
+.faq-card{height:270px!important;overflow:visible!important}
+.faq-list{height:auto!important;overflow:visible!important}
+.faq-list details{height:auto!important;min-height:41px}
+.faq-list details[open]{padding-bottom:7px}
+.faq-list details[open] summary:after{content:"−"}
+.faq-answer{margin:0;padding:0 34px 8px 13px;color:#455049;font-size:8px;font-weight:600;line-height:13px}

--- a/site_ui.py
+++ b/site_ui.py
@@ -5,7 +5,7 @@ from html import escape
 from pathlib import Path
 from urllib.parse import urlparse
 
-from flask import Blueprint, Response, render_template, send_from_directory, url_for
+from flask import Blueprint, Response, render_template, request, send_from_directory, url_for
 
 
 site_ui = Blueprint("site_ui", __name__)
@@ -75,6 +75,53 @@ def _wire_primary_ctas(html: str) -> str:
         replace_anchor,
         html,
     )
+
+
+def _wire_same_document_fragments(html: str) -> str:
+    """Keep hash navigation on the rendered preview document, not its asset base.
+
+    The preview documents use ``<base>`` so relative image/CSS paths resolve to
+    their asset directories. Without this rewrite, ``href="#faq"`` also resolves
+    against that asset base and leaves the public document, which caused the
+    observed 403 navigation failures.
+    """
+    current_path = escape(request.path, quote=True)
+    return re.sub(
+        r'href="#([A-Za-z0-9_-]+)"',
+        lambda match: f'href="{current_path}#{match.group(1)}"',
+        html,
+    )
+
+
+def _inject_mobile_faq_answers(html: str) -> str:
+    """Turn the frozen mobile FAQ shell into a useful public accordion."""
+    if 'class="faq-list"' not in html or 'class="faq-answer"' in html:
+        return html
+
+    answers = {
+        "料金はかかりますか？": (
+            "現在は多くの方に使っていただき、改善する段階です。"
+            "月額料金はお願いしていません。正式な料金・提供条件を決める際は、このページでご案内します。"
+        ),
+        "LINEだけで使えますか？": (
+            "学習の中心はLINEで利用できます。合格への道や見守りなど、"
+            "一部の画面はブラウザで開いて確認します。"
+        ),
+        "見守り機能では何が見えますか？": (
+            "学習日数、回答数、学習時間、分野別の取り組み状況などを確認できます。"
+            "個別の相談内容は共有されません。"
+        ),
+        "どんな人に向いていますか？": (
+            "理学療法士国家試験に向けて、苦手や次にやることを整理しながら学びたい方と、"
+            "その学習を見守りたいご家族を想定しています。"
+        ),
+    }
+    for question, answer in answers.items():
+        html = html.replace(
+            f"<details><summary>{question}</summary></details>",
+            f'<details><summary>{question}</summary><p class="faq-answer">{answer}</p></details>',
+        )
+    return html
 
 
 def _inject_mobile_trust_support(html: str) -> str:
@@ -173,22 +220,46 @@ def _sale_safe_html(html: str) -> str:
         '<a href="/site/legal/operator">運営者情報</a>',
     )
     html = html.replace(
+        '<a>運営情報</a>',
+        '<a href="/site/legal/operator">運営情報</a>',
+    )
+    html = html.replace(
         '<a>お問い合わせ</a>',
         '<a href="/site/legal/contact">お問い合わせ</a><a href="/site/support">LicenseTownを応援する</a>',
     )
+    html = _inject_mobile_faq_answers(html)
     html = _inject_mobile_trust_support(html)
     return _wire_primary_ctas(html)
+
+
+def _preview_interaction_script() -> str:
+    """Small public-only behaviors for the frozen preview documents."""
+    return """<script>
+document.addEventListener('DOMContentLoaded', function () {
+  var faqItems = document.querySelectorAll('.faq-list details');
+  faqItems.forEach(function (item) {
+    item.addEventListener('toggle', function () {
+      if (!item.open) return;
+      faqItems.forEach(function (other) {
+        if (other !== item) other.open = false;
+      });
+    });
+  });
+});
+</script>"""
 
 
 def _preview_document(source_path, base_url, extra_stylesheet_url):
     html = source_path.read_text(encoding="utf-8")
     html = _sale_safe_html(html)
+    html = _wire_same_document_fragments(html)
     html = html.replace("<head>", f'<head><base href="{base_url}">', 1)
     html = html.replace(
         "</head>",
         f'<link rel="stylesheet" href="{extra_stylesheet_url}"></head>',
         1,
     )
+    html = html.replace("</body>", _preview_interaction_script() + "</body>", 1)
     return Response(html, mimetype="text/html")
 
 

--- a/tests/test_site_public_interactions.py
+++ b/tests/test_site_public_interactions.py
@@ -1,0 +1,55 @@
+import os
+
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
+os.environ.setdefault("CHANNEL_ACCESS_TOKEN", "test-token")
+os.environ.setdefault("CHANNEL_SECRET", "test-secret")
+
+from app import app
+
+
+def test_preview_hash_links_stay_on_rendered_documents_despite_asset_base():
+    client = app.test_client()
+    pc_html = client.get("/site/view/pc").get_data(as_text=True)
+    mobile_html = client.get("/site/view/mobile").get_data(as_text=True)
+
+    assert 'href="/site/view/pc#features"' in pc_html
+    assert 'href="/site/view/pc#faq"' in pc_html
+    assert 'href="/site/view/mobile#features"' in mobile_html
+    assert 'href="/site/view/mobile#howto"' in mobile_html
+    assert 'href="/site/view/mobile#parents"' in mobile_html
+    assert 'href="/site/view/mobile#faq"' in mobile_html
+    assert 'href="/site/view/mobile#contact"' in mobile_html
+
+
+def test_mobile_footer_operator_and_legal_links_are_public_routes():
+    client = app.test_client()
+    html = client.get("/site/view/mobile").get_data(as_text=True)
+
+    assert '<a href="/site/legal/terms">利用規約</a>' in html
+    assert '<a href="/site/legal/privacy">プライバシーポリシー</a>' in html
+    assert '<a href="/site/legal/contact">お問い合わせ</a>' in html
+    assert '<a href="/site/legal/operator">運営情報</a>' in html
+
+    for path in (
+        "/site/legal/terms",
+        "/site/legal/privacy",
+        "/site/legal/contact",
+        "/site/legal/operator",
+    ):
+        assert client.get(path).status_code == 200, path
+
+
+def test_mobile_faq_has_answers_and_single_open_accordion_behavior():
+    client = app.test_client()
+    html = client.get("/site/view/mobile").get_data(as_text=True)
+    css = client.get("/site/preview-responsive/mobile.css").get_data(as_text=True)
+
+    assert html.count('class="faq-answer"') == 4
+    assert "月額料金はお願いしていません" in html
+    assert "一部の画面はブラウザで開いて確認します" in html
+    assert "個別の相談内容は共有されません" in html
+    assert "理学療法士国家試験に向けて" in html
+    assert "if (other !== item) other.open = false" in html
+    assert '.faq-list details[open] summary:after{content:"−"}' in css
+    assert ".faq-answer{" in css
+    assert ".story-faq{height:286px!important" in css

--- a/tests/test_site_ui.py
+++ b/tests/test_site_ui.py
@@ -131,7 +131,7 @@ def test_mobile_public_trust_support_is_stacked_before_final_cta_and_has_canvas_
     mobile_css = client.get("/site/preview-responsive/mobile.css").get_data(as_text=True)
 
     assert mobile_html.index('class="mobile-trust-support"') < mobile_html.index('class="final-cta"')
-    assert ".page{height:2624px!important}" in mobile_css
+    assert ".page{height:2674px!important}" in mobile_css
     assert ".mobile-trust-support{position:relative;width:724px;height:452px" in mobile_css
     assert ".mobile-principles-card{top:12px;height:166px" in mobile_css
     assert ".mobile-support-card{top:188px;height:250px}" in mobile_css


### PR DESCRIPTION
Public-site interaction repair after real-device review.

Changes:
- keeps fragment navigation on the rendered `/site/view/pc` and `/site/view/mobile` documents despite their asset `<base>` tags, fixing the observed 403s from top navigation and other hash links
- wires the mobile `運営情報` footer link to the public operator route
- gives all four mobile FAQ items real answer copy
- makes the FAQ a single-open accordion and gives the expanded answer enough vertical room
- keeps the frozen `preview-724` source unchanged; changes are applied at the public rendering boundary and responsive override layer
- adds regression coverage for rendered fragment links, public legal/footer routes, FAQ answer copy and accordion behavior

No payment enablement, DB, LINE learning flow, selector, or PC visual redesign.