### PR TITLE
Make unavailable public-site controls explicitly static

### DIFF
--- a/preview-pc/trust-support.css
+++ b/preview-pc/trust-support.css
@@ -132,3 +132,7 @@
 .brand-panel h2{font-size:17px!important;line-height:1.4;letter-spacing:-.01em;white-space:nowrap}
 .faq-panel{overflow:visible!important;padding-bottom:16px!important}
 .faq-panel>a{margin-top:6px!important;padding-bottom:2px}
+
+/* Preserve placeholder layout without presenting unavailable actions as live. */
+.public-static-control{cursor:default!important;text-decoration:none!important}
+.btn.login.public-static-control,.detail.public-static-control{border-color:#cbd4cd!important;background:#f4f6f4!important;color:#657068!important}

--- a/preview-responsive/mobile.css
+++ b/preview-responsive/mobile.css
@@ -28,3 +28,10 @@
 .faq-list details[open]{padding-bottom:7px}
 .faq-list details[open] summary:after{content:"−"}
 .faq-answer{margin:0;padding:0 34px 8px 13px;color:#455049;font-size:8px;font-weight:600;line-height:13px}
+
+/* Public-only inert states; the frozen 724px source remains untouched. */
+.video-card-static{cursor:default}
+.video-status{position:absolute;z-index:3;left:120px;top:31px;display:grid;place-items:center;width:62px;height:48px;border-radius:24px;background:rgba(35,35,35,.83);color:#fff;font-size:8px;font-weight:700;line-height:12px;text-align:center}
+.dash-nav>.public-static-control{display:block;height:32px;padding:7px 4px;border-radius:4px;font-size:7px;font-weight:700;cursor:default}
+.dash-nav>.public-static-control.active{background:#559b5a}
+.progress-card>.public-static-control,.rank-card>.public-static-control,.today-card>.public-static-control{position:absolute;right:9px;bottom:7px;color:#647068;font-size:6px;font-weight:700;cursor:default}

--- a/site_ui.py
+++ b/site_ui.py
@@ -162,6 +162,64 @@ def _inject_mobile_trust_support(html: str) -> str:
     return html.replace('<section class="final-cta"', section + '<section class="final-cta"', 1)
 
 
+def _add_static_control_class(attrs: str) -> str:
+    class_match = re.search(r'class="([^"]*)"', attrs)
+    if class_match:
+        classes = f'{class_match.group(1)} public-static-control'.strip()
+        return attrs[: class_match.start()] + f'class="{classes}"' + attrs[class_match.end() :]
+    return attrs + ' class="public-static-control"'
+
+
+def _make_public_dead_interactions_static(html: str) -> str:
+    """Make unavailable public-preview interactions explicitly inert."""
+    html = html.replace(
+        '<a class="btn login">ログイン</a>',
+        '<span class="btn login public-static-control" aria-disabled="true">'
+        'ログイン（準備中）</span>',
+    )
+    html = html.replace(
+        '<a class="detail">詳しく見る</a>',
+        '<span class="detail public-static-control" aria-disabled="true">'
+        '表示イメージ</span>',
+    )
+    html = html.replace(
+        '<a>その他の質問はこちら　›</a>',
+        '<a href="/site/legal/contact">その他の質問はこちら　›</a>',
+    )
+
+    video_pattern = re.compile(
+        r'<button class="video-card"[^>]*>(?P<body>.*?)</button>',
+        flags=re.DOTALL,
+    )
+
+    def replace_video(match):
+        body = match.group("body").replace(
+            '<span class="play">▶</span>',
+            '<span class="video-status">紹介動画<br>準備中</span>',
+        )
+        return (
+            '<div class="video-card video-card-static" '
+            'aria-label="30秒でわかるLicenseTown 紹介動画 準備中">'
+            f"{body}</div>"
+        )
+
+    html = video_pattern.sub(replace_video, html)
+
+    def replace_href_less_anchor(match):
+        attrs = match.group("attrs") or ""
+        if re.search(r"\bhref\s*=", attrs, flags=re.IGNORECASE):
+            return match.group(0)
+        attrs = _add_static_control_class(attrs)
+        return f'<span{attrs} aria-disabled="true">{match.group("body")}</span>'
+
+    return re.sub(
+        r'<a\b(?P<attrs>[^>]*)>(?P<body>.*?)</a>',
+        replace_href_less_anchor,
+        html,
+        flags=re.DOTALL | re.IGNORECASE,
+    )
+
+
 def _sale_safe_html(html: str) -> str:
     """Remove prototype claims that must not appear as factual sale copy yet.
 
@@ -229,7 +287,8 @@ def _sale_safe_html(html: str) -> str:
     )
     html = _inject_mobile_faq_answers(html)
     html = _inject_mobile_trust_support(html)
-    return _wire_primary_ctas(html)
+    html = _wire_primary_ctas(html)
+    return _make_public_dead_interactions_static(html)
 
 
 def _preview_interaction_script() -> str:

--- a/tests/test_site_public_interactions.py
+++ b/tests/test_site_public_interactions.py
@@ -1,4 +1,5 @@
 import os
+import re
 
 os.environ.setdefault("OPENAI_API_KEY", "test-key")
 os.environ.setdefault("CHANNEL_ACCESS_TOKEN", "test-token")
@@ -53,3 +54,40 @@ def test_mobile_faq_has_answers_and_single_open_accordion_behavior():
     assert '.faq-list details[open] summary:after{content:"−"}' in css
     assert ".faq-answer{" in css
     assert ".story-faq{height:286px!important" in css
+
+
+def test_pc_public_document_has_no_href_less_anchor_affordances():
+    html = app.test_client().get("/site/view/pc").get_data(as_text=True)
+
+    assert not re.search(r"<a\b(?![^>]*\bhref=)[^>]*>", html)
+    assert "ログイン（準備中）" in html
+    assert '<span class="detail public-static-control"' in html
+    assert '表示イメージ</span>' in html
+    assert '<a href="/site/legal/contact">その他の質問はこちら' in html
+
+
+def test_mobile_public_video_is_static_and_clearly_not_ready():
+    html = app.test_client().get("/site/view/mobile").get_data(as_text=True)
+
+    assert '<button class="video-card"' not in html
+    assert '<div class="video-card video-card-static"' in html
+    assert '<span class="video-status">紹介動画<br>準備中</span>' in html
+    assert '<span class="play">▶</span>' not in html
+
+
+def test_mobile_dashboard_mock_controls_are_inert_but_keep_layout_classes():
+    html = app.test_client().get("/site/view/mobile").get_data(as_text=True)
+
+    assert '<span class="active public-static-control" aria-disabled="true">⌂ ダッシュボード</span>' in html
+    assert '<span class="public-static-control" aria-disabled="true">すべて見る ›</span>' in html
+    assert '<span class="public-static-control" aria-disabled="true">苦手を詳しく見る ›</span>' in html
+    assert '<span class="public-static-control" aria-disabled="true">おすすめをもっと見る ›</span>' in html
+    assert not re.search(r"<a\b(?![^>]*\bhref=)[^>]*>", html)
+
+
+def test_frozen_mobile_source_keeps_original_design_contract():
+    source = app.test_client().get("/site/preview-724/index.html").get_data(as_text=True)
+
+    assert '<button class="video-card" type="button"' in source
+    assert '<span class="play">▶</span>' in source
+    assert "紹介動画<br>準備中" not in source


### PR DESCRIPTION
Public-site cleanup after real-device verification of PR #184.

Changes:
- make unavailable PC controls explicitly static instead of link-like
- route the PC FAQ catch-all to the public contact page
- render the mobile intro video card as a static “準備中” card until a real video exists
- neutralize mock-dashboard links while preserving the frozen visual layout
- keep preview-724/index.html unchanged
- preserve PR #184 fragment navigation, FAQ accordion, and public legal links

Validation reported on branch:
- focused: 27 passed
- full: 980 passed / 125 subtests passed / 1 deselected
- git diff --check: PASS
- main comparison: ahead 1 / behind 0

No Render operation, DB change, payment enablement, or LINE learning-flow change.