### PR TITLE
Add learner path latency baseline timing

### DIFF
--- a/app.py
+++ b/app.py
@@ -60,6 +60,7 @@ from goukaku_ui import (
     goukaku_ui,
 )
 from learner_navigation_performance import RequestTiming
+import learner_path_performance as learner_path_perf
 from site_ui import site_ui
 from question_bank import (
     get_category_group_names,
@@ -1048,23 +1049,28 @@ def start_next_quiz(user_id):
 # 小テストをバックグラウンドで生成・送信
 # =========================================================
 
+@learner_path_perf.timed("study_start_async.total")
 def prepare_and_send_quiz(user_id):
     """
     Webhookとは別の処理で問題を生成し、
     完成後にLINEへプッシュ送信する。
     """
 
+    import learner_path_performance as learner_path_perf
+
     try:
         show_loading_animation(user_id)
 
-        quiz_messages = start_quiz(user_id)
+        with learner_path_perf.measure("study_start_async.selector_build"):
+            quiz_messages = start_quiz(user_id)
         created_session = study_sessions.get(user_id)
 
         for quiz_message in quiz_messages:
             if study_sessions.get(user_id) is not created_session:
                 logging.info("Discarded stale initial quiz push: user_id=%s", user_id)
                 return
-            push_quiz_to_line(user_id, quiz_message)
+            with learner_path_perf.measure("study_start_async.line_send"):
+                push_quiz_to_line(user_id, quiz_message)
 
     except QuestionBankError:
         logging.exception("Formal question bank quiz preparation failed: user_id=%s", user_id)
@@ -2133,28 +2139,33 @@ def reply_current_quiz(reply_token, session, intro_text=None):
     line_bot_api.reply_message(reply_token, reply_messages)
 
 
+@learner_path_perf.timed("study_start.total")
 def start_and_reply_quiz(
     reply_token, user_id, intro_text=None, session_kind=None, question_count=None,
     exclude_ids=None,
 ):
     """正式問題バンクから初回5問を準備し、同じ返信内で直ちに表示する。"""
+    import learner_path_performance as learner_path_perf
+
     try:
-        start_quiz(
-            user_id,
-            session_kind=session_kind,
-            question_count=question_count,
-            exclude_ids=exclude_ids,
-        )
-        reply_current_quiz(
-            reply_token,
-            study_sessions[user_id],
-            intro_text=intro_text or (
-                "おう、任せろ＾＾\n"
-                "まず5問いくぞ（笑）\n"
-                "問題を解いてる最中に中断したくなったら、"
-                "入力欄に『中断する』って入れて教えてくれな＾＾"
-            ),
-        )
+        with learner_path_perf.measure("study_start.selector_build"):
+            start_quiz(
+                user_id,
+                session_kind=session_kind,
+                question_count=question_count,
+                exclude_ids=exclude_ids,
+            )
+        with learner_path_perf.measure("study_start.line_send"):
+            reply_current_quiz(
+                reply_token,
+                study_sessions[user_id],
+                intro_text=intro_text or (
+                    "おう、任せろ＾＾\n"
+                    "まず5問いくぞ（笑）\n"
+                    "問題を解いてる最中に中断したくなったら、"
+                    "入力欄に『中断する』って入れて教えてくれな＾＾"
+                ),
+            )
         return True
     except QuestionBankError:
         logging.exception("Formal question bank initial reply failed: user_id=%s", user_id)
@@ -3612,8 +3623,11 @@ def callback():
 # 通常のテキストメッセージ
 # =========================================================
 
+@learner_path_perf.timed("study_answer.total")
 def process_study_answer_input(reply_token, user_id, user_message):
     """通常学習の5問回答を固定処理し、自由会話へ流さない。"""
+    import learner_path_performance as learner_path_perf
+
     session = study_sessions.get(user_id)
     if not (
         session
@@ -3629,10 +3643,11 @@ def process_study_answer_input(reply_token, user_id, user_message):
         "expected_numbers",
         range(start_number, start_number + questions_per_set),
     ))
