### PR TITLE
Streamline learner navigation recommendation start

### DIFF
--- a/app.py
+++ b/app.py
@@ -51,7 +51,15 @@ from learning_engine import (
     summarize_initial_assessment,
     summarize_daily_session,
 )
-from goukaku_ui import build_dashboard, create_dashboard_token, dashboard_user_id, goukaku_ui
+from goukaku_ui import (
+    build_dashboard,
+    build_learner_navigation_from_formal_inputs,
+    create_dashboard_token,
+    dashboard_user_id,
+    get_learner_navigation_formal_inputs,
+    goukaku_ui,
+)
+from learner_navigation_performance import RequestTiming
 from site_ui import site_ui
 from question_bank import (
     get_category_group_names,
@@ -2182,7 +2190,13 @@ web_recommendation_sessions = {}
 web_recommendation_start_lock = threading.Lock()
 
 
-def create_web_recommendation_session(user_id, category_small, question_count, token):
+def create_web_recommendation_session(
+    user_id,
+    category_small,
+    question_count,
+    token,
+    attempts=None,
+):
     """正式分野のWeb学習セッションを作成する。LINEセッションとは共有しない。"""
     with web_recommendation_start_lock:
         for session_id, session in web_recommendation_sessions.items():
@@ -2193,7 +2207,8 @@ def create_web_recommendation_session(user_id, category_small, question_count, t
                 and not session.get("completed")
             ):
                 return session_id, False
-        attempts = get_question_attempts(user_id)
+        if attempts is None:
+            attempts = get_question_attempts(user_id)
         selection_audit = {}
         questions = build_node_adaptive_session(
             attempts,
@@ -2251,25 +2266,58 @@ def start_dashboard_recommendation():
 
     source = str(payload.get("source", "")).strip()
     if source == "learner_navigation":
-        dashboard = build_dashboard(user_id, include_learner_navigation=True)
-        action = ((dashboard.get("learner_navigation") or {}).get("today_action") or {})
-        expected = (
-            action.get("field"),
-            int(action.get("count") or 0),
-            action.get("learning_intent"),
-            action.get("reason_code"),
-        )
-        received = (
-            field_name,
-            question_count,
-            str(payload.get("intent", "")).strip(),
-            str(payload.get("reason", "")).strip(),
-        )
-        if received != expected:
+        timing = RequestTiming()
+        response_status = 500
+        try:
+            with timing.measure("cta_validation_total"):
+                with timing.measure("formal_input_read"):
+                    formal_inputs = get_learner_navigation_formal_inputs(user_id)
+                attempts = formal_inputs["attempts"]
+                with timing.measure("evidence_progress_readiness_presentation_build"):
+                    navigation = build_learner_navigation_from_formal_inputs(
+                        attempts,
+                        formal_inputs["trial100_records"],
+                    )
+                action = navigation.get("today_action") or {}
+                expected = (
+                    action.get("field"),
+                    int(action.get("count") or 0),
+                    action.get("learning_intent"),
+                    action.get("reason_code"),
+                )
+                received = (
+                    field_name,
+                    question_count,
+                    str(payload.get("intent", "")).strip(),
+                    str(payload.get("reason", "")).strip(),
+                )
+                if received != expected:
+                    response_status = 409
+                    return {
+                        "ok": False,
+                        "message": "おすすめ内容が更新されました。画面を再読み込みしてください。",
+                    }, response_status
+            try:
+                with timing.measure("selector_session_creation"):
+                    session_id, started = create_web_recommendation_session(
+                        user_id,
+                        category_small,
+                        question_count,
+                        payload.get("token"),
+                        attempts=attempts,
+                    )
+            except QuestionBankError:
+                logging.exception("Web recommendation session creation failed")
+                response_status = 503
+                return {"ok": False, "message": "問題を準備できませんでした。"}, response_status
+            response_status = 200
             return {
-                "ok": False,
-                "message": "おすすめ内容が更新されました。画面を再読み込みしてください。",
-            }, 409
+                "ok": True,
+                "already_started": not started,
+                "redirect_url": f"/goukaku-no-michi/learning/{session_id}",
+            }
+        finally:
+            timing.finish(response_status)
     else:
         current_recommendations = build_dashboard(user_id).get("recommended_study", [])
         if (field_name, question_count) not in current_recommendations:

--- a/dashboard_read_bundle.py
+++ b/dashboard_read_bundle.py
@@ -48,6 +48,30 @@ def _attempts_with_connection(user_id: str, connection) -> list[dict[str, Any]]:
     return attempts
 
 
+def get_learner_navigation_read_bundle(user_id: str) -> dict[str, Any]:
+    """Return only the formal inputs needed to validate learner navigation.
+
+    Production intentionally shares one connection for attempts and Trial100.
+    Unlike the full dashboard bundle, this path does not calculate legacy
+    dashboard aggregates that cannot affect the structured CTA contract.
+    """
+    user_id = str(user_id or "").strip()
+    if not user_id:
+        return {"attempts": [], "trial100_records": []}
+    if not database.database_is_available():
+        return {
+            "attempts": database.get_question_attempts(user_id),
+            "trial100_records": get_trial100_records(user_id),
+        }
+    with database.get_db_connection() as conn:
+        attempts = _attempts_with_connection(user_id, conn)
+        trial100_records = get_trial100_records(user_id, connection=conn)
+    return {
+        "attempts": attempts,
+        "trial100_records": trial100_records,
+    }
+
+
 def get_dashboard_read_bundle(
     user_id: str,
     *,

--- a/goukaku_ui.py
+++ b/goukaku_ui.py
@@ -17,6 +17,7 @@ from database import (
     user_names,
 )
 from dashboard_read_bundle import get_dashboard_read_bundle as _get_production_dashboard_read_bundle
+from dashboard_read_bundle import get_learner_navigation_read_bundle as _get_production_learner_navigation_read_bundle
 from trial100_store import get_trial100_records
 from learning_analysis import build_gensan_comment, build_learning_guidance
 from supporter_report import build_supporter_report
@@ -173,6 +174,42 @@ def _dashboard_read_bundle(user_id, *, include_attempts=False, include_trial100=
     }
 
 
+def get_learner_navigation_formal_inputs(user_id):
+    """Read only the formal evidence needed to reproduce today's CTA."""
+    if database_is_available():
+        return _get_production_learner_navigation_read_bundle(user_id)
+    return {
+        "attempts": get_question_attempts(user_id),
+        "trial100_records": get_trial100_records(user_id),
+    }
+
+
+def build_learner_navigation_from_formal_inputs(
+    attempts,
+    trial100_records,
+    *,
+    evidence=None,
+    progress=None,
+    shadow_result=None,
+):
+    """Build the same structured learner CTA without legacy dashboard work."""
+    attempts = list(attempts or [])
+    evidence = evidence or build_field_evidence(attempts)
+    progress = progress or build_field_progress(evidence)
+    shadow_result = shadow_result or build_dashboard_real_data_shadow(
+        attempts,
+        evidence=evidence,
+        progress=progress,
+    )
+    readiness = build_pass_readiness(
+        attempts,
+        field_evidence=evidence,
+        progress=progress,
+        trial100_records=trial100_records,
+    )
+    return build_learner_readiness_presentation(readiness, shadow_result)
+
+
 def build_dashboard(user_id=None, include_learner_navigation=False):
     today = tokyo_today()
     exam_date = get_effective_exam_date(user_id)
@@ -276,15 +313,13 @@ def build_dashboard(user_id=None, include_learner_navigation=False):
                 dashboard["dashboard_real_data_shadow_enabled"] = True
                 dashboard["dashboard_real_data_shadow"] = shadow_result
         if include_learner_navigation:
-            readiness = build_pass_readiness(
-                attempts,
-                field_evidence=evidence,
-                progress=progress,
-                trial100_records=bundle["trial100_records"],
-            )
             dashboard["learner_navigation_enabled"] = True
-            dashboard["learner_navigation"] = build_learner_readiness_presentation(
-                readiness, shadow_result
+            dashboard["learner_navigation"] = build_learner_navigation_from_formal_inputs(
+                attempts,
+                bundle["trial100_records"],
+                evidence=evidence,
+                progress=progress,
+                shadow_result=shadow_result,
             )
         if phase12_preview:
             shadow_judgment = build_shadow_judgment(

--- a/learner_navigation_performance.py
+++ b/learner_navigation_performance.py
@@ -1,0 +1,48 @@
+"""Feature-gated timing for the learner-navigation start route.
+
+Only operation names, durations, and response status are logged. Learner IDs,
+tokens, questions, and answer content are deliberately outside this API.
+"""
+
+from contextlib import contextmanager
+import logging
+import os
+from time import perf_counter
+
+
+logger = logging.getLogger(__name__)
+_TRUE_VALUES = {"1", "true", "yes", "on"}
+
+
+def enabled() -> bool:
+    return os.getenv("LT_LEARNER_NAVIGATION_PERF_LOG", "").strip().lower() in _TRUE_VALUES
+
+
+class RequestTiming:
+    def __init__(self):
+        self.active = enabled()
+        self.started_at = perf_counter() if self.active else None
+
+    @contextmanager
+    def measure(self, operation: str):
+        if not self.active:
+            yield
+            return
+        started_at = perf_counter()
+        try:
+            yield
+        finally:
+            self._log(operation, perf_counter() - started_at)
+
+    def finish(self, status_code: int):
+        if self.active and self.started_at is not None:
+            self._log("route_total", perf_counter() - self.started_at, status=status_code)
+
+    @staticmethod
+    def _log(operation: str, duration_seconds: float, *, status=None):
+        logger.info(
+            "lt_learner_navigation_perf op=%s duration_ms=%.3f%s",
+            operation,
+            max(duration_seconds, 0.0) * 1000.0,
+            f" status={status}" if status is not None else "",
+        )

--- a/tests/test_dashboard_read_bundle.py
+++ b/tests/test_dashboard_read_bundle.py
@@ -109,3 +109,77 @@ def test_attempt_rows_match_formal_database_shape():
 
     assert attempts[0]["question_id"] == "Q1"
     assert attempts[0]["answer_status"] == "unknown"
+
+
+def test_learner_navigation_bundle_shares_one_production_connection(monkeypatch):
+    connection_obj = object()
+    connection_entries = []
+    attempts = [{"question_id": "Q1"}]
+    trial100 = [{"source_version": "trial100-v1"}]
+
+    class ConnectionContext:
+        def __enter__(self):
+            connection_entries.append("enter")
+            return connection_obj
+
+        def __exit__(self, *args):
+            connection_entries.append("exit")
+            return False
+
+    monkeypatch.setattr(
+        dashboard_read_bundle.database, "database_is_available", lambda: True
+    )
+    monkeypatch.setattr(
+        dashboard_read_bundle.database, "get_db_connection", ConnectionContext
+    )
+    monkeypatch.setattr(
+        dashboard_read_bundle,
+        "_attempts_with_connection",
+        lambda user_id, conn: attempts if conn is connection_obj else None,
+    )
+    monkeypatch.setattr(
+        dashboard_read_bundle,
+        "get_trial100_records",
+        lambda user_id, connection=None: trial100 if connection is connection_obj else None,
+    )
+    monkeypatch.setattr(
+        dashboard_read_bundle.database,
+        "_get_question_result_rows",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("legacy dashboard aggregates are not part of this read")
+        ),
+    )
+
+    result = dashboard_read_bundle.get_learner_navigation_read_bundle("learner")
+
+    assert result == {"attempts": attempts, "trial100_records": trial100}
+    assert connection_entries == ["enter", "exit"]
+
+
+def test_learner_navigation_bundle_preserves_local_fallback(monkeypatch):
+    attempts = [{"question_id": "Q1"}]
+    trial100 = [{"source_version": "trial100-v1"}]
+    monkeypatch.setattr(
+        dashboard_read_bundle.database, "database_is_available", lambda: False
+    )
+    monkeypatch.setattr(
+        dashboard_read_bundle.database,
+        "get_question_attempts",
+        lambda user_id: attempts,
+    )
+    monkeypatch.setattr(
+        dashboard_read_bundle,
+        "get_trial100_records",
+        lambda user_id: trial100,
+    )
+    monkeypatch.setattr(
+        dashboard_read_bundle.database,
+        "get_dashboard_learning_data",
+        lambda user_id: (_ for _ in ()).throw(
+            AssertionError("full dashboard read is not part of the fallback")
+        ),
+    )
+
+    result = dashboard_read_bundle.get_learner_navigation_read_bundle("learner")
+
+    assert result == {"attempts": attempts, "trial100_records": trial100}

--- a/tests/test_learner_goukaku_navigation_ui.py
+++ b/tests/test_learner_goukaku_navigation_ui.py
@@ -177,11 +177,24 @@ def test_supporter_view_does_not_enable_learner_navigation(monkeypatch):
 
 
 def test_navigation_cta_rejects_stale_or_tampered_intent(monkeypatch):
+    attempts = [{"question_id": "Q1"}]
     monkeypatch.setattr(app_module, "dashboard_user_id", lambda token: "learner")
     monkeypatch.setattr(
         app_module,
         "build_dashboard",
-        lambda user_id, include_learner_navigation=False: _dashboard(),
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("full dashboard must not validate learner-navigation CTA")
+        ),
+    )
+    monkeypatch.setattr(
+        app_module,
+        "get_learner_navigation_formal_inputs",
+        lambda user_id: {"attempts": attempts, "trial100_records": []},
+    )
+    monkeypatch.setattr(
+        app_module,
+        "build_learner_navigation_from_formal_inputs",
+        lambda rows, trial100: _navigation(),
     )
     client = app_module.app.test_client()
     response = client.post(
@@ -198,18 +211,66 @@ def test_navigation_cta_rejects_stale_or_tampered_intent(monkeypatch):
     assert response.status_code == 409
 
 
+def test_navigation_cta_rejects_action_that_became_stale(monkeypatch):
+    current_navigation = _navigation()
+    current_navigation["today_action"] = {
+        **current_navigation["today_action"],
+        "field": "心理学",
+    }
+    monkeypatch.setattr(app_module, "dashboard_user_id", lambda token: "learner")
+    monkeypatch.setattr(
+        app_module,
+        "get_learner_navigation_formal_inputs",
+        lambda user_id: {"attempts": [], "trial100_records": []},
+    )
+    monkeypatch.setattr(
+        app_module,
+        "build_learner_navigation_from_formal_inputs",
+        lambda rows, trial100: current_navigation,
+    )
+
+    response = app_module.app.test_client().post(
+        "/goukaku-no-michi/recommendation/start",
+        json={
+            "token": "ok",
+            "field": "神経医学",
+            "count": 10,
+            "source": "learner_navigation",
+            "intent": "exploration",
+            "reason": "coverage_expand",
+        },
+    )
+
+    assert response.status_code == 409
+
+
 def test_navigation_cta_accepts_validated_intent_then_uses_central_session_creator(monkeypatch):
     calls = []
+    attempts = [{"question_id": "Q1"}]
     monkeypatch.setattr(app_module, "dashboard_user_id", lambda token: "learner")
     monkeypatch.setattr(
         app_module,
         "build_dashboard",
-        lambda user_id, include_learner_navigation=False: _dashboard(),
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("full dashboard must not validate learner-navigation CTA")
+        ),
+    )
+    monkeypatch.setattr(
+        app_module,
+        "get_learner_navigation_formal_inputs",
+        lambda user_id: {"attempts": attempts, "trial100_records": []},
+    )
+    monkeypatch.setattr(
+        app_module,
+        "build_learner_navigation_from_formal_inputs",
+        lambda rows, trial100: _navigation(),
     )
     monkeypatch.setattr(
         app_module,
         "create_web_recommendation_session",
-        lambda user_id, category_small, question_count, token: calls.append((user_id, category_small, question_count, token)) or ("session-1", True),
+        lambda user_id, category_small, question_count, token, attempts=None: calls.append(
+            (user_id, category_small, question_count, token, attempts)
+        ) or ("session-1", True),
     )
     response = app_module.app.test_client().post(
         "/goukaku-no-michi/recommendation/start",
@@ -225,6 +286,61 @@ def test_navigation_cta_accepts_validated_intent_then_uses_central_session_creat
     assert response.status_code == 200
     assert response.get_json()["redirect_url"] == "/goukaku-no-michi/learning/session-1"
     assert len(calls) == 1
+    assert calls[0][4] is attempts
+
+
+def test_web_session_uses_supplied_attempts_without_second_read(monkeypatch):
+    attempts = [{"question_id": "Q1"}]
+    selected = [{"id": "Q2", "question": "q", "choices": ["a"]}]
+    captured = []
+    app_module.web_recommendation_sessions.clear()
+    monkeypatch.setattr(
+        app_module,
+        "get_question_attempts",
+        lambda user_id: (_ for _ in ()).throw(AssertionError("duplicate attempt read")),
+    )
+    monkeypatch.setattr(
+        app_module,
+        "build_node_adaptive_session",
+        lambda rows, **kwargs: captured.append(rows) or selected,
+    )
+
+    session_id, started = app_module.create_web_recommendation_session(
+        "learner", "09", 10, "token", attempts=attempts
+    )
+
+    assert started is True
+    assert captured == [attempts]
+    assert app_module.web_recommendation_sessions[session_id]["questions"] is selected
+    app_module.web_recommendation_sessions.clear()
+
+
+def test_legacy_recommendation_keeps_dashboard_validation_and_legacy_attempt_read(monkeypatch):
+    calls = []
+    monkeypatch.setattr(app_module, "dashboard_user_id", lambda token: "learner")
+    monkeypatch.setattr(
+        app_module,
+        "build_dashboard",
+        lambda user_id: calls.append(("dashboard", user_id)) or {
+            "recommended_study": [("神経医学", 10)]
+        },
+    )
+    monkeypatch.setattr(
+        app_module,
+        "create_web_recommendation_session",
+        lambda user_id, category_small, question_count, token: calls.append(
+            ("session", user_id, category_small, question_count, token)
+        ) or ("legacy-session", True),
+    )
+
+    response = app_module.app.test_client().post(
+        "/goukaku-no-michi/recommendation/start",
+        json={"token": "ok", "field": "神経医学", "count": 10, "source": "dashboard"},
+    )
+
+    assert response.status_code == 200
+    assert calls[0] == ("dashboard", "learner")
+    assert calls[1][0] == "session"
 
 
 def test_javascript_forces_structured_web_post_for_learner_navigation():

--- a/tests/test_learner_navigation_performance.py
+++ b/tests/test_learner_navigation_performance.py
@@ -1,0 +1,27 @@
+import logging
+
+import learner_navigation_performance as performance
+
+
+def test_timing_is_off_by_default(monkeypatch, caplog):
+    monkeypatch.delenv("LT_LEARNER_NAVIGATION_PERF_LOG", raising=False)
+    with caplog.at_level(logging.INFO):
+        timing = performance.RequestTiming()
+        with timing.measure("formal_input_read"):
+            pass
+        timing.finish(200)
+    assert "lt_learner_navigation_perf" not in caplog.text
+
+
+def test_timing_logs_only_stage_duration_and_status(monkeypatch, caplog):
+    monkeypatch.setenv("LT_LEARNER_NAVIGATION_PERF_LOG", "true")
+    with caplog.at_level(logging.INFO):
+        timing = performance.RequestTiming()
+        with timing.measure("formal_input_read"):
+            pass
+        timing.finish(200)
+    assert "op=formal_input_read" in caplog.text
+    assert "op=route_total" in caplog.text
+    assert "status=200" in caplog.text
+    assert "user_id" not in caplog.text
+    assert "token" not in caplog.text


### PR DESCRIPTION
Measured performance optimization for Issue #106.

Scope:
- replace full learner dashboard rebuild during learner_navigation CTA validation with a formal-input-only path
- read question_attempts + Trial100 on one Production DB connection
- rebuild the same formal evidence/progress/shadow/readiness/presentation contract
- preserve the four-field stale/tampered validation contract
- reuse the validated attempts in central session creation to avoid a second attempts read
- keep legacy recommendation path unchanged
- add feature-gated privacy-safe learner-navigation timing probe

Safety / semantics unchanged:
- selector ownership unchanged
- Safety / repair / Recent Question Cooldown unchanged
- no schema or migration changes
- no Stripe or public-site changes

Reported validation:
- focused: 92 passed
- full: 987 passed / 125 subtests passed / 1 deselected
- git diff --check PASS