### PR TITLE
Expand developer console with read-only system status

### DIFF
--- a/developer_status.py
+++ b/developer_status.py
@@ -1,0 +1,120 @@
+"""Read-only status summary for the LicenseTown internal developer console.
+
+This module intentionally reads only repository files and non-secret feature-flag
+presence. It never opens Production DB connections and never exposes secret
+values. The internal console can therefore show high-level system health without
+adding work to learner or supporter routes.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent
+BANK_DIR = ROOT / "data" / "question_bank"
+MANIFEST_PATH = BANK_DIR / "bank_manifest.json"
+TAG_AUDIT_PATH = BANK_DIR / "question_tags_audit.txt"
+
+_TRUE_VALUES = {"1", "true", "yes", "on"}
+
+
+def _flag(name: str) -> bool:
+    return os.getenv(name, "").strip().lower() in _TRUE_VALUES
+
+
+def _read_manifest() -> dict:
+    try:
+        payload = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    except (OSError, ValueError, TypeError):
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _read_audit_text() -> str:
+    try:
+        return TAG_AUDIT_PATH.read_text(encoding="utf-8")
+    except OSError:
+        return ""
+
+
+def _extract_int(text: str, pattern: str) -> int | None:
+    match = re.search(pattern, text, re.MULTILINE)
+    return int(match.group(1)) if match else None
+
+
+def _audit_summary(text: str) -> dict:
+    errors = _extract_int(text, r"^errors:\s*(\d+)\s*$")
+    return {
+        "records": _extract_int(text, r"^records:\s*(\d+)\s*$"),
+        "errors": errors,
+        "status": "PASS" if errors == 0 else ("WARN" if errors is not None else "UNKNOWN"),
+        "original": _extract_int(text, r"^\s*original:\s*(\d+)"),
+        "past_exam": _extract_int(text, r"^\s*past_exam:\s*(\d+)"),
+        "safety_critical": _extract_int(text, r"^\s*critical:\s*(\d+)"),
+        "safety_moderate": _extract_int(text, r"^\s*moderate:\s*(\d+)"),
+        "canonical_registry": _extract_int(text, r"^\s*registry nodes:\s*(\d+)"),
+        "canonical_represented": _extract_int(
+            text, r"^\s*canonical nodes represented by questions:\s*(\d+)"
+        ),
+        "canonical_singleton": _extract_int(text, r"^\s*singleton canonical nodes:\s*(\d+)"),
+        "canonical_multi": _extract_int(text, r"^\s*multi-question canonical nodes:\s*(\d+)"),
+        "shared_groups": _extract_int(text, r"^\s*confirmed-shared registry groups:\s*(\d+)"),
+    }
+
+
+def build_developer_system_status() -> dict:
+    """Return a compact developer-only status snapshot without DB/network I/O."""
+    manifest = _read_manifest()
+    audit = _audit_summary(_read_audit_text())
+    return {
+        "question_bank": {
+            "version": manifest.get("bank_version") or "unknown",
+            "question_count": manifest.get("question_count"),
+            "first_question_number": manifest.get("first_question_number"),
+            "last_question_number": manifest.get("last_question_number"),
+            **audit,
+        },
+        "feature_flags": {
+            "node_adaptive": _flag("ENABLE_NODE_ADAPTIVE_RECOMMENDATION"),
+            "prerequisite_backtrack": _flag("ENABLE_PREREQUISITE_BACKTRACK"),
+            "learner_perf_log": _flag("LT_LEARNER_PATH_PERF_LOG"),
+            "supporter_perf_log": _flag("LT_SUPPORTER_PERF_LOG"),
+            "rich_menu_apply_once": _flag("LT_APPLY_RICH_MENU_V2_ON_BOOT"),
+        },
+        "capabilities": [
+            {
+                "name": "学習診断",
+                "state": "available",
+                "detail": "Phase11・repeat・cooldownをユーザー単位で確認",
+            },
+            {
+                "name": "本人画面プレビュー",
+                "state": "available",
+                "detail": "開発QA用に合格への道を本人視点で確認",
+            },
+            {
+                "name": "Question Bank監査",
+                "state": "available" if audit.get("status") == "PASS" else "attention",
+                "detail": "正式4ストア・タグ・Knowledge Node整合性の保存済み監査",
+            },
+            {
+                "name": "Knowledge Node / Repair Supply",
+                "state": "available",
+                "detail": "正式データと学習診断から確認可能",
+            },
+            {
+                "name": "性能・エラー監視",
+                "state": "external",
+                "detail": "Renderログで確認。常時の詳細計測ログは原則OFF",
+            },
+            {
+                "name": "DB状態・履歴監査",
+                "state": "external",
+                "detail": "Neon/専用監査から確認。内部トップでは重いDB読込を行わない",
+            },
+        ],
+    }

--- a/developer_ui.py
+++ b/developer_ui.py
@@ -13,6 +13,7 @@ import os
 
 from flask import abort, redirect, render_template, request, url_for
 
+from developer_status import build_developer_system_status
 from goukaku_ui import build_dashboard
 from pilot_diagnostics import build_pilot_diagnostics
 from supporter_performance import begin_request, finish_request
@@ -91,6 +92,7 @@ def register_developer_routes(blueprint) -> None:
             "internal/index.html",
             internal_token=token,
             learner_id=learner_id,
+            system_status=build_developer_system_status(),
             pilot_url=(
                 url_for(
                     "site_ui.internal_pilot_diagnostics",

--- a/templates/internal/index.html
+++ b/templates/internal/index.html
@@ -1,21 +1,111 @@
 <!doctype html>
 <html lang="ja">
-<head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>LicenseTown Internal</title></head>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>LicenseTown Internal</title>
+  <style>
+    :root { color-scheme: light; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    body { margin: 0; background: #f5f7f6; color: #16231b; }
+    main { width: min(1080px, calc(100% - 32px)); margin: 32px auto 64px; }
+    h1 { margin-bottom: 6px; }
+    h2 { margin: 0 0 14px; font-size: 1.08rem; }
+    .muted { color: #5f6d64; }
+    .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 12px; }
+    .card { background: #fff; border: 1px solid #dbe4de; border-radius: 12px; padding: 16px; box-shadow: 0 1px 3px rgba(0,0,0,.04); }
+    .metric { font-size: 1.55rem; font-weight: 700; margin: 6px 0 2px; }
+    .pass { color: #116530; font-weight: 700; }
+    .warn { color: #9b5d00; font-weight: 700; }
+    section { margin-top: 22px; }
+    form { display: flex; flex-wrap: wrap; gap: 10px; align-items: end; }
+    label { display: grid; gap: 5px; font-weight: 600; }
+    input { min-width: min(420px, 72vw); padding: 9px 10px; border: 1px solid #aebbb2; border-radius: 8px; }
+    button, a.action { display: inline-block; border: 0; border-radius: 8px; padding: 10px 14px; background: #176b42; color: #fff; text-decoration: none; font-weight: 700; cursor: pointer; }
+    ul { padding-left: 20px; }
+    li { margin: 7px 0; }
+    .flag { display: flex; justify-content: space-between; gap: 16px; border-bottom: 1px solid #edf1ee; padding: 7px 0; }
+    .flag:last-child { border-bottom: 0; }
+    .on { color: #9b5d00; font-weight: 700; }
+    .off { color: #4c6255; font-weight: 700; }
+    .capability strong { display: block; margin-bottom: 5px; }
+    .capability p { margin: 0; color: #5f6d64; font-size: .92rem; line-height: 1.5; }
+  </style>
+</head>
 <body>
   <main>
     <h1>LicenseTown Internal</h1>
-    <p>開発・診断専用。学習者・見守り画面とは分離されています。</p>
-    <form method="get">
-      <input type="hidden" name="token" value="{{ internal_token }}">
-      <label>learner_user_id <input name="learner_user_id" value="{{ learner_id }}" autocomplete="off"></label>
-      <button type="submit">対象を開く</button>
-    </form>
-    {% if learner_id %}
-    <nav>
-      <p><a href="{{ pilot_url }}">学習診断 / Phase11・repeat・cooldown</a></p>
-      <p><a href="{{ preview_url }}">本人画面プレビュー（開発QA）</a></p>
-    </nav>
-    {% endif %}
+    <p class="muted">開発・診断専用。学習者・親向け「学習見守り」とは、URL・認証・処理・表示を分離しています。</p>
+
+    <section>
+      <h2>システム概要</h2>
+      <div class="grid">
+        <div class="card">
+          <div class="muted">Question Bank</div>
+          <div class="metric">{{ system_status.question_bank.question_count or '—' }}問</div>
+          <div>Q{{ system_status.question_bank.first_question_number or '—' }}〜Q{{ system_status.question_bank.last_question_number or '—' }}</div>
+          <div class="muted">{{ system_status.question_bank.version }}</div>
+        </div>
+        <div class="card">
+          <div class="muted">正式データ監査</div>
+          <div class="metric {{ 'pass' if system_status.question_bank.status == 'PASS' else 'warn' }}">{{ system_status.question_bank.status }}</div>
+          <div>errors: {{ system_status.question_bank.errors if system_status.question_bank.errors is not none else '—' }}</div>
+          <div class="muted">records: {{ system_status.question_bank.records or '—' }}</div>
+        </div>
+        <div class="card">
+          <div class="muted">Knowledge Node</div>
+          <div class="metric">{{ system_status.question_bank.canonical_represented or '—' }}</div>
+          <div>question represented / registry {{ system_status.question_bank.canonical_registry or '—' }}</div>
+          <div class="muted">singleton {{ system_status.question_bank.canonical_singleton or '—' }} / multi {{ system_status.question_bank.canonical_multi or '—' }}</div>
+        </div>
+        <div class="card">
+          <div class="muted">問題ソース</div>
+          <div class="metric">{{ system_status.question_bank.original or '—' }} + {{ system_status.question_bank.past_exam or '—' }}</div>
+          <div>original + past exam</div>
+          <div class="muted">Safety critical {{ system_status.question_bank.safety_critical or '—' }} / moderate {{ system_status.question_bank.safety_moderate or '—' }}</div>
+        </div>
+      </div>
+    </section>
+
+    <section>
+      <div class="card">
+        <h2>ユーザー別診断</h2>
+        <form method="get">
+          <input type="hidden" name="token" value="{{ internal_token }}">
+          <label>learner_user_id
+            <input name="learner_user_id" value="{{ learner_id }}" autocomplete="off" placeholder="診断対象の learner_user_id">
+          </label>
+          <button type="submit">対象を開く</button>
+        </form>
+        {% if learner_id %}
+        <p style="margin-bottom:0;">
+          <a class="action" href="{{ pilot_url }}">学習診断 / Phase11・repeat・cooldown</a>
+          <a class="action" href="{{ preview_url }}">本人画面プレビュー（開発QA）</a>
+        </p>
+        {% endif %}
+      </div>
+    </section>
+
+    <section>
+      <h2>開発ツールの現在地</h2>
+      <div class="grid">
+        {% for item in system_status.capabilities %}
+        <div class="card capability">
+          <strong>{{ item.name }}</strong>
+          <p>{{ item.detail }}</p>
+        </div>
+        {% endfor %}
+      </div>
+    </section>
+
+    <section>
+      <div class="card">
+        <h2>一時機能・計測フラグ</h2>
+        <p class="muted">値そのものや秘密情報は表示しません。ON/OFFだけを確認します。</p>
+        {% for name, enabled in system_status.feature_flags.items() %}
+          <div class="flag"><span>{{ name }}</span><span class="{{ 'on' if enabled else 'off' }}">{{ 'ON' if enabled else 'OFF' }}</span></div>
+        {% endfor %}
+      </div>
+    </section>
   </main>
 </body>
 </html>

--- a/tests/test_developer_status.py
+++ b/tests/test_developer_status.py
@@ -1,0 +1,35 @@
+import developer_status
+
+
+def test_formal_bank_status_matches_frozen_b12_data():
+    status = developer_status.build_developer_system_status()
+    bank = status["question_bank"]
+    assert bank["version"] == "2026-09-b12"
+    assert bank["question_count"] == 1737
+    assert bank["first_question_number"] == 1
+    assert bank["last_question_number"] == 1737
+    assert bank["records"] == 1737
+    assert bank["errors"] == 0
+    assert bank["status"] == "PASS"
+    assert bank["original"] == 643
+    assert bank["past_exam"] == 1094
+
+
+def test_status_reports_knowledge_node_and_safety_counts():
+    bank = developer_status.build_developer_system_status()["question_bank"]
+    assert bank["canonical_registry"] == 1538
+    assert bank["canonical_represented"] == 1508
+    assert bank["canonical_singleton"] == 1305
+    assert bank["canonical_multi"] == 203
+    assert bank["shared_groups"] == 186
+    assert bank["safety_critical"] == 65
+    assert bank["safety_moderate"] == 232
+
+
+def test_feature_flags_are_boolean_and_do_not_expose_values(monkeypatch):
+    monkeypatch.setenv("LT_LEARNER_PATH_PERF_LOG", "true")
+    monkeypatch.setenv("LT_SUPPORTER_PERF_LOG", "false")
+    flags = developer_status.build_developer_system_status()["feature_flags"]
+    assert flags["learner_perf_log"] is True
+    assert flags["supporter_perf_log"] is False
+    assert all(isinstance(value, bool) for value in flags.values())

--- a/tests/test_internal_developer_boundary.py
+++ b/tests/test_internal_developer_boundary.py
@@ -25,6 +25,24 @@ def test_internal_index_accepts_header_token(monkeypatch):
     text = response.get_data(as_text=True)
     assert "/internal/pilot-diagnostics" in text
     assert "/internal/learner-preview" in text
+    assert "システム概要" in text
+    assert "Question Bank" in text
+    assert "正式データ監査" in text
+    assert "Knowledge Node" in text
+    assert "一時機能・計測フラグ" in text
+
+
+def test_internal_index_does_not_render_admin_secret_as_status_value(monkeypatch):
+    monkeypatch.setenv("LT_INTERNAL_ADMIN_TOKEN", "do-not-display-this-token")
+    response = app.test_client().get(
+        "/internal",
+        headers={"X-LT-Developer-Token": "do-not-display-this-token"},
+    )
+    assert response.status_code == 200
+    text = response.get_data(as_text=True)
+    # The token is still carried only in the existing hidden navigation field;
+    # status cards must never describe or echo it as a monitored setting.
+    assert "LT_INTERNAL_ADMIN_TOKEN" not in text
 
 
 def test_developer_authorized_uses_constant_time_comparison(monkeypatch):


### PR DESCRIPTION
## 目的
添付方針の「開発者向け管理画面を開けばLicenseTownの状態がほぼ全部分かる」に向け、既存 `/internal` v0.1 を安全なシステム概要付きコンソールへ拡張します。

## 変更
- `developer_status.py` を追加し、Production DBや外部APIを呼ばずに正式Question Bank/タグ監査の保存済み状態を表示
- Q1〜Q1737、bank version、監査PASS/errors、Knowledge Node/Safety/問題ソース数を内部トップで確認可能にする
- feature/performance one-shot flagsは秘密値を出さずON/OFFだけ表示
- 既存のユーザー別 Phase11/repeat/cooldown 診断と本人画面プレビューを同じ内部コンソールから開ける
- Render/Neon由来の性能・DB監査は「外部運用ソース」と明示し、内部トップを重くしない

## 境界
- `/supporter` の処理・表示は変更しない
- learner/Question Bank/selector/DB schemaは変更しない
- `LT_INTERNAL_ADMIN_TOKEN` 認証を維持し、秘密値をステータス表示しない
- Production DB writeなし

## テスト
- frozen B12 formal data counts/status
- Knowledge Node/Safety counts
- feature flag boolean-only contract
- internal admin boundary and system-status rendering