-    parsed_answers = parse_quiz_answers(
-        user_message,
-        expected_numbers=expected_numbers,
-    )
+    with learner_path_perf.measure("study_answer.parse"):
+        parsed_answers = parse_quiz_answers(
+            user_message,
+            expected_numbers=expected_numbers,
+        )
 
     if set(parsed_answers) != expected_numbers:
         reply_quiz_input_error(reply_token, start_number, questions_per_set)
@@ -3640,7 +3655,8 @@ def process_study_answer_input(reply_token, user_id, user_message):
 
     for question_number, answer_data in parsed_answers.items():
         session["all_answers"][question_number] = answer_data
-    record_confirmed_learning_batch(user_id, session)
+    with learner_path_perf.measure("study_answer.persist"):
+        record_confirmed_learning_batch(user_id, session)
     globals().get(
         "queue_prerequisite_backtrack_for_next_set", lambda *_args: None
     )(user_id, session)
@@ -3663,25 +3679,27 @@ def process_study_answer_input(reply_token, user_id, user_message):
                 session["question_count"] = 15
                 session["total_sets"] = 3
                 session["status"] = "waiting_for_continue"
-                reply_study_set_result(reply_token, session)
+                with learner_path_perf.measure("study_answer.reply"):
+                    reply_study_set_result(reply_token, session)
                 return True
             mark_initial_assessment_completed(user_id)
             finish_active_learning_time(user_id)
             session["status"] = "assessment_completed"
-            line_bot_api.reply_message(
-                reply_token,
-                TextSendMessage(
-                    text=summarize_initial_assessment(assessment_results),
-                    quick_reply=QuickReply(items=[
-                        QuickReplyButton(action=MessageAction(
-                            label="勉強を始める", text="勉強を始める"
-                        )),
-                        QuickReplyButton(action=MessageAction(
-                            label="ホームに戻る", text="ホームに戻る"
-                        )),
-                    ]),
-                ),
-            )
+            with learner_path_perf.measure("study_answer.reply"):
+                line_bot_api.reply_message(
+                    reply_token,
+                    TextSendMessage(
+                        text=summarize_initial_assessment(assessment_results),
+                        quick_reply=QuickReply(items=[
+                            QuickReplyButton(action=MessageAction(
+                                label="勉強を始める", text="勉強を始める"
+                            )),
+                            QuickReplyButton(action=MessageAction(
+                                label="ホームに戻る", text="ホームに戻る"
+                            )),
+                        ]),
+                    ),
+                )
             return True
         finish_active_learning_time(user_id)
         session["quiz_result"] = calculate_quiz_result(
@@ -3690,11 +3708,13 @@ def process_study_answer_input(reply_token, user_id, user_message):
         )
         session["explanation_set"] = 0
         session["status"] = "waiting_for_explanations"
-        reply_quiz_ready_for_explanations(reply_token, session)
+        with learner_path_perf.measure("study_answer.reply"):
+            reply_quiz_ready_for_explanations(reply_token, session)
         return True
 
     session["status"] = "waiting_for_continue"
-    reply_study_set_result(reply_token, session)
+    with learner_path_perf.measure("study_answer.reply"):
+        reply_study_set_result(reply_token, session)
     return True
 
 
@@ -4370,9 +4390,22 @@ def handle_text_message(event):
     # それ以外は、今までどおり普通に会話する
 
     # それ以外は、今までどおり普通に会話する
+    import learner_path_performance as learner_path_perf
+
+    current_mode = user_modes.get(user_id, "normal")
+    consultation_timing = (
+        learner_path_perf.measure("consult.total")
+        if current_mode == "chat"
+        else None
+    )
+    if consultation_timing is not None:
+        consultation_timing.__enter__()
     try:
-        current_mode = user_modes.get(user_id, "normal")
-        reply_message = create_text_response(user_message, current_mode)
+        if current_mode == "chat":
+            with learner_path_perf.measure("consult.openai"):
+                reply_message = create_text_response(user_message, current_mode)
+        else:
+            reply_message = create_text_response(user_message, current_mode)
 
     except Exception:
         logging.exception("OpenAI response generation failed.")
