### PR TITLE
Remove overflowing PC Gensan CTA

### DIFF
--- a/preview-pc/index.html
+++ b/preview-pc/index.html
@@ -29,7 +29,7 @@
     </div></section>
 
     <section class="feature-two"><div class="container two-grid">
-      <article class="gensan-card" id="gensan"><img src="../preview-724/assets/gensan-main.png" alt="教えて源さん"><div class="gensan-copy"><h2>教えて源さん</h2><p>国試で出てくる、わからない用語を<br>その場ですぐ確認。<br>問題・解説からポイントを探します。</p><a href="#feature-preview">わからない言葉を確認してみる</a><small class="card-image-note">※画面イメージです</small></div><ul><li>FIMって<br>何？</li><li>MMTって<br>どういう意味？</li><li>Brunnstrom stage<br>とは？</li></ul></article>
+      <article class="gensan-card" id="gensan"><img src="../preview-724/assets/gensan-main.png" alt="教えて源さん"><div class="gensan-copy"><h2>教えて源さん</h2><p>国試で出てくる、わからない用語を<br>その場ですぐ確認。<br>問題・解説からポイントを探します。</p><small class="card-image-note">※画面イメージです</small></div><ul><li>FIMって<br>何？</li><li>MMTって<br>どういう意味？</li><li>Brunnstrom stage<br>とは？</li></ul></article>
       <article class="road-card" id="road"><div class="road-copy"><h2>合格への道</h2><p>現在の学習状況から、次に取り組む内容を提示。<br>日々の学習で、着実にステップアップ。</p><small>※表示内容・数値は画面イメージです</small><a href="#feature-preview">詳しく見る</a></div><div class="road-score"><h3>学習ナビ <em>（画面イメージ）</em></h3><small>総合達成度</small><div class="ring">68%</div></div><div class="week-task"><h3>今週の学習タスク</h3><p>基礎問題を解く <i style="--w:76%"></i><small>20/30問</small></p><p>単語分野の練習 <i style="--w:62%"></i><small>2/3セット</small></p><p>過去問演習 <i style="--w:48%"></i><small>1/2回</small></p></div></article>
     </div></section>
 


### PR DESCRIPTION
## 目的
PC版「教えて源さん」カードで、不要な「わからない言葉を確認してみる」リンクが本文と重なり、最後の「す。」が見えなくなる問題を修正します。

## 変更
- PC版の該当CTAリンクを削除
- 本文「問題・解説からポイントを探します。」をそのまま表示できるようにする
- スマホ版は変更しない

## 変更範囲
- `preview-pc/index.html` のみ
- CSS、カード高さ、他セクションは変更しない
