### PR TITLE
Make term answers definition-first and remove consultation rich-menu tile

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,5 @@ wheel>=0.40.0
 build>=1.0.3
 python-docx
 pypdf
+Pillow>=10.0.0
 psycopg[binary]>=3.2.0

--- a/scripts/setup_rich_menu.py
+++ b/scripts/setup_rich_menu.py
@@ -3,20 +3,31 @@
 from __future__ import annotations
 
 import argparse
+import io
 import json
 import os
 from pathlib import Path
 
+from PIL import Image
 from linebot import LineBotApi
 from linebot.models import MessageAction, RichMenu, RichMenuArea, RichMenuBounds, RichMenuSize
 
 
-IMAGE_PATH = Path(__file__).resolve().parents[1] / "static" / "rich_menu" / "rich_menu_beta.jpg"
+SOURCE_IMAGE_PATH = Path(__file__).resolve().parents[1] / "static" / "rich_menu" / "rich_menu_beta.jpg"
 IMAGE_WIDTH = 2500
 IMAGE_HEIGHT = 843
 MAX_IMAGE_BYTES = 1_000_000
 TOP_HEIGHT = 588
 TOP_ITEM_WIDTH = 625
+
+# Existing source image layout: 合格への道 / 勉強する / 相談する / 熱血 / 教えて源さん
+# We remove the consultation tile and redistribute the remaining four tiles equally.
+_SOURCE_TOP_AREAS = (
+    (0, 0, 562, TOP_HEIGHT),
+    (562, 0, 471, TOP_HEIGHT),
+    (1495, 0, 474, TOP_HEIGHT),
+    (1969, 0, 531, TOP_HEIGHT),
+)
 
 AREA_SPECS = (
     ("合格への道", "合格への道", 0, 0, TOP_ITEM_WIDTH, TOP_HEIGHT),
@@ -31,7 +42,7 @@ def build_rich_menu() -> RichMenu:
     return RichMenu(
         size=RichMenuSize(width=IMAGE_WIDTH, height=IMAGE_HEIGHT),
         selected=True,
-        name="LicenseTown Closed Beta",
+        name="LicenseTown Closed Beta v2",
         chat_bar_text="メニュー",
         areas=[
             RichMenuArea(
@@ -43,16 +54,42 @@ def build_rich_menu() -> RichMenu:
     )
 
 
-def validate_image() -> None:
-    if not IMAGE_PATH.is_file():
-        raise FileNotFoundError(f"Rich Menu画像がありません: {IMAGE_PATH}")
-    if IMAGE_PATH.stat().st_size > MAX_IMAGE_BYTES:
-        raise ValueError("Rich Menu画像がLINEの1MB上限を超えています。")
+def validate_source_image() -> None:
+    if not SOURCE_IMAGE_PATH.is_file():
+        raise FileNotFoundError(f"Rich Menu元画像がありません: {SOURCE_IMAGE_PATH}")
+
+
+def build_menu_image_bytes() -> bytes:
+    """Create the 4-column rich-menu JPEG from the existing 5-column source image."""
+    validate_source_image()
+    source = Image.open(SOURCE_IMAGE_PATH).convert("RGB")
+    if source.size != (IMAGE_WIDTH, IMAGE_HEIGHT):
+        raise ValueError(
+            f"Rich Menu元画像サイズが想定外です: {source.size} / expected {(IMAGE_WIDTH, IMAGE_HEIGHT)}"
+        )
+
+    canvas = Image.new("RGB", (IMAGE_WIDTH, IMAGE_HEIGHT), "white")
+    for index, (x, y, width, height) in enumerate(_SOURCE_TOP_AREAS):
+        tile = source.crop((x, y, x + width, y + height))
+        tile = tile.resize((TOP_ITEM_WIDTH, TOP_HEIGHT), Image.Resampling.LANCZOS)
+        canvas.paste(tile, (TOP_ITEM_WIDTH * index, 0))
+
+    bottom = source.crop((0, TOP_HEIGHT, IMAGE_WIDTH, IMAGE_HEIGHT))
+    canvas.paste(bottom, (0, TOP_HEIGHT))
+
+    buffer = io.BytesIO()
+    canvas.save(buffer, format="JPEG", quality=94, optimize=True)
+    image_bytes = buffer.getvalue()
+    if len(image_bytes) > MAX_IMAGE_BYTES:
+        raise ValueError("生成したRich Menu画像がLINEの1MB上限を超えています。")
+    return image_bytes
 
 
 def dry_run_payload() -> dict:
+    image_bytes = build_menu_image_bytes()
     return {
-        "image": str(IMAGE_PATH),
+        "source_image": str(SOURCE_IMAGE_PATH),
+        "generated_image_bytes": len(image_bytes),
         "size": [IMAGE_WIDTH, IMAGE_HEIGHT],
         "areas": [
             {"label": label, "text": text, "x": x, "y": y, "width": width, "height": height}
@@ -62,7 +99,7 @@ def dry_run_payload() -> dict:
 
 
 def create_and_set_default(set_default: bool = True) -> str:
-    validate_image()
+    image_bytes = build_menu_image_bytes()
     channel_access_token = os.getenv("CHANNEL_ACCESS_TOKEN")
     if not channel_access_token:
         raise RuntimeError("CHANNEL_ACCESS_TOKENを環境変数へ設定してください。")
@@ -70,8 +107,7 @@ def create_and_set_default(set_default: bool = True) -> str:
     api = LineBotApi(channel_access_token)
     rich_menu_id = api.create_rich_menu(rich_menu=build_rich_menu())
     try:
-        with IMAGE_PATH.open("rb") as image_file:
-            api.set_rich_menu_image(rich_menu_id, "image/jpeg", image_file)
+        api.set_rich_menu_image(rich_menu_id, "image/jpeg", io.BytesIO(image_bytes))
         if set_default:
             api.set_default_rich_menu(rich_menu_id)
     except Exception:
@@ -85,7 +121,6 @@ def main() -> None:
     parser.add_argument("--dry-run", action="store_true", help="APIを呼ばず設定内容だけ表示します。")
     parser.add_argument("--no-default", action="store_true", help="作成後に既定メニューへ設定しません。")
     args = parser.parse_args()
-    validate_image()
     if args.dry_run:
         print(json.dumps(dry_run_payload(), ensure_ascii=False, indent=2))
         return

--- a/scripts/setup_rich_menu.py
+++ b/scripts/setup_rich_menu.py
@@ -16,13 +16,13 @@ IMAGE_WIDTH = 2500
 IMAGE_HEIGHT = 843
 MAX_IMAGE_BYTES = 1_000_000
 TOP_HEIGHT = 588
+TOP_ITEM_WIDTH = 625
 
 AREA_SPECS = (
-    ("合格への道", "合格への道", 0, 0, 562, TOP_HEIGHT),
-    ("勉強する", "勉強する", 562, 0, 471, TOP_HEIGHT),
-    ("相談する", "相談する", 1033, 0, 462, TOP_HEIGHT),
-    ("熱血モード", "熱血モード", 1495, 0, 474, TOP_HEIGHT),
-    ("教えて源さん", "教えて源さん", 1969, 0, 531, TOP_HEIGHT),
+    ("合格への道", "合格への道", 0, 0, TOP_ITEM_WIDTH, TOP_HEIGHT),
+    ("勉強する", "勉強する", TOP_ITEM_WIDTH, 0, TOP_ITEM_WIDTH, TOP_HEIGHT),
+    ("熱血モード", "熱血モード", TOP_ITEM_WIDTH * 2, 0, TOP_ITEM_WIDTH, TOP_HEIGHT),
+    ("教えて源さん", "教えて源さん", TOP_ITEM_WIDTH * 3, 0, TOP_ITEM_WIDTH, TOP_HEIGHT),
     ("ホームへ戻る", "ホームへ戻る", 0, TOP_HEIGHT, IMAGE_WIDTH, IMAGE_HEIGHT - TOP_HEIGHT),
 )
 

--- a/term_explainer.py
+++ b/term_explainer.py
@@ -1,7 +1,8 @@
 """LicenseTown formal-bank term explainer without external AI calls.
 
-The learner-facing answer is built only from the saved formal question bank.
-It intentionally does not invent a definition when the bank has no supporting text.
+The learner-facing answer is built from a small vetted local glossary plus the
+saved formal question bank. It intentionally does not invent a definition when
+neither source has enough support.
 """
 
 from __future__ import annotations
@@ -42,6 +43,52 @@ _QUERY_SUFFIXES = (
 _SENTENCE_SPLIT_RE = re.compile(r"(?<=[。！？!?])\s*|[\r\n]+")
 _CACHE_LOCK = threading.Lock()
 _INDEX_CACHE: tuple[dict, ...] | None = None
+
+# Frequently used exam terms get a short, learner-facing definition first.
+# This stays local, deterministic and free of external AI calls. The related
+# points/questions shown afterwards are still taken from the formal bank.
+_LOCAL_GLOSSARY = {
+    "fim": {
+        "title": "FIM",
+        "definition": "FIM（Functional Independence Measure：機能的自立度評価法）は、日常生活動作の自立度・介助量を評価する尺度で、運動13項目と認知5項目の計18項目で構成されます。",
+        "points": (
+            "認知5項目は、理解・表出・社会的交流・問題解決・記憶です。",
+            "国試では『何を評価するか』『運動13＋認知5』をまず押さえると整理しやすいです。",
+        ),
+    },
+    "mmt": {
+        "title": "MMT",
+        "definition": "MMT（Manual Muscle Testing：徒手筋力検査）は、筋力を徒手的に0〜5の6段階で評価する検査です。",
+        "points": (
+            "0＝筋収縮なし、1＝筋収縮はあるが関節運動なし、2＝重力の影響を除けば全可動域を動かせます。",
+            "3＝重力に抗して全可動域、4＝抵抗に抗して運動可能、5＝正常筋力です。",
+        ),
+    },
+    "brunnstrom": {
+        "title": "Brunnstrom stage",
+        "definition": "Brunnstrom stage（ブルンストローム・ステージ）は、脳卒中などの片麻痺における運動麻痺の回復段階をⅠ〜Ⅵの6段階で示す評価です。",
+        "points": (
+            "Ⅰは弛緩、Ⅱ〜Ⅲで共同運動や痙縮が目立ち、Ⅳ以降は共同運動から分離した運動が増えていきます。",
+            "国試では、各Stageで『共同運動からどれだけ分離できているか』を整理すると覚えやすいです。",
+        ),
+    },
+    "brunnstrom stage": {
+        "title": "Brunnstrom stage",
+        "definition": "Brunnstrom stage（ブルンストローム・ステージ）は、脳卒中などの片麻痺における運動麻痺の回復段階をⅠ〜Ⅵの6段階で示す評価です。",
+        "points": (
+            "Ⅰは弛緩、Ⅱ〜Ⅲで共同運動や痙縮が目立ち、Ⅳ以降は共同運動から分離した運動が増えていきます。",
+            "国試では、各Stageで『共同運動からどれだけ分離できているか』を整理すると覚えやすいです。",
+        ),
+    },
+    "ブルンストローム": {
+        "title": "Brunnstrom stage",
+        "definition": "Brunnstrom stage（ブルンストローム・ステージ）は、脳卒中などの片麻痺における運動麻痺の回復段階をⅠ〜Ⅵの6段階で示す評価です。",
+        "points": (
+            "Ⅰは弛緩、Ⅱ〜Ⅲで共同運動や痙縮が目立ち、Ⅳ以降は共同運動から分離した運動が増えていきます。",
+            "国試では、各Stageで『共同運動からどれだけ分離できているか』を整理すると覚えやすいです。",
+        ),
+    },
+}
 
 
 @dataclass(frozen=True)
@@ -186,17 +233,87 @@ def search_term_records(
                 snippets=_matching_snippets(record, normalized),
             )
         )
-    ranked.sort(key=lambda item: (-item.score, int(item.question_id[1:]) if item.question_id[1:].isdigit() else 10**9))
+    ranked.sort(
+        key=lambda item: (
+            -item.score,
+            int(item.question_id[1:]) if item.question_id[1:].isdigit() else 10**9,
+        )
+    )
     return ranked[: max(1, int(limit))]
 
 
+def _definition_sentence_score(sentence: str, normalized_term: str) -> int:
+    normalized = _normalize(sentence)
+    if normalized_term not in normalized:
+        return -1
+    score = 0
+    if normalized.startswith(normalized_term + "は"):
+        score += 30
+    if normalized.startswith(normalized_term + "とは"):
+        score += 32
+    if f"{normalized_term}（" in normalized:
+        score += 18
+    for marker in ("評価する", "検査", "尺度", "指標", "方法", "分類", "段階", "構成", "測定"):
+        if marker in sentence:
+            score += 5
+    # Case-description sentences are poor answers to "what is X?".
+    for marker in ("歳", "患者", "症例", "歩行", "立脚", "rom", "mmt3", "mmt4", "mmt5"):
+        if marker in normalized:
+            score -= 8
+    return score
+
+
+def _find_definition_sentence(term: str) -> str | None:
+    normalized_term = _normalize(term)
+    best: tuple[int, str] | None = None
+    for record in _bank_records():
+        for source in (record.get("explanation", ""), *record.get("choice_explanations", ())):
+            for sentence in _sentences(source):
+                score = _definition_sentence_score(sentence, normalized_term)
+                if score < 12:
+                    continue
+                clipped = _clip(sentence, limit=220)
+                if best is None or score > best[0]:
+                    best = (score, clipped)
+    return best[1] if best else None
+
+
+def _local_glossary_entry(term: str) -> dict | None:
+    normalized = _normalize(term)
+    if normalized in _LOCAL_GLOSSARY:
+        return _LOCAL_GLOSSARY[normalized]
+    if "brunnstrom" in normalized:
+        return _LOCAL_GLOSSARY["brunnstrom"]
+    if "ブルンストローム" in normalized:
+        return _LOCAL_GLOSSARY["ブルンストローム"]
+    return None
+
+
+def _useful_bank_points(results: list[TermSearchResult], definition: str | None) -> list[str]:
+    points: list[str] = []
+    normalized_definition = _normalize(definition or "")
+    for result in results:
+        for snippet in result.snippets:
+            normalized = _normalize(snippet)
+            if normalized_definition and normalized == normalized_definition:
+                continue
+            # Avoid presenting individual case facts as a general definition/point.
+            if any(marker in normalized for marker in ("歳", "患者", "症例", "立脚", "歩幅", "インプラント")):
+                continue
+            if snippet not in points:
+                points.append(snippet)
+            if len(points) >= 2:
+                return points
+    return points
+
+
 def explain_term(term: object) -> str:
-    """Return a LINE-friendly evidence-grounded explanation without OpenAI API."""
+    """Return a LINE-friendly, definition-first explanation without OpenAI API."""
     cleaned = clean_term_query(term)
     if len(_normalize(cleaned)) < 2:
         return (
             "おう、調べたい言葉をもう少し具体的に入れてくれ＾＾\n"
-            "たとえば『FIM』『相反性抑制』『Brunnstrom stage』みたいな感じだ。"
+            "たとえば『FIM』『MMT』『Brunnstrom stage』みたいな感じだ。"
         )
 
     try:
@@ -214,29 +331,26 @@ def explain_term(term: object) -> str:
             "略語なら正式名称、長い質問なら調べたい用語だけにして、もう一度入れてみてくれ＾＾"
         )
 
-    snippets: list[str] = []
-    for result in results:
-        for snippet in result.snippets:
-            if snippet not in snippets:
-                snippets.append(snippet)
-            if len(snippets) >= 3:
-                break
-        if len(snippets) >= 3:
-            break
+    glossary = _local_glossary_entry(cleaned)
+    definition = glossary["definition"] if glossary else _find_definition_sentence(cleaned)
+    title = glossary["title"] if glossary else cleaned
 
-    lines = [
-        f"おう、『{cleaned}』な。",
-        "LicenseTownの正式な問題・解説から確認すると、ここを押さえるといいぞ。",
-    ]
-    if snippets:
-        lines.extend(["", "■問題・解説にあるポイント"])
-        lines.extend(f"・{snippet}" for snippet in snippets)
+    lines = [f"おう、『{title}』な。", "", "■一言でいうと"]
+    if definition:
+        lines.append(definition)
     else:
-        lines.extend([
-            "",
-            "この言葉が出てくる問題は見つかったが、保存済み解説の中に直接説明している文は見つからなかった。",
-            "意味を推測で作らず、まず関連問題を示しておくぞ。",
-        ])
+        lines.append(
+            "この用語が出てくる問題は見つかったが、保存済み解説の中に『これは何か』を断定できる定義文までは見つからなかった。"
+        )
+
+    if glossary and glossary.get("points"):
+        lines.extend(["", "■国試で押さえるポイント"])
+        lines.extend(f"・{point}" for point in glossary["points"])
+    else:
+        bank_points = _useful_bank_points(results, definition)
+        if bank_points:
+            lines.extend(["", "■国試で押さえるポイント"])
+            lines.extend(f"・{point}" for point in bank_points)
 
     lines.extend(["", "■関連問題"])
     lines.extend(
@@ -245,6 +359,6 @@ def explain_term(term: object) -> str:
     )
     lines.extend([
         "",
-        "※この回答はLicenseTownに保存してある正式問題・解説をもとにしている。",
+        "※定義はLicenseTown内の用語辞書または正式解説、関連ポイント・問題は正式Question Bankをもとに表示しています。",
     ])
     return "\n".join(lines)

--- a/tests/test_rich_menu.py
+++ b/tests/test_rich_menu.py
@@ -1,57 +1,45 @@
+import io
 from pathlib import Path
-import struct
+
+from PIL import Image
 
 from scripts.setup_rich_menu import (
     AREA_SPECS,
     IMAGE_HEIGHT,
-    IMAGE_PATH,
     IMAGE_WIDTH,
     MAX_IMAGE_BYTES,
+    SOURCE_IMAGE_PATH,
     TOP_HEIGHT,
+    TOP_ITEM_WIDTH,
+    build_menu_image_bytes,
     build_rich_menu,
     dry_run_payload,
-    validate_image,
+    validate_source_image,
 )
 
 
-def jpeg_size(path: Path) -> tuple[int, int]:
-    with path.open("rb") as file:
-        assert file.read(2) == b"\xff\xd8"
-        while True:
-            marker_start = file.read(1)
-            if not marker_start:
-                raise AssertionError("JPEG size marker not found")
-            if marker_start != b"\xff":
-                continue
-            marker = file.read(1)
-            while marker == b"\xff":
-                marker = file.read(1)
-            if marker in {bytes([value]) for value in range(0xC0, 0xC4)}:
-                length = struct.unpack(">H", file.read(2))[0]
-                data = file.read(length - 2)
-                return struct.unpack(">HH", data[1:5])[::-1]
-            if marker in {b"\xd8", b"\xd9"}:
-                continue
-            length = struct.unpack(">H", file.read(2))[0]
-            file.seek(length - 2, 1)
+def test_rich_menu_source_and_generated_image_meet_line_requirements():
+    validate_source_image()
+    assert SOURCE_IMAGE_PATH.is_file()
+    data = build_menu_image_bytes()
+    assert len(data) <= MAX_IMAGE_BYTES
+    image = Image.open(io.BytesIO(data))
+    assert image.size == (IMAGE_WIDTH, IMAGE_HEIGHT)
+    assert image.format == "JPEG"
 
 
-def test_rich_menu_image_meets_line_requirements():
-    validate_image()
-    assert jpeg_size(IMAGE_PATH) == (IMAGE_WIDTH, IMAGE_HEIGHT)
-    assert IMAGE_PATH.stat().st_size <= MAX_IMAGE_BYTES
+def test_rich_menu_areas_match_four_column_visual_without_gaps():
+    primary = AREA_SPECS[:4]
+    assert sum(spec[4] for spec in primary) == IMAGE_WIDTH
+    assert [spec[2] for spec in primary] == [0, TOP_ITEM_WIDTH, TOP_ITEM_WIDTH * 2, TOP_ITEM_WIDTH * 3]
+    assert all(spec[3] == 0 and spec[4] == TOP_ITEM_WIDTH and spec[5] == TOP_HEIGHT for spec in primary)
+    assert AREA_SPECS[4][2:] == (0, TOP_HEIGHT, IMAGE_WIDTH, IMAGE_HEIGHT - TOP_HEIGHT)
 
 
-def test_rich_menu_areas_match_visual_rows_without_gaps():
-    assert sum(spec[4] for spec in AREA_SPECS[:5]) == IMAGE_WIDTH
-    assert [spec[2] for spec in AREA_SPECS[:5]] == [0, 562, 1033, 1495, 1969]
-    assert all(spec[3] == 0 and spec[5] == TOP_HEIGHT for spec in AREA_SPECS[:5])
-    assert AREA_SPECS[5][2:] == (0, TOP_HEIGHT, IMAGE_WIDTH, IMAGE_HEIGHT - TOP_HEIGHT)
-
-
-def test_rich_menu_actions_are_existing_commands_and_exclude_complete_reset():
-    expected = ["合格への道", "勉強する", "相談する", "熱血モード", "教えて源さん", "ホームへ戻る"]
+def test_rich_menu_actions_exclude_consultation_and_complete_reset():
+    expected = ["合格への道", "勉強する", "熱血モード", "教えて源さん", "ホームへ戻る"]
     assert [spec[1] for spec in AREA_SPECS] == expected
+    assert "相談する" not in expected
     assert all("ふりだしにもどる" not in value for spec in AREA_SPECS for value in spec[:2])
     menu = build_rich_menu()
     assert [area.action.text for area in menu.areas] == expected

--- a/tests/test_rich_menu_v2.py
+++ b/tests/test_rich_menu_v2.py
@@ -1,0 +1,25 @@
+import io
+
+from PIL import Image
+
+from scripts.setup_rich_menu import (
+    AREA_SPECS,
+    IMAGE_HEIGHT,
+    IMAGE_WIDTH,
+    MAX_IMAGE_BYTES,
+    build_menu_image_bytes,
+)
+
+
+def test_rich_menu_has_four_primary_actions_without_consultation():
+    labels = [item[0] for item in AREA_SPECS]
+    assert labels == ["合格への道", "勉強する", "熱血モード", "教えて源さん", "ホームへ戻る"]
+    assert "相談する" not in labels
+
+
+def test_generated_rich_menu_image_is_line_compatible():
+    data = build_menu_image_bytes()
+    assert len(data) <= MAX_IMAGE_BYTES
+    image = Image.open(io.BytesIO(data))
+    assert image.size == (IMAGE_WIDTH, IMAGE_HEIGHT)
+    assert image.format == "JPEG"

--- a/tests/test_term_explainer.py
+++ b/tests/test_term_explainer.py
@@ -49,7 +49,7 @@ def test_explain_term_does_not_claim_definition_without_bank_evidence(monkeypatc
     monkeypatch.setattr("term_explainer.search_term_records", lambda _term: [])
     message = explain_term("未知用語")
     assert "意味を断定できるだけの記述を見つけられなかった" in message
-    assert "■問題・解説にあるポイント" not in message
+    assert "■一言でいうと" not in message
 
 
 def test_formal_bank_supports_pc_public_example_terms():
@@ -57,3 +57,20 @@ def test_formal_bank_supports_pc_public_example_terms():
     # actual formal-bank evidence rather than a generic AI answer.
     for term in ("FIM", "MMT", "Brunnstrom stage"):
         assert search_term_records(term), term
+
+
+def test_fim_answer_starts_with_actual_definition():
+    message = explain_term("FIMって何？")
+    assert "■一言でいうと" in message
+    assert "日常生活動作の自立度・介助量を評価する尺度" in message
+    assert "運動13項目と認知5項目" in message
+    assert "■関連問題" in message
+
+
+def test_mmt_answer_is_definition_not_case_snippet():
+    message = explain_term("MMTとは？")
+    assert "■一言でいうと" in message
+    assert "徒手筋力検査" in message
+    assert "0〜5の6段階" in message
+    assert "Trendelenburg徴候は陰性" not in message
+    assert "インプラント異常" not in message

--- a/wsgi.py
+++ b/wsgi.py
@@ -8,6 +8,9 @@ advertised from HOME.
 
 from __future__ import annotations
 
+import logging
+import os
+
 import app as legacy
 from linebot.models import (
     MessageAction,
@@ -20,6 +23,7 @@ from linebot.models import (
 from term_explainer import explain_term
 
 
+logger = logging.getLogger(__name__)
 _original_create_text_response = legacy.create_text_response
 
 
@@ -60,10 +64,26 @@ def create_home_message(user_id=None):
     )
 
 
+def _apply_rich_menu_v2_if_requested() -> None:
+    """One-shot deployment hook used only when explicitly enabled in Render."""
+    if os.getenv("LT_APPLY_RICH_MENU_V2_ON_BOOT", "").strip().lower() not in {"1", "true", "yes", "on"}:
+        return
+    try:
+        from scripts.setup_rich_menu import create_and_set_default
+
+        rich_menu_id = create_and_set_default(set_default=True)
+        logger.warning("lt_rich_menu_v2_apply status=ok rich_menu_id=%s", rich_menu_id)
+    except Exception:
+        logger.exception("lt_rich_menu_v2_apply status=error")
+        raise
+
+
 # Registered LINE callbacks resolve these names from the legacy app module at
 # call time, so production behavior can be composed without rewriting app.py.
 legacy.create_text_response = create_text_response
 legacy.create_home_message = create_home_message
+
+_apply_rich_menu_v2_if_requested()
 
 # Gunicorn entrypoint.
 app = legacy.app


### PR DESCRIPTION
## 目的
- 「○○って何？」に対して、まず定義を返す用語解説へ修正する
- LINEリッチメニューから「相談する」を削除し、4機能構成へ整理する

## 用語解説
- FIM / MMT / Brunnstrom stage はローカル用語辞書で短い定義を最初に表示
- その後に国試ポイントと正式Question Bankの関連問題を表示
- その他の用語は正式Question Bank内の定義らしい文を優先抽出
- 症例固有のMMT値や歩行所見を一般定義として出しにくくする
- OpenAI APIは呼ばない

## リッチメニュー
- 相談するタイルを削除
- 合格への道 / 勉強する / 熱血モード / 教えて源さん の4列へ再配置
- 既存の高解像度5列画像から、実行時に4列JPEGを生成してLINEへ設定
- 一度だけ本番反映できる環境変数 `LT_APPLY_RICH_MENU_V2_ON_BOOT` を追加

## 安全策
- 既存5列画像は残すためロールバック可能
- 一度だけフラグONで既定Rich Menuを更新し、反映後すぐOFFへ戻す
- Question Bank / selector / DB schema は変更しない

## テスト
- FIMが定義から始まること
- MMTが症例断片ではなく徒手筋力検査の定義になること
- 相談する領域が存在しないこと
- 生成Rich Menu画像が2500×843 / JPEG / 1MB以下であること
