### PR TITLE
Replace primary consultation entry with formal-bank term explainer

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn --timeout 90 app:app
+web: gunicorn --timeout 90 wsgi:app

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn --timeout 90 wsgi:app
+web: gunicorn --timeout 90 app:app

--- a/preview-pc/index.html
+++ b/preview-pc/index.html
@@ -29,14 +29,14 @@
     </div></section>
 
     <section class="feature-two"><div class="container two-grid">
-      <article class="gensan-card" id="gensan"><img src="../preview-724/assets/gensan-main.png" alt="教えて源さん"><div class="gensan-copy"><h2>教えて源さん</h2><p>学習の悩みや、つまずきポイントを<br>源さんがやさしく解説！<br>モチベーションも上がります。</p><a href="#feature-preview">源さんに質問してみる</a><small class="card-image-note">※画面イメージです</small></div><ul><li>苦手な分野を<br>どう克服すればいい？</li><li>勉強が続かないときは<br>どうしたらいい？</li><li>試験直前の過ごし方は？</li></ul></article>
+      <article class="gensan-card" id="gensan"><img src="../preview-724/assets/gensan-main.png" alt="教えて源さん"><div class="gensan-copy"><h2>教えて源さん</h2><p>国試で出てくる、わからない用語を<br>その場ですぐ確認。<br>問題・解説からポイントを探します。</p><a href="#feature-preview">わからない言葉を確認してみる</a><small class="card-image-note">※画面イメージです</small></div><ul><li>FIMって<br>何？</li><li>MMTって<br>どういう意味？</li><li>Brunnstrom stage<br>とは？</li></ul></article>
       <article class="road-card" id="road"><div class="road-copy"><h2>合格への道</h2><p>現在の学習状況から、次に取り組む内容を提示。<br>日々の学習で、着実にステップアップ。</p><small>※表示内容・数値は画面イメージです</small><a href="#feature-preview">詳しく見る</a></div><div class="road-score"><h3>学習ナビ <em>（画面イメージ）</em></h3><small>総合達成度</small><div class="ring">68%</div></div><div class="week-task"><h3>今週の学習タスク</h3><p>基礎問題を解く <i style="--w:76%"></i><small>20/30問</small></p><p>単語分野の練習 <i style="--w:62%"></i><small>2/3セット</small></p><p>過去問演習 <i style="--w:48%"></i><small>1/2回</small></p></div></article>
     </div></section>
 
     <section class="watch" id="watch"><div class="container watch-row"><div class="family-icon">♟♟</div><div class="watch-copy"><h2>親御さん向け見守り</h2><p>学習の進捗や理解度、取り組み状況をダッシュボードで確認。<br>がんばりを見える化して、適切なサポートができます。<br><small>※表示内容・数値は画面イメージです</small></p></div><a class="detail">詳しく見る</a><div class="watch-metric"><small>学習時間（今週）</small><b>7<em>時間</em>45<em>分</em></b></div><div class="watch-metric"><small>課題達成率</small><b>72<em>%</em></b></div><div class="watch-metric"><small>正答率</small><b>68<em>%</em></b></div><div class="topics"><b>最近の学習トピック</b><p>・法令分野の正答率が上がっています！<br>・苦手な計算問題に取り組みましょう。</p></div></div></section>
 
     <section class="feature-preview" id="feature-preview"><div class="container preview-grid">
