### PR TITLE
Share one DB connection across supporter first-open request

### DIFF
--- a/goukaku_ui.py
+++ b/goukaku_ui.py
@@ -8,6 +8,7 @@ from database import (
     calculate_overall_progress,
     database_is_available,
     get_dashboard_learning_data,
+    get_db_connection,
     get_field_learning_summary,
     get_learning_activity,
     get_question_attempts,
@@ -21,6 +22,7 @@ from dashboard_read_bundle import get_learner_navigation_read_bundle as _get_pro
 from trial100_store import get_trial100_records
 from learning_analysis import build_gensan_comment, build_learning_guidance
 from supporter_report import build_supporter_report
+from supporter_performance import measure
 from pilot_diagnostics import build_pilot_diagnostics
 from field_evidence import build_field_evidence
 from field_progress import build_field_progress
@@ -157,6 +159,44 @@ def authorized_supporter_learner(token, requested_learner_id=None):
             abort(403)
         return supporter_id, requested_learner_id
     return supporter_id, learner_ids[0]
+
+
+def _authorized_supporter_learner_with_connection(
+    token,
+    requested_learner_id,
+    connection,
+):
+    """Production /supporter用。既存認可意味を保ったままcaller connectionを使う。"""
+    supporter_id = supporter_user_id(token)
+    if not supporter_id:
+        abort(403)
+    with connection.cursor() as cur:
+        cur.execute(
+            """
+            SELECT learner_user_id FROM supporter_links
+            WHERE supporter_user_id = %s AND is_active = TRUE
+            ORDER BY created_at, id
+            """,
+            (supporter_id,),
+        )
+        learner_ids = [row[0] for row in cur.fetchall()]
+    if not learner_ids:
+        abort(403)
+    if requested_learner_id:
+        if requested_learner_id not in learner_ids:
+            abort(403)
+        return supporter_id, requested_learner_id
+    return supporter_id, learner_ids[0]
+
+
+def _user_name_with_connection(user_id, connection, default="学習者"):
+    """Production /supporterでプロフィール名を同じDB connectionから読む。"""
+    with connection.cursor() as cur:
+        cur.execute("SELECT name FROM user_profiles WHERE user_id = %s", (user_id,))
+        row = cur.fetchone()
+    if row is None or row[0] is None:
+        return default
+    return row[0]
 
 
 def _dashboard_read_bundle(user_id, *, include_attempts=False, include_trial100=False):
@@ -442,19 +482,36 @@ def learning():
 @goukaku_ui.route("/supporter")
 def supporter_dashboard():
     token = request.args.get("token")
-    _, learner_id = authorized_supporter_learner(
-        token,
-        request.args.get("learner_user_id"),
-    )
-    report = build_supporter_report(learner_id)
-    learner_name = user_names.get(learner_id, "学習者") or "学習者"
-    return render_template(
-        "goukaku/supporter.html",
-        learner_name=learner_name,
-        learner_id=learner_id,
-        supporter_token=token,
-        report=report,
-    )
+    requested_learner_id = request.args.get("learner_user_id")
+    if database_is_available():
+        with get_db_connection() as conn:
+            with measure("supporter.authorization"):
+                _, learner_id = _authorized_supporter_learner_with_connection(
+                    token,
+                    requested_learner_id,
+                    conn,
+                )
+            report = build_supporter_report(learner_id, _connection=conn)
+            with measure("supporter.learner_name"):
+                learner_name = _user_name_with_connection(learner_id, conn)
+    else:
+        with measure("supporter.authorization"):
+            _, learner_id = authorized_supporter_learner(
+                token,
+                requested_learner_id,
+            )
+        report = build_supporter_report(learner_id)
+        with measure("supporter.learner_name"):
+            learner_name = user_names.get(learner_id, "学習者") or "学習者"
+    with measure("supporter.template_render"):
+        response = render_template(
+            "goukaku/supporter.html",
+            learner_name=learner_name,
+            learner_id=learner_id,
+            supporter_token=token,
+            report=report,
+        )
+    return response
 
 
 @goukaku_ui.route("/supporter/weekly-question-history")

--- a/supporter_report.py
+++ b/supporter_report.py
@@ -8,6 +8,7 @@ performance simplification.
 
 from __future__ import annotations
 
+from contextlib import nullcontext
 from datetime import timezone
 from zoneinfo import ZoneInfo
 
@@ -181,11 +182,16 @@ def _shared_dashboard_learning_data(learner_user_id: str, conn) -> dict:
     }
 
 
-def build_supporter_report(learner_user_id: str) -> dict:
-    """Return parent-facing data only; never consultation text or dev diagnostics."""
+def build_supporter_report(learner_user_id: str, *, _connection=None) -> dict:
+    """Return parent-facing data only; reuse a caller-owned Production connection."""
     with measure("build_supporter_report.total"):
         if database_is_available():
-            with get_db_connection() as conn:
+            connection_context = (
+                nullcontext(_connection)
+                if _connection is not None
+                else get_db_connection()
+            )
+            with connection_context as conn:
                 with measure("db.dashboard_learning_data"):
                     learning_data = _shared_dashboard_learning_data(learner_user_id, conn)
                 summary = learning_data["summary"]

