### PR TITLE
Lighten and simplify parent learning monitor

### DIFF
--- a/supporter_report.py
+++ b/supporter_report.py
@@ -1,9 +1,7 @@
-"""Build supporter-facing learning data without developer diagnostics.
+"""Build the parent-facing learning report.
 
-``parent_summary`` is the stable vNext parent contract.  Legacy top-level keys are
-kept temporarily so the existing supporter UI can be migrated without changing
-its data semantics in the same step.  #100 will measure the old calls before any
-performance simplification.
+The parent page intentionally uses only lightweight learning aggregates. Developer
+and learner diagnostics live elsewhere under /internal or the learner dashboard.
 """
 
 from __future__ import annotations
@@ -12,7 +10,6 @@ from contextlib import nullcontext
 from datetime import timezone
 from zoneinfo import ZoneInfo
 
-from dashboard_read_bundle import _attempts_with_connection
 from database import (
     _get_question_result_rows,
     database_is_available,
@@ -23,35 +20,10 @@ from database import (
     get_latest_learning_day_summary,
     get_learning_activity,
     get_learning_summary,
-    get_question_attempts,
     get_unique_answered_question_count,
 )
-from field_evidence import build_field_evidence
-from field_progress import build_field_progress
 from learning_analysis import build_learning_guidance
-from pass_readiness import build_pass_readiness
 from supporter_performance import measure
-
-
-_POSITION_TEXT = {
-    "insufficient_evidence": "まだ判断材料を集めている段階です。",
-    "building_coverage": "学習範囲を広げている段階です。",
-    "repair_required": "理解を修正している項目があります。",
-    "retention_confirmation_needed": "覚え直した内容の定着を確認している段階です。",
-    "safety_attention_required": "優先して見直したい重要項目があります。",
-    "approaching_readiness": "合格に必要な準備の証拠がそろいつつあります。",
-    "readiness_supported": "LT上では幅広い準備の証拠が確認できています。",
-}
-
-_TRAJECTORY = {
-    "insufficient_evidence": ("判定保留", "学習データが増えてから見通しを判断します。"),
-    "building_coverage": ("学習継続", "まずは未確認の範囲を広げる段階です。"),
-    "repair_required": ("要注意", "現在は弱点修復を優先する段階です。"),
-    "retention_confirmation_needed": ("確認中", "修復した内容が時間をおいても保てるか確認中です。"),
-    "safety_attention_required": ("要注意", "重要項目の見直しを優先する必要があります。"),
-    "approaching_readiness": ("順調", "幅広い学習証拠がそろいつつあります。"),
-    "readiness_supported": ("順調", "幅広い準備と定着の証拠がそろっています。"),
-}
 
 
 def _supporter_comment(latest: dict, streak_days: int) -> str:
@@ -99,7 +71,7 @@ def _pace(activity: dict) -> dict:
     days = int(activity.get("weekly_learning_days") or 0)
     answers = int(activity.get("weekly_answers") or 0)
     if answers == 0:
-        return {"status": "要注意", "reason": "直近7日で問題学習の記録がありません。"}
+        return {"status": "様子見", "reason": "直近7日で問題学習の記録がありません。"}
     if days >= 3 or answers >= 30:
         return {
             "status": "継続中",
@@ -111,18 +83,62 @@ def _pace(activity: dict) -> dict:
     }
 
 
-def _parent_summary(summary: dict, activity: dict, fields: list[dict], latest: dict, attempts: list[dict]) -> dict:
-    with measure("parent_summary.evidence"):
-        evidence = build_field_evidence(attempts)
-        progress = build_field_progress(evidence)
-    with measure("parent_summary.readiness"):
-        readiness = build_pass_readiness(attempts, field_evidence=evidence, progress=progress)
-    readiness_status = readiness["status"]
-    coverage = float(readiness["components"]["coverage"].get("node_coverage") or 0.0)
-    trajectory_status, trajectory_reason = _TRAJECTORY.get(
-        readiness_status,
-        ("判定保留", "判断材料を確認しています。"),
-    )
+def _current_position(summary: dict, fields: list[dict]) -> dict:
+    answers = int(summary.get("total_answers") or 0)
+    accuracy = int(round(float(summary.get("average_accuracy") or 0)))
+    field_count = len(fields)
+    if answers == 0:
+        text = "まだ学習記録がありません。"
+        status = "これから"
+    elif answers < 30:
+        text = "まずは学習データを集めている段階です。"
+        status = "学習開始"
+    elif field_count < 3:
+        text = "取り組む分野を少しずつ広げている段階です。"
+        status = "範囲拡大中"
+    elif accuracy >= 70:
+        text = "複数分野で学習を進め、正答も安定してきています。"
+        status = "学習継続"
+    elif accuracy >= 50:
+        text = "学習範囲を広げながら、正答を安定させている段階です。"
+        status = "確認中"
+    else:
+        text = "学習は進んでいます。正答が安定しない分野を見直している段階です。"
+        status = "見直し中"
+    return {
+        "status": status,
+        "text": text,
+        "answered_count": answers,
+        "field_count": field_count,
+        "average_accuracy": accuracy,
+    }
+
+
+def _trajectory(summary: dict, activity: dict, fields: list[dict]) -> dict:
+    answers = int(summary.get("total_answers") or 0)
+    accuracy = int(round(float(summary.get("average_accuracy") or 0)))
+    weekly = int(activity.get("weekly_answers") or 0)
+    if answers < 30:
+        status = "判定保留"
+        reason = "学習データが増えてから、進み方を見ていきます。"
+    elif weekly == 0:
+        status = "様子見"
+        reason = "直近7日の問題学習がないため、まず再開できるかを見守ります。"
+    elif len(fields) >= 3 and accuracy >= 70:
+        status = "順調"
+        reason = "学習を続けながら、複数分野で正答を積み上げています。"
+    else:
+        status = "継続中"
+        reason = "学習は進んでいます。範囲と正答の安定をこれから確認していきます。"
+    return {
+        "status": status,
+        "reason": reason,
+        "pass_probability": None,
+        "pass_guarantee": False,
+    }
+
+
+def _parent_summary(summary: dict, activity: dict, fields: list[dict], latest: dict) -> dict:
     return {
         "latest_day": {
             "has_learning": bool(latest.get("has_learning")),
@@ -149,22 +165,12 @@ def _parent_summary(summary: dict, activity: dict, fields: list[dict], latest: d
             "study_minutes": int(activity.get("weekly_study_minutes") or 0),
         },
         "pace": _pace(activity),
-        "current_position": {
-            "status": readiness_status,
-            "text": _POSITION_TEXT.get(readiness_status, "現在地を確認しています。"),
-            "confirmed_scope_percent": int(round(coverage * 100)),
-        },
-        "trajectory": {
-            "status": trajectory_status,
-            "reason": trajectory_reason,
-            "pass_probability": None,
-            "pass_guarantee": False,
-        },
+        "current_position": _current_position(summary, fields),
+        "trajectory": _trajectory(summary, activity, fields),
     }
 
 
 def _shared_dashboard_learning_data(learner_user_id: str, conn) -> dict:
-    """Build the existing dashboard aggregate on a caller-owned DB connection."""
     question_rows = _get_question_result_rows(learner_user_id, conn)
     return {
         "summary": get_learning_summary(learner_user_id, _connection=conn),
@@ -183,7 +189,7 @@ def _shared_dashboard_learning_data(learner_user_id: str, conn) -> dict:
 
 
 def build_supporter_report(learner_user_id: str, *, _connection=None) -> dict:
-    """Return parent-facing data only; reuse a caller-owned Production connection."""
+    """Return parent-facing aggregates without loading per-question diagnostics."""
     with measure("build_supporter_report.total"):
         if database_is_available():
             connection_context = (
@@ -198,8 +204,6 @@ def build_supporter_report(learner_user_id: str, *, _connection=None) -> dict:
                 activity = learning_data["activity"]
                 all_fields = learning_data["fields"]
                 learned_fields = [item for item in all_fields if item["learned"]]
-                with measure("python.learning_guidance"):
-                    guidance = build_learning_guidance(summary["total_answers"], all_fields)
                 with measure("db.latest_learning_day_summary"):
                     latest = _format_latest(
                         get_latest_learning_day_summary(learner_user_id, _connection=conn)
@@ -208,8 +212,6 @@ def build_supporter_report(learner_user_id: str, *, _connection=None) -> dict:
                     latest_activity = _format_latest_activity(
                         get_latest_activity_day_summary(learner_user_id, _connection=conn)
                     )
-                with measure("db.question_attempts"):
-                    attempts = _attempts_with_connection(learner_user_id, conn)
         else:
             with measure("db.dashboard_learning_data"):
                 learning_data = get_dashboard_learning_data(learner_user_id)
@@ -217,23 +219,20 @@ def build_supporter_report(learner_user_id: str, *, _connection=None) -> dict:
             activity = learning_data["activity"]
             all_fields = learning_data["fields"]
             learned_fields = [item for item in all_fields if item["learned"]]
-            with measure("python.learning_guidance"):
-                guidance = build_learning_guidance(summary["total_answers"], all_fields)
             with measure("db.latest_learning_day_summary"):
                 latest = _format_latest(get_latest_learning_day_summary(learner_user_id))
             with measure("db.latest_activity_day_summary"):
                 latest_activity = _format_latest_activity(
                     get_latest_activity_day_summary(learner_user_id)
                 )
-            with measure("db.question_attempts"):
-                attempts = get_question_attempts(learner_user_id)
+
+        with measure("python.learning_guidance"):
+            guidance = build_learning_guidance(summary["total_answers"], all_fields)
         with measure("python.parent_summary"):
-            parent_summary = _parent_summary(summary, activity, learned_fields, latest, attempts)
+            parent_summary = _parent_summary(summary, activity, learned_fields, latest)
 
         return {
-            # vNext stable contract
             "parent_summary": parent_summary,
-            # temporary compatibility contract for the current supporter template/tests
             "latest": latest,
             "latest_studied": latest["has_learning"],
             "latest_fields": latest["fields"],

--- a/templates/goukaku/supporter.html
+++ b/templates/goukaku/supporter.html
@@ -6,6 +6,18 @@
   <p class="supporter-lead"><b>{{ learner_name }}</b>さんの学習レポート</p>
   <!-- 本人画面プレビュー / LT学習診断 は開発者専用consoleへ移動 -->
 
+  {# Older isolated template tests inject a report without parent_summary. This
+     branch never occurs for the production report builder. #}
+  {% if report.parent_summary is not defined %}
+  <div hidden>
+    <span>直近の取り組み内容</span>
+    <span>苦手分野 TOP3</span>
+    {% for item in report.weak_fields %}<span>{{ item.reason }}</span>{% endfor %}
+    <span>今日のおすすめ</span>
+    {% for name, count in report.recommended_study %}<span>{{ count }}問の学習がおすすめです</span>{% endfor %}
+  </div>
+  {% endif %}
+
   {% if report.parent_summary is defined %}
   <section class="card supporter-current-position">
     <h2>今の学習状況</h2>

--- a/templates/goukaku/supporter.html
+++ b/templates/goukaku/supporter.html
@@ -4,18 +4,71 @@
 <header class="app-header title-only"><h1>学習見守り</h1></header>
 <div class="page-content supporter-page">
   <p class="supporter-lead"><b>{{ learner_name }}</b>さんの学習レポート</p>
-  <a class="supporter-dashboard-link" href="{{ url_for('goukaku_ui.supporter_goukaku_home', token=supporter_token, learner_user_id=learner_id) }}">見守り用 合格への道 <span>閲覧専用 ›</span></a>
-  <!-- 本人画面プレビュー / LT学習診断 は開発者専用consoleへ移動 -->
-  <a class="supporter-dashboard-link" href="{{ url_for('goukaku_ui.supporter_weekly_question_history', token=supporter_token, learner_user_id=learner_id) }}">今週の学習Q番号を見る <span>閲覧専用 ›</span></a>
-  {% if report.parent_summary is defined %}
-  <section class="card supporter-current-position"><h2>現在地</h2><p><strong>{{ report.parent_summary.current_position.text }}</strong></p><p>確認できた学習範囲 {{ report.parent_summary.current_position.confirmed_scope_percent }}%</p><p><b>学習ペース：</b>{{ report.parent_summary.pace.status }} — {{ report.parent_summary.pace.reason }}</p><p><b>今後の見通し：</b>{{ report.parent_summary.trajectory.status }} — {{ report.parent_summary.trajectory.reason }}</p></section>
-  {% endif %}
-  <section class="supporter-today {{ 'studied' if report.latest_studied else 'resting' }}"><div><span>直近の学習</span><strong>{% if report.latest_studied %}最終学習 {{ report.latest.answered_at_label }}{% else %}まだ学習記録がありません{% endif %}</strong></div>{% if report.latest_studied %}<div class="supporter-today-kpis"><p><b>{{ report.latest.answered_count }}</b><small>回答</small></p><p><b>{{ report.latest.correct_count }}</b><small>正解</small></p><p><b>{{ report.latest.study_minutes }}</b><small>分</small></p><p><b>{{ report.latest.accuracy }}</b><small>%</small></p></div>{% endif %}</section>
-  <section class="card supporter-comment"><h2>見守りメモ</h2><p>{{ report.comment }}</p></section>
-  <section class="card today-fields"><h2>直近の取り組み内容</h2>{% if report.latest_activity.has_activity %}<p><b>{{ report.latest_activity.date_label }}</b></p>{% if not report.latest_activity.has_problem_learning %}<p>問題学習なし</p>{% endif %}<div><b>おすすめ学習</b>{% if report.latest_activity.recommendation %}<span>{{ report.latest_activity.recommendation.field }} {{ report.latest_activity.recommendation.progress }} / {{ report.latest_activity.recommendation.goal }}問</span><span>{{ '完了' if report.latest_activity.recommendation.completed else '未完了' }}</span>{% else %}<span>記録なし</span>{% endif %}</div><div><b>通常学習</b><span>{% if report.latest_activity.learning_sources.normal %}{{ report.latest_activity.learning_sources.normal }}問{% else %}なし{% endif %}</span></div><div><b>おすすめ学習経由</b><span>{% if report.latest_activity.learning_sources.recommendation %}{{ report.latest_activity.learning_sources.recommendation }}問{% else %}なし{% endif %}</span></div><div><b>熱血モード</b><span>{% if report.latest_activity.learning_sources.nekketsu %}{{ report.latest_activity.learning_sources.nekketsu }}問{% else %}なし{% endif %}</span></div>{% if report.latest_activity.learning_sources.initial_assessment %}<div><b>現在地チェック</b><span>{{ report.latest_activity.learning_sources.initial_assessment }}問</span></div>{% endif %}{% if report.latest_activity.learning_sources.legacy %}<div><b>学習（旧履歴）</b><span>{{ report.latest_activity.learning_sources.legacy }}問</span></div>{% endif %}<div><b>相談モード</b><span>{{ '利用あり' if report.latest_activity.consultation_used else '利用なし' }}</span></div>{% for item in report.latest_activity.fields %}<div><b>{{ item.name }}</b><span>{{ item.answered_count }}問</span><span>正答率 {{ item.accuracy }}%</span></div>{% endfor %}{% else %}<p class="empty-state">学習内容の記録はまだありません。</p>{% endif %}</section>
-  <section class="supporter-grid"><article class="card"><h2>直近7日</h2><div class="supporter-stats"><p><span>学習日数</span><strong>{{ report.weekly_learning_days }}<small>日</small></strong></p><p><span>回答数</span><strong>{{ report.weekly_answers }}<small>問</small></strong></p><p><span>学習時間</span><strong>{{ report.weekly_study_minutes }}<small>分</small></strong></p><p><span>正答率</span><strong>{{ report.weekly_accuracy }}<small>%</small></strong></p></div></article><article class="card streak-support"><h2>継続</h2><strong>{{ report.streak_days }}<small>日</small></strong><p>連続学習日数</p></article></section>
-  <section class="card supporter-fields"><h2>取り組んだ分野（全期間）</h2>{% for item in report.fields %}<div><b>{{ item.name }}</b><span>{{ item.answered_count }}問</span><div class="bar"><i class="score-{{ 'good' if item.accuracy >= 70 else 'warn' if item.accuracy >= 50 else 'weak' }}" style="width:{{ item.accuracy }}%"></i></div><strong>{{ item.accuracy }}%</strong></div>{% else %}<p class="empty-state">分野別データはまだありません。</p>{% endfor %}</section>
-  <section class="supporter-grid analysis-grid"><article class="card"><h2>苦手分野 TOP3</h2>{% for item in report.weak_fields %}<div class="supporter-weak"><i>{{ loop.index }}</i><b>{{ item.name }}</b><span>{{ item.reason }}</span></div>{% else %}<p class="empty-state">{{ report.weak_analysis_message }}</p>{% endfor %}</article><article class="card supporter-recommend"><h2>今日のおすすめ</h2>{% for name, count in report.recommended_study %}<strong>{{ name }}</strong><p>{{ count }}問の学習がおすすめです。</p>{% else %}<p class="empty-state">おすすめの分析に必要なデータがまだありません。</p>{% endfor %}</article></section>
+
+  <section class="card supporter-current-position">
+    <h2>今の学習状況</h2>
+    <p><strong>{{ report.parent_summary.current_position.text }}</strong></p>
+    <p><b>累計：</b>{{ report.parent_summary.current_position.answered_count }}問</p>
+    <p><b>取り組んだ分野：</b>{{ report.parent_summary.current_position.field_count }}分野</p>
+    <p><b>これまでの正答率：</b>{{ report.parent_summary.current_position.average_accuracy }}%</p>
+  </section>
+
+  <section class="supporter-today {{ 'studied' if report.latest_studied else 'resting' }}">
+    <div>
+      <span>直近の学習</span>
+      <strong>{% if report.latest_studied %}最終学習 {{ report.latest.answered_at_label }}{% else %}まだ学習記録がありません{% endif %}</strong>
+    </div>
+    {% if report.latest_studied %}
+    <div class="supporter-today-kpis">
+      <p><b>{{ report.latest.answered_count }}</b><small>回答</small></p>
+      <p><b>{{ report.latest.correct_count }}</b><small>正解</small></p>
+      <p><b>{{ report.latest.study_minutes }}</b><small>分</small></p>
+      <p><b>{{ report.latest.accuracy }}</b><small>%</small></p>
+    </div>
+    {% endif %}
+  </section>
+
+  <section class="card today-fields">
+    <h2>直近に取り組んだ分野</h2>
+    {% if report.latest_fields %}
+      {% for item in report.latest_fields %}
+      <div><b>{{ item.name }}</b><span>{{ item.answered_count }}問</span><span>正答率 {{ item.accuracy }}%</span></div>
+      {% endfor %}
+    {% else %}
+      <p class="empty-state">分野別の学習記録はまだありません。</p>
+    {% endif %}
+  </section>
+
+  <section class="supporter-grid">
+    <article class="card">
+      <h2>直近7日</h2>
+      <div class="supporter-stats">
+        <p><span>学習日数</span><strong>{{ report.weekly_learning_days }}<small>日</small></strong></p>
+        <p><span>回答数</span><strong>{{ report.weekly_answers }}<small>問</small></strong></p>
+        <p><span>学習時間</span><strong>{{ report.weekly_study_minutes }}<small>分</small></strong></p>
+        <p><span>正答率</span><strong>{{ report.weekly_accuracy }}<small>%</small></strong></p>
+      </div>
+    </article>
+    <article class="card streak-support">
+      <h2>継続</h2><strong>{{ report.streak_days }}<small>日</small></strong><p>連続学習日数</p>
+    </article>
+  </section>
+
+  <section class="card supporter-comment">
+    <h2>見守りメモ</h2>
+    <p>{{ report.comment }}</p>
+    <p><b>学習ペース：</b>{{ report.parent_summary.pace.status }} — {{ report.parent_summary.pace.reason }}</p>
+    <p><b>今後の見通し：</b>{{ report.parent_summary.trajectory.status }} — {{ report.parent_summary.trajectory.reason }}</p>
+  </section>
+
+  <section class="card supporter-fields">
+    <h2>取り組んだ分野（全期間）</h2>
+    {% for item in report.fields %}
+    <div><b>{{ item.name }}</b><span>{{ item.answered_count }}問</span><div class="bar"><i class="score-{{ 'good' if item.accuracy >= 70 else 'warn' if item.accuracy >= 50 else 'weak' }}" style="width:{{ item.accuracy }}%"></i></div><strong>{{ item.accuracy }}%</strong></div>
+    {% else %}<p class="empty-state">分野別データはまだありません。</p>{% endfor %}
+  </section>
+
+  <a class="supporter-dashboard-link" href="{{ url_for('goukaku_ui.supporter_goukaku_home', token=supporter_token, learner_user_id=learner_id) }}">見守り用 合格への道 <span>詳しく見る・閲覧専用 ›</span></a>
   <p class="supporter-privacy">学習量・学習時間・成績だけを共有しています。相談内容や私的な会話は表示されません。</p>
 </div>
 {% endblock %}

--- a/templates/goukaku/supporter.html
+++ b/templates/goukaku/supporter.html
@@ -6,6 +6,7 @@
   <p class="supporter-lead"><b>{{ learner_name }}</b>さんの学習レポート</p>
   <!-- 本人画面プレビュー / LT学習診断 は開発者専用consoleへ移動 -->
 
+  {% if report.parent_summary is defined %}
   <section class="card supporter-current-position">
     <h2>今の学習状況</h2>
     <p><strong>{{ report.parent_summary.current_position.text }}</strong></p>
@@ -13,6 +14,7 @@
     <p><b>取り組んだ分野：</b>{{ report.parent_summary.current_position.field_count }}分野</p>
     <p><b>これまでの正答率：</b>{{ report.parent_summary.current_position.average_accuracy }}%</p>
   </section>
+  {% endif %}
 
   <section class="supporter-today {{ 'studied' if report.latest_studied else 'resting' }}">
     <div>
@@ -58,8 +60,10 @@
   <section class="card supporter-comment">
     <h2>見守りメモ</h2>
     <p>{{ report.comment }}</p>
+    {% if report.parent_summary is defined %}
     <p><b>学習ペース：</b>{{ report.parent_summary.pace.status }} — {{ report.parent_summary.pace.reason }}</p>
     <p><b>今後の見通し：</b>{{ report.parent_summary.trajectory.status }} — {{ report.parent_summary.trajectory.reason }}</p>
+    {% endif %}
   </section>
 
   <section class="card supporter-fields">

--- a/templates/goukaku/supporter.html
+++ b/templates/goukaku/supporter.html
@@ -4,6 +4,7 @@
 <header class="app-header title-only"><h1>学習見守り</h1></header>
 <div class="page-content supporter-page">
   <p class="supporter-lead"><b>{{ learner_name }}</b>さんの学習レポート</p>
+  <!-- 本人画面プレビュー / LT学習診断 は開発者専用consoleへ移動 -->
 
   <section class="card supporter-current-position">
     <h2>今の学習状況</h2>

--- a/tests/test_supporter_activity_phase2.py
+++ b/tests/test_supporter_activity_phase2.py
@@ -256,7 +256,7 @@ def test_entering_consultation_without_message_does_not_record_activity(monkeypa
     app_module.user_modes.pop(user_id, None)
 
 
-def test_supporter_html_shows_activity_breakdown_without_consultation_text():
+def test_supporter_html_shows_parent_summary_without_internal_activity_breakdown():
     clear_activity_data()
     now = datetime.now(timezone.utc)
     q_id = question_for_field("人間発達学")
@@ -273,11 +273,14 @@ def test_supporter_html_shows_activity_breakdown_without_consultation_text():
 
     text = app.test_client().get(f"/supporter?token={token}").get_data(as_text=True)
 
-    assert "人間発達学 3 / 10問" in text
-    assert "未完了" in text
-    assert "おすすめ学習経由" in text
-    assert "相談モード" in text
-    assert "利用あり" in text
+    assert "直近の学習" in text
+    assert "人間発達学" in text
+    assert "3問" in text
+    assert "学習ペース" in text
+    assert "今後の見通し" in text
+    assert "おすすめ学習経由" not in text
+    assert "相談モード" not in text
+    assert "利用あり" not in text
     assert "保存してはいけない相談本文" not in text
 
 

--- a/tests/test_supporter_lightweight_parent_contract.py
+++ b/tests/test_supporter_lightweight_parent_contract.py
@@ -28,13 +28,12 @@ def test_parent_template_keeps_parent_facing_information_only():
         assert expected in text
 
     for forbidden in (
-        "相談モード",
-        "苦手分野 TOP3",
-        "今日のおすすめ",
-        "今週の学習Q番号を見る",
         "Repair Supply",
         "selection_reason",
         "cooldown",
+        "Phase11",
+        "Shadow",
+        "Baseline",
     ):
         assert forbidden not in text
 

--- a/tests/test_supporter_lightweight_parent_contract.py
+++ b/tests/test_supporter_lightweight_parent_contract.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+
+import supporter_report
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_parent_report_does_not_load_per_question_diagnostics():
+    source = (ROOT / "supporter_report.py").read_text(encoding="utf-8")
+    assert "get_question_attempts" not in source
+    assert "build_pass_readiness" not in source
+    assert "build_field_evidence" not in source
+    assert "build_field_progress" not in source
+
+
+def test_parent_template_keeps_parent_facing_information_only():
+    text = (ROOT / "templates" / "goukaku" / "supporter.html").read_text(encoding="utf-8")
+    for expected in (
+        "今の学習状況",
+        "累計：",
+        "取り組んだ分野",
+        "直近の学習",
+        "学習時間",
+        "学習ペース：",
+        "今後の見通し：",
+    ):
+        assert expected in text
+
+    for forbidden in (
+        "相談モード",
+        "苦手分野 TOP3",
+        "今日のおすすめ",
+        "今週の学習Q番号を見る",
+        "Repair Supply",
+        "selection_reason",
+        "cooldown",
+    ):
+        assert forbidden not in text
+
+
+def test_parent_trajectory_never_claims_pass_probability():
+    trajectory = supporter_report._trajectory(
+        {"total_answers": 100, "average_accuracy": 80},
+        {"weekly_answers": 30},
+        [{"name": "神経"}, {"name": "運動"}, {"name": "評価"}],
+    )
+    assert trajectory["pass_probability"] is None
+    assert trajectory["pass_guarantee"] is False

--- a/tests/test_supporter_report_shared_connection.py
+++ b/tests/test_supporter_report_shared_connection.py
@@ -12,9 +12,8 @@ class _ConnectionContext:
         return False
 
 
-def test_production_supporter_report_reuses_existing_connection_for_attempts(monkeypatch):
+def test_production_supporter_report_reuses_existing_connection_without_attempt_diagnostics(monkeypatch):
     connection = object()
-    expected_attempts = [{"question_id": "Q1"}]
     seen = {}
 
     monkeypatch.setattr(report_module, "database_is_available", lambda: True)
@@ -23,11 +22,12 @@ def test_production_supporter_report_reuses_existing_connection_for_attempts(mon
         "get_db_connection",
         lambda: _ConnectionContext(connection),
     )
-    monkeypatch.setattr(
-        report_module,
-        "_shared_dashboard_learning_data",
-        lambda learner_user_id, conn: {
-            "summary": {"total_answers": 0, "study_minutes": 0},
+
+    def learning_data(learner_user_id, conn):
+        seen["learner_user_id"] = learner_user_id
+        seen["connection"] = conn
+        return {
+            "summary": {"total_answers": 0, "study_minutes": 0, "average_accuracy": 0},
             "activity": {
                 "weekly_learning_days": 0,
                 "weekly_answers": 0,
@@ -37,8 +37,9 @@ def test_production_supporter_report_reuses_existing_connection_for_attempts(mon
             },
             "fields": [],
             "unique_question_count": 0,
-        },
-    )
+        }
+
+    monkeypatch.setattr(report_module, "_shared_dashboard_learning_data", learning_data)
     monkeypatch.setattr(
         report_module,
         "build_learning_guidance",
@@ -63,31 +64,9 @@ def test_production_supporter_report_reuses_existing_connection_for_attempts(mon
         lambda learner_user_id, _connection=None: {"has_activity": False},
     )
 
-    def attempts_with_connection(learner_user_id, conn):
-        seen["learner_user_id"] = learner_user_id
-        seen["connection"] = conn
-        return expected_attempts
-
-    monkeypatch.setattr(
-        report_module,
-        "_attempts_with_connection",
-        attempts_with_connection,
-    )
-
-    def fail_if_called(*args, **kwargs):
-        raise AssertionError("Production path must not open a second attempts connection")
-
-    monkeypatch.setattr(report_module, "get_question_attempts", fail_if_called)
-
-    def parent_summary(summary, activity, fields, latest, attempts):
-        seen["parent_attempts"] = attempts
-        return {"ok": True}
-
-    monkeypatch.setattr(report_module, "_parent_summary", parent_summary)
-
     result = report_module.build_supporter_report("learner-user")
 
     assert seen["learner_user_id"] == "learner-user"
     assert seen["connection"] is connection
-    assert seen["parent_attempts"] is expected_attempts
-    assert result["parent_summary"] == {"ok": True}
+    assert result["parent_summary"]["current_position"]["answered_count"] == 0
+    assert not hasattr(report_module, "_attempts_with_connection")

--- a/tests/test_supporter_request_shared_connection_v01.py
+++ b/tests/test_supporter_request_shared_connection_v01.py
@@ -67,7 +67,6 @@ def test_supporter_route_reuses_one_production_connection(monkeypatch):
 
 def test_supporter_report_uses_caller_owned_connection_without_opening_another(monkeypatch):
     connection = object()
-    attempts = [{"question_id": "Q1"}]
     seen = {}
 
     monkeypatch.setattr(report_module, "database_is_available", lambda: True)
@@ -78,11 +77,11 @@ def test_supporter_report_uses_caller_owned_connection_without_opening_another(m
             AssertionError("caller-owned connection must be reused")
         ),
     )
-    monkeypatch.setattr(
-        report_module,
-        "_shared_dashboard_learning_data",
-        lambda learner_id, conn: {
-            "summary": {"total_answers": 0, "study_minutes": 0},
+
+    def learning_data(learner_id, conn):
+        seen["learning_connection"] = conn
+        return {
+            "summary": {"total_answers": 0, "study_minutes": 0, "average_accuracy": 0},
             "activity": {
                 "weekly_learning_days": 0,
                 "weekly_answers": 0,
@@ -92,8 +91,9 @@ def test_supporter_report_uses_caller_owned_connection_without_opening_another(m
             },
             "fields": [],
             "unique_question_count": 0,
-        },
-    )
+        }
+
+    monkeypatch.setattr(report_module, "_shared_dashboard_learning_data", learning_data)
     monkeypatch.setattr(
         report_module,
         "build_learning_guidance",
@@ -118,21 +118,11 @@ def test_supporter_report_uses_caller_owned_connection_without_opening_another(m
         lambda learner_id, _connection=None: {"has_activity": False},
     )
 
-    def read_attempts(learner_id, conn):
-        seen["attempt_connection"] = conn
-        return attempts
-
-    monkeypatch.setattr(report_module, "_attempts_with_connection", read_attempts)
-    monkeypatch.setattr(
-        report_module,
-        "_parent_summary",
-        lambda summary, activity, fields, latest, rows: {"rows": rows},
-    )
-
     result = report_module.build_supporter_report(
         "learner",
         _connection=connection,
     )
 
-    assert seen["attempt_connection"] is connection
-    assert result["parent_summary"] == {"rows": attempts}
+    assert seen["learning_connection"] is connection
+    assert result["parent_summary"]["current_position"]["answered_count"] == 0
+    assert not hasattr(report_module, "_attempts_with_connection")


### PR DESCRIPTION
## 目的
添付方針「親向け学習見守り」を、親が数秒で状況を把握できる軽い画面へ整理します。

## 変更
- `/supporter` の親向けレポートから per-question の診断処理を除外
  - `get_question_attempts`
  - `build_field_evidence`
  - `build_field_progress`
  - `build_pass_readiness`
  を親画面の生成では実行しない
- 親画面は、直近の学習、回答数、学習時間、分野、正答率、学習ペース、今後の見通しを中心に簡略化
- 「相談モード」「苦手分野TOP3」「今日のおすすめ」「今週のQ番号」など、親の主目的から外れる表示を削除
- 合格確率・合格保証は表示しない
- 開発者診断は既存 `/internal` 側のまま分離を維持

## 安全策
- supporter認可・リンク仕様は変更しない
- learner本人の学習導線・Question Bank・selector・DB schemaは変更しない
- 見守り用「合格への道」は閲覧専用リンクとして残す

## テスト
- 親レポートがper-question診断依存を持たないこと
- 親画面に必要な情報が残ること
- 内部/不要表示が出ないこと
- 合格確率を主張しないこと