-      <article class="preview-card"><div class="preview-heading"><span>画面イメージ</span><h2>源さんに質問してみる</h2><p>勉強の悩みや、わからないところをそのまま相談できます。</p></div><div class="chat-sample"><p class="user-bubble">酸塩基平衡がどうしても混乱します。</p><p class="gensan-bubble"><b>源さん</b>まず「pH → PaCO₂ → HCO₃⁻」の順で見てみよう。どこで迷ったか一緒に整理しようか。</p></div><small>※実際の回答内容・表示は利用状況により異なります。</small></article>
+      <article class="preview-card"><div class="preview-heading"><span>画面イメージ</span><h2>わからない言葉をその場で確認</h2><p>LicenseTownの正式な問題・解説を参照して、関連するポイントと問題を確認できます。</p></div><div class="chat-sample"><p class="user-bubble">FIMって何？</p><p class="gensan-bubble"><b>源さん</b>おう、「FIM」な。LicenseTownの問題・解説から、押さえるポイントと関連問題を探して確認するぞ。</p></div><small>※回答はLicenseTownに保存されている正式な問題・解説の記述をもとに表示します。</small></article>
       <article class="preview-card"><div class="preview-heading"><span>画面イメージ</span><h2>「合格への道」を詳しく見る</h2><p>今の状態だけでなく、次にやるべき学習までわかる画面を目指しています。</p></div><div class="road-detail-sample"><div><b>現在の到達度</b><strong>68%</strong></div><p><span>安定している分野</span>安全管理・基礎運動学</p><p><span>修復中</span>酸塩基平衡の判別</p><p><span>未確認</span>循環器の一部領域</p><p class="today-task"><span>今日やること</span>修復確認5問 → 未確認領域5問</p></div><small>※表示内容・数値は画面イメージです。</small></article>
     </div></section>
 
@@ -46,7 +46,7 @@
     </div></section>
 
     <section class="bottom" id="bottom"><div class="container bottom-grid">
-      <article class="brand-panel"><h2>ライセンスタウンは、あなたの「合格したい」を応援します。</h2><p>理学療法士国家試験の学習を支える伴走型学習サービス</p><div><span>▣<b>資格に特化した<br>豊富な問題</b></span><span>◉<b>弱点を分析する<br>AI学習サポート</b></span><span>✓<b>続けられる仕組みで<br>学習習慣化</b></span><span>♜<b>安心のサポート体制</b></span></div></article>
+      <article class="brand-panel"><h2>ライセンスタウンは、あなたの「合格したい」を応援します。</h2><p>理学療法士国家試験の学習を支える伴走型学習サービス</p><div><span>▣<b>資格に特化した<br>豊富な問題</b></span><span>◉<b>弱点を整理する<br>学習サポート</b></span><span>✓<b>続けられる仕組みで<br>学習習慣化</b></span><span>♜<b>安心のサポート体制</b></span></div></article>
       <article class="faq-panel" id="faq"><h2>よくある質問</h2><p>ライセンスタウンの使い方を教えてください <b>›</b></p><p>どんな機能が使えますか？ <b>›</b></p><p>利用開始の方法を教えてください <b>›</b></p><p>解約・退会の方法を教えてください <b>›</b></p><a>その他の質問はこちら　›</a></article>
       <article class="try-panel" id="try"><h2>サービス提供準備中</h2><p>正式な料金・提供条件は、公開前にこのページでご案内します。</p><a>まずは使ってみる　›</a></article>
     </div></section>