@@ -4384,9 +4417,13 @@ def handle_text_message(event):
         )
 
     if current_mode == "chat":
-        record_activity_event(user_id, "consultation")
-        consultation_contexts.setdefault(user_id, []).append(user_message)
-        reply_consultation_response(event.reply_token, reply_message)
+        try:
+            record_activity_event(user_id, "consultation")
+            consultation_contexts.setdefault(user_id, []).append(user_message)
+            with learner_path_perf.measure("consult.line_send"):
+                reply_consultation_response(event.reply_token, reply_message)
+        finally:
+            consultation_timing.__exit__(None, None, None)
     else:
         reply_to_line(event.reply_token, reply_message)
 

--- a/goukaku_ui.py
+++ b/goukaku_ui.py
@@ -40,6 +40,7 @@ from dashboard_settings import (
 from learning_milestones import build_learning_milestones
 from judgment_shadow import build_shadow_judgment
 from phase12_presentation import build_phase12_presentation
+import learner_path_performance as learner_path_perf
 
 
 goukaku_ui = Blueprint("goukaku_ui", __name__)
@@ -401,42 +402,47 @@ def build_dashboard(user_id=None, include_learner_navigation=False):
 
 
 @goukaku_ui.route("/goukaku-no-michi")
+@learner_path_perf.timed("dashboard.route_total")
 def home():
     token = learner_dashboard_token(request.args)
     user_id = authorized_dashboard_learner(token)
-    dashboard = build_dashboard(user_id, include_learner_navigation=True)
+    with learner_path_perf.measure("dashboard.build"):
+        dashboard = build_dashboard(user_id, include_learner_navigation=True)
     navigation = dashboard.get("learner_navigation") or {}
     action = navigation.get("today_action") or {}
     if action.get("field"):
-        record_activity_event(
-            user_id,
-            "recommendation_plan",
-            {
-                "field": action["field"],
-                "goal": action["count"],
-                "learning_intent": action["learning_intent"],
-                "reason_code": action["reason_code"],
-                "source": "learner_navigation",
-            },
-        )
+        with learner_path_perf.measure("dashboard.activity_record"):
+            record_activity_event(
+                user_id,
+                "recommendation_plan",
+                {
+                    "field": action["field"],
+                    "goal": action["count"],
+                    "learning_intent": action["learning_intent"],
+                    "reason_code": action["reason_code"],
+                    "source": "learner_navigation",
+                },
+            )
     elif dashboard["recommended_study"]:
         recommended_name, recommended_count = dashboard["recommended_study"][0]
-        record_activity_event(
-            user_id,
-            "recommendation_plan",
-            {"field": recommended_name, "goal": recommended_count},
+        with learner_path_perf.measure("dashboard.activity_record"):
+            record_activity_event(
+                user_id,
+                "recommendation_plan",
+                {"field": recommended_name, "goal": recommended_count},
+            )
+    with learner_path_perf.measure("dashboard.template_render"):
+        return render_template(
+            "goukaku/home.html",
+            dashboard=dashboard,
+            dashboard_token=token,
+            dashboard_title="合格への道",
+            read_only=False,
+            learner_preview=False,
+            subjects_url=url_for("goukaku_ui.subjects", token=token),
+            line_official_account_id=os.getenv("LINE_OFFICIAL_ACCOUNT_ID", "").strip(),
+            liff_id=os.getenv("LIFF_ID", "").strip(),
         )
-    return render_template(
-        "goukaku/home.html",
-        dashboard=dashboard,
-        dashboard_token=token,
-        dashboard_title="合格への道",
-        read_only=False,
-        learner_preview=False,
-        subjects_url=url_for("goukaku_ui.subjects", token=token),
-        line_official_account_id=os.getenv("LINE_OFFICIAL_ACCOUNT_ID", "").strip(),
-        liff_id=os.getenv("LIFF_ID", "").strip(),
-    )
 
 
 @goukaku_ui.route("/goukaku-no-michi/subjects")

--- a/learner_path_performance.py
+++ b/learner_path_performance.py
@@ -1,14 +1,15 @@
 """Privacy-safe, feature-gated timing for learner-facing request paths."""
 
-from contextlib import contextmanager
 from functools import wraps
 import logging
 import os
+import sys
 from time import perf_counter
 
 
 logger = logging.getLogger(__name__)
 _TRUE_VALUES = {"1", "true", "yes", "on"}
+_SKIP_FALSE_RESULT_OPERATIONS = {"study_answer.total"}
 
 
 def enabled() -> bool:
@@ -31,20 +32,35 @@ def _log(operation: str, duration_seconds: float, outcome: str = "ok") -> None:
         pass
 
 
-@contextmanager
+class _Measurement:
+    """Context manager that keeps timing passive even when exited manually."""
+
+    def __init__(self, operation: str):
+        self.operation = operation
+        self.started_at = None
+
+    def __enter__(self):
+        if enabled():
+            self.started_at = perf_counter()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        if self.started_at is None:
+            return False
+
+        # Some legacy call sites manually pass (None, None, None) from a
+        # finally block.  During exception propagation sys.exc_info() still
+        # exposes the active exception, so preserve an accurate error outcome.
+        active_exc_type = exc_type
+        if active_exc_type is None:
+            active_exc_type = sys.exc_info()[0]
+        outcome = "error" if active_exc_type is not None else "ok"
+        _log(self.operation, perf_counter() - self.started_at, outcome)
+        return False
+
+
 def measure(operation: str):
-    if not enabled():
-        yield
-        return
-    started_at = perf_counter()
-    outcome = "ok"
-    try:
-        yield
-    except BaseException:
-        outcome = "error"
-        raise
-    finally:
-        _log(operation, perf_counter() - started_at, outcome)
+    return _Measurement(operation)
 
 
 def timed(operation: str):
@@ -52,7 +68,25 @@ def timed(operation: str):
     def decorator(function):
         @wraps(function)
         def wrapped(*args, **kwargs):
-            with measure(operation):
+            if not enabled():
                 return function(*args, **kwargs)
+
+            started_at = perf_counter()
+            try:
+                result = function(*args, **kwargs)
+            except BaseException:
+                _log(operation, perf_counter() - started_at, "error")
+                raise
+
+            # process_study_answer_input is also used as a dispatcher probe.
+            # False means this was not a real study-answer request, so do not
+            # emit a misleading study_answer.total sample.
+            if not (
+                operation in _SKIP_FALSE_RESULT_OPERATIONS
+                and result is False
+            ):
+                _log(operation, perf_counter() - started_at, "ok")
+            return result
+
         return wrapped
     return decorator

--- a/learner_path_performance.py
+++ b/learner_path_performance.py
@@ -1,0 +1,58 @@
+"""Privacy-safe, feature-gated timing for learner-facing request paths."""
+
+from contextlib import contextmanager
+from functools import wraps
+import logging
+import os
+from time import perf_counter
+
+
+logger = logging.getLogger(__name__)
+_TRUE_VALUES = {"1", "true", "yes", "on"}
+
+
+def enabled() -> bool:
+    return os.getenv("LT_LEARNER_PATH_PERF_LOG", "").strip().lower() in _TRUE_VALUES
+
+
+def _log(operation: str, duration_seconds: float, outcome: str = "ok") -> None:
+    """Log only the fixed operation, elapsed time, and coarse outcome."""
+    if not enabled():
+        return
+    try:
+        logger.info(
+            "lt_learner_path_perf op=%s duration_ms=%.3f outcome=%s",
+            operation,
+            max(duration_seconds, 0.0) * 1000.0,
+            outcome,
+        )
+    except Exception:
+        # Instrumentation must never affect the learner path.
+        pass
+
+
+@contextmanager
+def measure(operation: str):
+    if not enabled():
+        yield
+        return
+    started_at = perf_counter()
+    outcome = "ok"
+    try:
+        yield
+    except BaseException:
+        outcome = "error"
+        raise
+    finally:
+        _log(operation, perf_counter() - started_at, outcome)
+
+
+def timed(operation: str):
+    """Measure a whole function without changing its return or exception behavior."""
+    def decorator(function):
+        @wraps(function)
+        def wrapped(*args, **kwargs):
+            with measure(operation):
+                return function(*args, **kwargs)
+        return wrapped
+    return decorator

--- a/tests/test_learner_path_performance.py
+++ b/tests/test_learner_path_performance.py
@@ -1,0 +1,145 @@
+import logging
+import os
+from types import SimpleNamespace
+
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
+os.environ.setdefault("CHANNEL_ACCESS_TOKEN", "test-token")
+os.environ.setdefault("CHANNEL_SECRET", "test-secret")
+
+import app as bot_app
+import goukaku_ui
+import learner_path_performance as performance
+
+
+def _operations(caplog):
+    return [record.getMessage() for record in caplog.records if "lt_learner_path_perf" in record.getMessage()]
+
+
+def test_performance_flag_off_is_noop(monkeypatch, caplog):
+    monkeypatch.delenv("LT_LEARNER_PATH_PERF_LOG", raising=False)
+    with caplog.at_level(logging.INFO, logger=performance.__name__):
+        with performance.measure("test.operation"):
+            pass
+    assert _operations(caplog) == []
+
+
+def test_performance_log_contains_only_operation_duration_and_outcome(monkeypatch, caplog):
+    monkeypatch.setenv("LT_LEARNER_PATH_PERF_LOG", "true")
+    secret = "private-user-token-and-answer"
+    with caplog.at_level(logging.INFO, logger=performance.__name__):
+        with performance.measure("test.operation"):
+            _ = secret
+    messages = _operations(caplog)
+    assert len(messages) == 1
+    assert "op=test.operation" in messages[0]
+    assert "duration_ms=" in messages[0]
+    assert "outcome=ok" in messages[0]
+    assert secret not in messages[0]
+
+
+def test_sync_and_async_study_start_keep_existing_send_semantics(monkeypatch, caplog):
+    monkeypatch.setenv("LT_LEARNER_PATH_PERF_LOG", "1")
+    calls = []
+
+    def start(user_id, **_kwargs):
+        calls.append(("start", user_id))
+        bot_app.study_sessions[user_id] = {"questions": []}
+        return ["first-five"]
+
+    monkeypatch.setattr(bot_app, "start_quiz", start)
+    monkeypatch.setattr(bot_app, "reply_current_quiz", lambda token, session, **_kwargs: calls.append(("reply", token, session)))
+    monkeypatch.setattr(bot_app, "show_loading_animation", lambda user_id: calls.append(("loading", user_id)))
+    monkeypatch.setattr(bot_app, "push_quiz_to_line", lambda user_id, message: calls.append(("push", user_id, message)))
+
+    with caplog.at_level(logging.INFO, logger=performance.__name__):
+        assert bot_app.start_and_reply_quiz("reply-token", "sync-user") is True
+        bot_app.prepare_and_send_quiz("async-user")
+
+    assert calls[0][:2] == ("start", "sync-user")
+    assert calls[1][0:2] == ("reply", "reply-token")
+    assert ("loading", "async-user") in calls
+    assert ("push", "async-user", "first-five") in calls
+    messages = "\n".join(_operations(caplog))
+    for operation in (
+        "study_start.selector_build", "study_start.line_send", "study_start.total",
+        "study_start_async.selector_build", "study_start_async.line_send", "study_start_async.total",
+    ):
+        assert f"op={operation}" in messages
+
+
+def test_five_answer_path_keeps_parse_persist_and_reply(monkeypatch, caplog):
+    monkeypatch.setenv("LT_LEARNER_PATH_PERF_LOG", "1")
+    user_id = "answer-user"
+    session = {
+        "mode": "study", "status": "waiting_for_answers", "current_set": 1,
+        "questions_per_set": 5, "expected_numbers": [1, 2, 3, 4, 5],
+        "all_answers": {}, "total_sets": 2,
+    }
+    bot_app.study_sessions[user_id] = session
+    persisted = []
+    replies = []
+    parsed = {number: {"answer": "A", "confidence": "1"} for number in range(1, 6)}
+    monkeypatch.setattr(bot_app, "parse_quiz_answers", lambda *_args, **_kwargs: parsed)
+    monkeypatch.setattr(bot_app, "record_confirmed_learning_batch", lambda uid, saved: persisted.append((uid, saved)))
+    monkeypatch.setattr(bot_app, "queue_prerequisite_backtrack_for_next_set", lambda *_args: None)
+    monkeypatch.setattr(bot_app, "reply_study_set_result", lambda token, saved: replies.append((token, saved["status"])))
+
+    with caplog.at_level(logging.INFO, logger=performance.__name__):
+        assert bot_app.process_study_answer_input("reply-token", user_id, "answers") is True
+
+    assert persisted == [(user_id, session)]
+    assert replies == [("reply-token", "waiting_for_continue")]
+    assert len(session["all_answers"]) == 5
+    messages = "\n".join(_operations(caplog))
+    for operation in ("study_answer.parse", "study_answer.persist", "study_answer.reply", "study_answer.total"):
+        assert f"op={operation}" in messages
+
+
+def test_consultation_times_one_ai_call_and_one_line_reply(monkeypatch, caplog):
+    monkeypatch.setenv("LT_LEARNER_PATH_PERF_LOG", "1")
+    user_id = "consult-user"
+    bot_app.user_names[user_id] = "learner"
+    bot_app.user_modes[user_id] = "chat"
+    bot_app.user_states[user_id] = "consultation_input"
+    calls = []
+    monkeypatch.setattr(bot_app, "user_profile_exists", lambda _user_id: True)
+    monkeypatch.setattr(bot_app, "process_study_flow_command", lambda *_args: False)
+    monkeypatch.setattr(bot_app, "process_nekketsu_flow_command", lambda *_args: False)
+    monkeypatch.setattr(bot_app, "process_study_answer_input", lambda *_args: False)
+    monkeypatch.setattr(bot_app, "create_text_response", lambda text, mode: calls.append(("ai", text, mode)) or "response")
+    monkeypatch.setattr(bot_app, "record_activity_event", lambda *_args: None)
+    monkeypatch.setattr(bot_app, "reply_consultation_response", lambda token, text: calls.append(("reply", token, text)))
+    event = SimpleNamespace(
+        source=SimpleNamespace(user_id=user_id),
+        message=SimpleNamespace(text="private consultation"),
+        reply_token="private reply token",
+    )
+
+    with caplog.at_level(logging.INFO, logger=performance.__name__):
+        bot_app.handle_text_message(event)
+
+    assert [call[0] for call in calls] == ["ai", "reply"]
+    messages = "\n".join(_operations(caplog))
+    for operation in ("consult.openai", "consult.line_send", "consult.total"):
+        assert f"op={operation}" in messages
+    assert "private consultation" not in messages
+    assert "private reply token" not in messages
+
+
+def test_dashboard_times_existing_build_activity_and_render(monkeypatch, caplog):
+    monkeypatch.setenv("LT_LEARNER_PATH_PERF_LOG", "1")
+    token = goukaku_ui.create_dashboard_token("dashboard-user")
+    recorded = []
+    monkeypatch.setattr(goukaku_ui, "record_activity_event", lambda *args: recorded.append(args))
+
+    with caplog.at_level(logging.INFO, logger=performance.__name__):
+        response = bot_app.app.test_client().get(f"/goukaku-no-michi?token={token}")
+
+    assert response.status_code == 200
+    assert recorded and recorded[0][1] == "recommendation_plan"
+    messages = "\n".join(_operations(caplog))
+    for operation in (
+        "dashboard.build", "dashboard.activity_record",
+        "dashboard.template_render", "dashboard.route_total",
+    ):
+        assert f"op={operation}" in messages

--- a/tests/test_learner_path_performance.py
+++ b/tests/test_learner_path_performance.py
@@ -2,6 +2,8 @@ import logging
 import os
 from types import SimpleNamespace
 
+import pytest
+
 os.environ.setdefault("OPENAI_API_KEY", "test-key")
 os.environ.setdefault("CHANNEL_ACCESS_TOKEN", "test-token")
 os.environ.setdefault("CHANNEL_SECRET", "test-secret")
@@ -95,6 +97,18 @@ def test_five_answer_path_keeps_parse_persist_and_reply(monkeypatch, caplog):
         assert f"op={operation}" in messages
 
 
+def test_non_study_dispatch_probe_does_not_emit_study_answer_total(monkeypatch, caplog):
+    monkeypatch.setenv("LT_LEARNER_PATH_PERF_LOG", "1")
+    user_id = "not-an-answer-user"
+    bot_app.study_sessions.pop(user_id, None)
+
+    with caplog.at_level(logging.INFO, logger=performance.__name__):
+        assert bot_app.process_study_answer_input("reply-token", user_id, "hello") is False
+
+    messages = "\n".join(_operations(caplog))
+    assert "op=study_answer.total" not in messages
+
+
 def test_consultation_times_one_ai_call_and_one_line_reply(monkeypatch, caplog):
     monkeypatch.setenv("LT_LEARNER_PATH_PERF_LOG", "1")
     user_id = "consult-user"
@@ -124,6 +138,38 @@ def test_consultation_times_one_ai_call_and_one_line_reply(monkeypatch, caplog):
         assert f"op={operation}" in messages
     assert "private consultation" not in messages
     assert "private reply token" not in messages
+
+
+def test_consultation_total_marks_propagating_error(monkeypatch, caplog):
+    monkeypatch.setenv("LT_LEARNER_PATH_PERF_LOG", "1")
+    user_id = "consult-error-user"
+    bot_app.user_names[user_id] = "learner"
+    bot_app.user_modes[user_id] = "chat"
+    bot_app.user_states[user_id] = "consultation_input"
+    monkeypatch.setattr(bot_app, "user_profile_exists", lambda _user_id: True)
+    monkeypatch.setattr(bot_app, "process_study_flow_command", lambda *_args: False)
+    monkeypatch.setattr(bot_app, "process_nekketsu_flow_command", lambda *_args: False)
+    monkeypatch.setattr(bot_app, "process_study_answer_input", lambda *_args: False)
+    monkeypatch.setattr(bot_app, "create_text_response", lambda *_args: "response")
+
+    def fail_activity(*_args):
+        raise RuntimeError("activity write failed")
+
+    monkeypatch.setattr(bot_app, "record_activity_event", fail_activity)
+    event = SimpleNamespace(
+        source=SimpleNamespace(user_id=user_id),
+        message=SimpleNamespace(text="private consultation"),
+        reply_token="private reply token",
+    )
+
+    with caplog.at_level(logging.INFO, logger=performance.__name__):
+        with pytest.raises(RuntimeError, match="activity write failed"):
+            bot_app.handle_text_message(event)
+
+    messages = _operations(caplog)
+    consult_total = [message for message in messages if "op=consult.total" in message]
+    assert len(consult_total) == 1
+    assert "outcome=error" in consult_total[0]
 
 
 def test_dashboard_times_existing_build_activity_and_render(monkeypatch, caplog):


### PR DESCRIPTION
Issue #106 instrumentation-only baseline. Adds feature-gated privacy-safe timing for learner study start, 5-question answer handling, consultation, and dashboard first-open. No selector/Safety/repair/cooldown semantics, DB schema, Stripe, supporter, or site behavior changes intended. Branch tests reported: focused 44 passed; answer regression 57 passed / 125 subtests / 1 deselected; full 995 passed / 125 subtests / 1 deselected; git diff --check PASS.