--- a/tests/test_supporter_request_shared_connection_v01.py
+++ b/tests/test_supporter_request_shared_connection_v01.py
@@ -1,0 +1,138 @@
+import app as app_module
+import goukaku_ui as ui_module
+import supporter_report as report_module
+
+
+class _ConnectionContext:
+    def __init__(self, connection, events=None):
+        self.connection = connection
+        self.events = events if events is not None else []
+
+    def __enter__(self):
+        self.events.append("enter")
+        return self.connection
+
+    def __exit__(self, exc_type, exc, tb):
+        self.events.append("exit")
+        return False
+
+
+def test_supporter_route_reuses_one_production_connection(monkeypatch):
+    connection = object()
+    events = []
+    seen = {}
+
+    monkeypatch.setattr(ui_module, "database_is_available", lambda: True)
+    monkeypatch.setattr(
+        ui_module,
+        "get_db_connection",
+        lambda: _ConnectionContext(connection, events),
+    )
+
+    def authorize(token, requested_learner_id, conn):
+        seen["authorize"] = (token, requested_learner_id, conn)
+        return "supporter", "learner"
+
+    monkeypatch.setattr(
+        ui_module,
+        "_authorized_supporter_learner_with_connection",
+        authorize,
+    )
+
+    def build_report(learner_id, *, _connection=None):
+        seen["report"] = (learner_id, _connection)
+        return {"parent_summary": {}}
+
+    monkeypatch.setattr(ui_module, "build_supporter_report", build_report)
+
+    def learner_name(learner_id, conn, default="学習者"):
+        seen["name"] = (learner_id, conn, default)
+        return "テスト学習者"
+
+    monkeypatch.setattr(ui_module, "_user_name_with_connection", learner_name)
+    monkeypatch.setattr(
+        ui_module,
+        "render_template",
+        lambda *args, **kwargs: "ok",
+    )
+
+    response = app_module.app.test_client().get("/supporter?token=ok")
+
+    assert response.status_code == 200
+    assert events == ["enter", "exit"]
+    assert seen["authorize"] == ("ok", None, connection)
+    assert seen["report"] == ("learner", connection)
+    assert seen["name"] == ("learner", connection, "学習者")
+
+
+def test_supporter_report_uses_caller_owned_connection_without_opening_another(monkeypatch):
+    connection = object()
+    attempts = [{"question_id": "Q1"}]
+    seen = {}
+
+    monkeypatch.setattr(report_module, "database_is_available", lambda: True)
+    monkeypatch.setattr(
+        report_module,
+        "get_db_connection",
+        lambda: (_ for _ in ()).throw(
+            AssertionError("caller-owned connection must be reused")
+        ),
+    )
+    monkeypatch.setattr(
+        report_module,
+        "_shared_dashboard_learning_data",
+        lambda learner_id, conn: {
+            "summary": {"total_answers": 0, "study_minutes": 0},
+            "activity": {
+                "weekly_learning_days": 0,
+                "weekly_answers": 0,
+                "weekly_study_minutes": 0,
+                "weekly_accuracy": 0,
+                "streak_days": 0,
+            },
+            "fields": [],
+            "unique_question_count": 0,
+        },
+    )
+    monkeypatch.setattr(
+        report_module,
+        "build_learning_guidance",
+        lambda total_answers, fields: {
+            "weak_fields": [],
+            "weak_analysis_message": "",
+            "recommended_study": [],
+        },
+    )
+    monkeypatch.setattr(
+        report_module,
+        "get_latest_learning_day_summary",
+        lambda learner_id, _connection=None: {
+            "has_learning": False,
+            "fields": [],
+            "answered_count": 0,
+        },
+    )
+    monkeypatch.setattr(
+        report_module,
+        "get_latest_activity_day_summary",
+        lambda learner_id, _connection=None: {"has_activity": False},
+    )
+
+    def read_attempts(learner_id, conn):
+        seen["attempt_connection"] = conn
+        return attempts
+
+    monkeypatch.setattr(report_module, "_attempts_with_connection", read_attempts)
+    monkeypatch.setattr(
+        report_module,
+        "_parent_summary",
+        lambda summary, activity, fields, latest, rows: {"rows": rows},
+    )
+
+    result = report_module.build_supporter_report(
+        "learner",
+        _connection=connection,
+    )
+
+    assert seen["attempt_connection"] is connection
+    assert result["parent_summary"] == {"rows": attempts}


### PR DESCRIPTION
Measured follow-up for Issue #100.

This change keeps the existing supporter authorization and parent-report semantics while removing repeated Production DB connection setup from the normal `/supporter` first-open path.

Production flow after this PR:
- open one caller-owned DB connection in `/supporter`
- validate supporter token + active learner link on that connection
- build the existing supporter report on the same connection
- read learner display name on the same connection
- render the same supporter template

Local/test fallback stays on the existing code path.

Timing additions under the existing `LT_SUPPORTER_PERF_LOG` gate:
- `supporter.authorization`
- `supporter.learner_name`
- `supporter.template_render`

No DB schema/migration, selector, Question Bank, Stripe, or public-site changes.