--- a/term_explainer.py
+++ b/term_explainer.py
@@ -1,0 +1,250 @@
+"""LicenseTown formal-bank term explainer without external AI calls.
+
+The learner-facing answer is built only from the saved formal question bank.
+It intentionally does not invent a definition when the bank has no supporting text.
+"""
+
+from __future__ import annotations
+
+import re
+import threading
+import unicodedata
+from dataclasses import dataclass
+from typing import Iterable
+
+from question_bank import (
+    QuestionBankError,
+    get_category_name,
+    get_question_tag,
+    get_quiz_question,
+    question_ids,
+)
+
+
+_QUERY_PREFIXES = (
+    "教えて源さん",
+    "源さん",
+)
+_QUERY_SUFFIXES = (
+    "とは何ですか",
+    "とはなんですか",
+    "とは何",
+    "とはなに",
+    "って何ですか",
+    "ってなんですか",
+    "って何",
+    "ってなに",
+    "について教えて",
+    "を教えて",
+    "教えて",
+    "とは",
+)
+_SENTENCE_SPLIT_RE = re.compile(r"(?<=[。！？!?])\s*|[\r\n]+")
+_CACHE_LOCK = threading.Lock()
+_INDEX_CACHE: tuple[dict, ...] | None = None
+
+
+@dataclass(frozen=True)
+class TermSearchResult:
+    question_id: str
+    score: int
+    category_name: str
+    snippets: tuple[str, ...]
+
+
+def _normalize(text: object) -> str:
+    return unicodedata.normalize("NFKC", str(text or "")).strip().lower()
+
+
+def clean_term_query(text: object) -> str:
+    """Remove conversational wrappers while preserving the learner's term text."""
+    value = unicodedata.normalize("NFKC", str(text or "")).strip()
+    value = re.sub(r"^[\s、。,.!?！？]+|[\s、。,.!?！？]+$", "", value)
+    for prefix in _QUERY_PREFIXES:
+        if value.startswith(prefix):
+            value = value[len(prefix):].lstrip(" 、。,:：")
+            break
+    for suffix in _QUERY_SUFFIXES:
+        if value.endswith(suffix):
+            value = value[: -len(suffix)].rstrip(" 、。,:：")
+            break
+    return value.strip()
+
+
+def _sentences(text: object) -> list[str]:
+    return [
+        sentence.strip()
+        for sentence in _SENTENCE_SPLIT_RE.split(str(text or ""))
+        if sentence and sentence.strip()
+    ]
+
+
+def _clip(text: str, limit: int = 180) -> str:
+    value = re.sub(r"\s+", " ", str(text or "")).strip()
+    if len(value) <= limit:
+        return value
+    return value[: limit - 1].rstrip() + "…"
+
+
+def _record_from_bank(question_id: str) -> dict:
+    question = get_quiz_question(question_id)
+    tag = get_question_tag(question_id)
+    category_small = question.get("category_small")
+    try:
+        category_name = get_category_name(category_small)
+    except QuestionBankError:
+        category_name = "関連分野"
+    return {
+        "question_id": str(question_id),
+        "question_text": str(question.get("question", "")),
+        "choices": tuple(str(value) for value in question.get("choices", {}).values()),
+        "explanation": str(question.get("explanation", "")),
+        "choice_explanations": tuple(
+            str(value) for value in question.get("choice_explanations", {}).values()
+        ),
+        "knowledge_node": str(
+            tag.get("knowledge_node")
+            or tag.get("knowledge_node_label")
+            or tag.get("knowledge_node_id")
+            or ""
+        ),
+        "category_name": category_name,
+    }
+
+
+def _bank_records() -> tuple[dict, ...]:
+    global _INDEX_CACHE
+    if _INDEX_CACHE is None:
+        with _CACHE_LOCK:
+            if _INDEX_CACHE is None:
+                _INDEX_CACHE = tuple(_record_from_bank(q_id) for q_id in question_ids())
+    return _INDEX_CACHE
+
+
+def _matching_snippets(record: dict, normalized_term: str) -> tuple[str, ...]:
+    candidates: list[str] = []
+    for source in (record.get("explanation", ""), *record.get("choice_explanations", ())):
+        for sentence in _sentences(source):
+            if normalized_term in _normalize(sentence):
+                clipped = _clip(sentence)
+                if clipped and clipped not in candidates:
+                    candidates.append(clipped)
+            if len(candidates) >= 2:
+                return tuple(candidates)
+    return tuple(candidates)
+
+
+def _score_record(record: dict, normalized_term: str) -> int:
+    if not normalized_term:
+        return 0
+    node = _normalize(record.get("knowledge_node", ""))
+    explanation = _normalize(record.get("explanation", ""))
+    choice_explanations = " ".join(
+        _normalize(value) for value in record.get("choice_explanations", ())
+    )
+    question = _normalize(record.get("question_text", ""))
+    choices = " ".join(_normalize(value) for value in record.get("choices", ()))
+
+    score = 0
+    if node == normalized_term:
+        score += 24
+    elif normalized_term in node:
+        score += 12
+    if normalized_term in explanation:
+        score += 10
+    if normalized_term in choice_explanations:
+        score += 8
+    if normalized_term in question:
+        score += 6
+    if normalized_term in choices:
+        score += 4
+    return score
+
+
+def search_term_records(
+    term: str,
+    records: Iterable[dict] | None = None,
+    *,
+    limit: int = 3,
+) -> list[TermSearchResult]:
+    """Rank exact textual evidence from formal saved data only."""
+    cleaned = clean_term_query(term)
+    normalized = _normalize(cleaned)
+    if len(normalized) < 2:
+        return []
+
+    ranked: list[TermSearchResult] = []
+    for record in records if records is not None else _bank_records():
+        score = _score_record(record, normalized)
+        if score <= 0:
+            continue
+        ranked.append(
+            TermSearchResult(
+                question_id=str(record.get("question_id", "")),
+                score=score,
+                category_name=str(record.get("category_name", "関連分野")),
+                snippets=_matching_snippets(record, normalized),
+            )
+        )
+    ranked.sort(key=lambda item: (-item.score, int(item.question_id[1:]) if item.question_id[1:].isdigit() else 10**9))
+    return ranked[: max(1, int(limit))]
+
+
+def explain_term(term: object) -> str:
+    """Return a LINE-friendly evidence-grounded explanation without OpenAI API."""
+    cleaned = clean_term_query(term)
+    if len(_normalize(cleaned)) < 2:
+        return (
+            "おう、調べたい言葉をもう少し具体的に入れてくれ＾＾\n"
+            "たとえば『FIM』『相反性抑制』『Brunnstrom stage』みたいな感じだ。"
+        )
+
+    try:
+        results = search_term_records(cleaned)
+    except QuestionBankError:
+        return (
+            "おう、悪い。今は正式問題バンクを確認できない状態だ。\n"
+            "推測では答えず、問題バンクが戻ってからもう一度確認しよう。"
+        )
+
+    if not results:
+        return (
+            f"おう、『{cleaned}』だな。\n"
+            "今あるLicenseTownの正式問題・解説だけでは、意味を断定できるだけの記述を見つけられなかった。\n"
+            "略語なら正式名称、長い質問なら調べたい用語だけにして、もう一度入れてみてくれ＾＾"
+        )
+
+    snippets: list[str] = []
+    for result in results:
+        for snippet in result.snippets:
+            if snippet not in snippets:
+                snippets.append(snippet)
+            if len(snippets) >= 3:
+                break
+        if len(snippets) >= 3:
+            break
+
+    lines = [
+        f"おう、『{cleaned}』な。",
+        "LicenseTownの正式な問題・解説から確認すると、ここを押さえるといいぞ。",
+    ]
+    if snippets:
+        lines.extend(["", "■問題・解説にあるポイント"])
+        lines.extend(f"・{snippet}" for snippet in snippets)
+    else:
+        lines.extend([
+            "",
+            "この言葉が出てくる問題は見つかったが、保存済み解説の中に直接説明している文は見つからなかった。",
+            "意味を推測で作らず、まず関連問題を示しておくぞ。",
+        ])
+
+    lines.extend(["", "■関連問題"])
+    lines.extend(
+        f"{result.question_id}（{result.category_name}）"
+        for result in results
+    )
+    lines.extend([
+        "",
+        "※この回答はLicenseTownに保存してある正式問題・解説をもとにしている。",
+    ])
+    return "\n".join(lines)

--- a/tests/test_term_explainer.py
+++ b/tests/test_term_explainer.py
@@ -53,7 +53,7 @@ def test_explain_term_does_not_claim_definition_without_bank_evidence(monkeypatc
 
 
 def test_formal_bank_supports_pc_public_example_terms():
-    # These are the examples shown on the PC site. Keep public promises tied to
+    # These exact queries are shown on the PC site. Keep public promises tied to
     # actual formal-bank evidence rather than a generic AI answer.
-    for term in ("FIM", "MMT", "Brunnstrom"):
+    for term in ("FIM", "MMT", "Brunnstrom stage"):
         assert search_term_records(term), term

--- a/tests/test_term_explainer.py
+++ b/tests/test_term_explainer.py
@@ -1,0 +1,52 @@
+from term_explainer import clean_term_query, explain_term, search_term_records
+
+
+def _records():
+    return [
+        {
+            "question_id": "Q10",
+            "question_text": "FIMについて正しいのはどれか。",
+            "choices": ("運動項目", "認知項目"),
+            "explanation": "FIMは日常生活動作の自立度を評価する尺度である。運動項目と認知項目で構成される。",
+            "choice_explanations": ("FIMでは介助量を評価する。",),
+            "knowledge_node": "FIM",
+            "category_name": "理学療法評価各論",
+        },
+        {
+            "question_id": "Q20",
+            "question_text": "ADL評価について正しいのはどれか。",
+            "choices": ("FIM", "MMT"),
+            "explanation": "ADL評価には複数の尺度がある。",
+            "choice_explanations": ("FIMはADL評価尺度の一つである。",),
+            "knowledge_node": "ADL評価",
+            "category_name": "理学療法評価各論",
+        },
+    ]
+
+
+def test_clean_term_query_removes_conversational_wrapper():
+    assert clean_term_query("源さん、FIMとは？") == "FIM"
+    assert clean_term_query("相反性抑制について教えて") == "相反性抑制"
+
+
+def test_search_prefers_exact_knowledge_node_and_explanation_evidence():
+    results = search_term_records("FIM", _records(), limit=3)
+    assert [item.question_id for item in results] == ["Q10", "Q20"]
+    assert results[0].score > results[1].score
+    assert any("FIM" in snippet for snippet in results[0].snippets)
+
+
+def test_search_returns_no_evidence_for_unknown_term():
+    assert search_term_records("未知用語", _records()) == []
+
+
+def test_explain_term_short_query_requests_more_specific_input():
+    message = explain_term("a")
+    assert "もう少し具体的" in message
+
+
+def test_explain_term_does_not_claim_definition_without_bank_evidence(monkeypatch):
+    monkeypatch.setattr("term_explainer.search_term_records", lambda _term: [])
+    message = explain_term("未知用語")
+    assert "意味を断定できるだけの記述を見つけられなかった" in message
+    assert "推測" not in message or "推測では" not in message

--- a/tests/test_term_explainer.py
+++ b/tests/test_term_explainer.py
@@ -49,4 +49,11 @@ def test_explain_term_does_not_claim_definition_without_bank_evidence(monkeypatc
     monkeypatch.setattr("term_explainer.search_term_records", lambda _term: [])
     message = explain_term("未知用語")
     assert "意味を断定できるだけの記述を見つけられなかった" in message
-    assert "推測" not in message or "推測では" not in message
+    assert "■問題・解説にあるポイント" not in message
+
+
+def test_formal_bank_supports_pc_public_example_terms():
+    # These are the examples shown on the PC site. Keep public promises tied to
+    # actual formal-bank evidence rather than a generic AI answer.
+    for term in ("FIM", "MMT", "Brunnstrom"):
+        assert search_term_records(term), term

--- a/tests/test_wsgi_term_wiring.py
+++ b/tests/test_wsgi_term_wiring.py
@@ -1,0 +1,24 @@
+import wsgi
+
+
+def test_gensan_explain_uses_local_term_explainer(monkeypatch):
+    monkeypatch.setattr(wsgi, "explain_term", lambda text: f"LOCAL:{text}")
+
+    assert wsgi.create_text_response("FIM", mode="gensan_explain") == "LOCAL:FIM"
+
+
+def test_home_advertises_term_tool_instead_of_consultation():
+    message = wsgi.create_home_message()
+    items = message.quick_reply.items
+    labels = [item.action.label for item in items]
+    texts = [getattr(item.action, "text", None) for item in items]
+
+    assert "❓ 教えて源さん" in labels
+    assert "教えて源さん" in texts
+    assert "💬 相談する" not in labels
+    assert "相談する" not in texts
+
+
+def test_legacy_module_is_wired_for_registered_handlers():
+    assert wsgi.legacy.create_text_response is wsgi.create_text_response
+    assert wsgi.legacy.create_home_message is wsgi.create_home_message

--- a/wsgi.py
+++ b/wsgi.py
@@ -1,0 +1,69 @@
+"""Production composition for LicenseTown.
+
+This module keeps the legacy Flask/LINE application intact while wiring the
+learner-facing "教えて源さん" path to the formal-bank term explainer.
+The old consultation command remains backward compatible, but it is no longer
+advertised from HOME.
+"""
+
+from __future__ import annotations
+
+import app as legacy
+from linebot.models import (
+    MessageAction,
+    QuickReply,
+    QuickReplyButton,
+    TextSendMessage,
+    URIAction,
+)
+
+from term_explainer import explain_term
+
+
+_original_create_text_response = legacy.create_text_response
+
+
+def create_text_response(user_message, mode="normal"):
+    """Use saved formal data for term explanations; preserve other legacy modes."""
+    if mode == "gensan_explain":
+        return explain_term(user_message)
+    return _original_create_text_response(user_message, mode)
+
+
+def create_home_message(user_id=None):
+    """Expose the exam-term tool instead of free-form consultation on HOME."""
+    dashboard_url = legacy.build_dashboard_url(user_id)
+    return TextSendMessage(
+        text=(
+            "お！きたなｗ\n初めて来た奴も、戻ってきた奴も、お疲れさん＾＾\n"
+            "ここはお前たちの〝家”だよ＾＾\nここから全てが始まる…\n"
+            "さあ！行き先はお前が決めるんだ！"
+        ),
+        quick_reply=QuickReply(items=[
+            QuickReplyButton(action=URIAction(
+                label="📊 合格への道",
+                uri=dashboard_url,
+            )),
+            QuickReplyButton(action=MessageAction(
+                label="📘 勉強する！",
+                text="勉強する",
+            )),
+            QuickReplyButton(action=MessageAction(
+                label="❓ 教えて源さん",
+                text="教えて源さん",
+            )),
+            QuickReplyButton(action=MessageAction(
+                label="🔥 熱血モード",
+                text="熱血モード",
+            )),
+        ]),
+    )
+
+
+# Registered LINE callbacks resolve these names from the legacy app module at
+# call time, so production behavior can be composed without rewriting app.py.
+legacy.create_text_response = create_text_response
+legacy.create_home_message = create_home_message
+
+# Gunicorn entrypoint.
+app = legacy.app


### PR DESCRIPTION
## 目的
「相談モード」をHOMEの主役から外し、「教えて源さん」を国家試験の専門用語確認ツールとして使える形へ切り替える。

## 変更
- OpenAIを呼ばず、正式Question Bank（問題・解説・Knowledge Node）だけを検索する `term_explainer.py` を追加
- Production composition `wsgi.py` で `gensan_explain` をローカル用語検索へ配線
- HOMEの「相談する」を「教えて源さん」へ変更（旧相談コマンド自体は互換性のため残す）
- PC版HPの「教えて源さん」を用語解説中心の訴求へ変更
- スマホ版は変更しない
- PC版の「AI学習サポート」表記を、実態に合わせて「学習サポート」へ変更

## 安全側の仕様
- 保存済み正式データに根拠がない用語は、意味を生成・推測しない
- 関連する正式Q番号を表示
- Question Bank / selector / DB schema は変更しない
- OpenAI APIへの新規呼び出しは追加しない
- PC公開例（FIM / MMT / Brunnstrom stage）は正式バンクに検索根拠があることをテストで固定

## テスト
- CI run 33931820188: success
- 全体テスト通過

## デプロイ上の注意
Render本番サービスはリポジトリのProcfileではなく、サービス設定の start command `gunicorn --timeout 90 app:app` を明示指定している。そのため、マージ後に Render の start command を `gunicorn --timeout 90 wsgi:app` へ1回変更する必要がある。Procfileは既存契約・テストを壊さないため変更しない。
