### PR TITLE
Clarify current free-validation and future ¥980 position

### DIFF
--- a/docs/commercialization-gap-audit-v04.md
+++ b/docs/commercialization-gap-audit-v04.md
@@ -1,0 +1,138 @@
+# LicenseTown commercialization gap audit v0.4
+
+Date: 2026-09-05
+Status: current product/commercial position after owner clarification
+
+## Purpose
+
+This document supersedes the commercial-position section of v0.3.
+
+LicenseTown has enough technical payment infrastructure to charge later, but **that does not mean it is ready to ask users for money now**.
+
+The product remains in a validation phase. Real users may expose defects, confusing behavior, educational weaknesses, performance issues, or missing safeguards that the current builders cannot see yet. That unknown-risk surface is itself a reason to keep normal use free.
+
+## 1. Current operating model
+
+Current user-facing LicenseTown is **free during validation**.
+
+Operational requirements:
+
+- live Stripe charging: OFF;
+- paid access enforcement: OFF;
+- public subscription offer: not active;
+- future price candidate: **¥980/month**;
+- sandbox Stripe lifecycle: retained as tested future infrastructure;
+- normal learning access must not depend on payment while validation mode is active.
+
+No automatic date or usage threshold should switch LicenseTown to paid mode.
+
+## 2. Why this is the correct commercial stance now
+
+The main unresolved commercial problem is no longer payment plumbing. It is evidence.
+
+We do not yet know enough about:
+
+- how broader learners use the product outside the builder's family;
+- which learner routes still contain hidden state/UX failures;
+- whether `教えて源さん` definitions are consistently useful across many terms;
+- whether recommendation and repair behavior remains understandable over weeks/months;
+- how much parent monitoring is actually valued;
+- what support burden appears with multiple users;
+- what users would reasonably pay for after sustained use.
+
+Charging before those unknowns are reduced would create pressure to defend a product contract before the product has earned that confidence.
+
+Therefore the current success criterion is **better evidence and fewer unknowns**, not conversion revenue.
+
+## 3. Optional development support / 応援
+
+The current public philosophy may include an optional development-support message:
+
+> LicenseTown is still being built and tested. Normal use is not being sold yet. If someone nevertheless wants to support continued development, that support is voluntary.
+
+This must remain separate from access to learning functions.
+
+Any support mechanism must never imply:
+
+- pay to keep using LicenseTown;
+- pay to receive better answers or learning priority;
+- pay because the learner owes the project something;
+- guaranteed completion, results, or pass outcomes;
+- automatic conversion into a future subscription.
+
+Support collection itself remains OFF unless separately approved by the owner. A future voluntary-support flow would need its own truthful payment/legal wording.
+
+## 4. Future paid candidate
+
+If later evidence supports charging, the current one-plan candidate is **¥980/month**.
+
+The likely recurring value is:
+
+- adaptive study continuity;
+- repair/recheck continuity;
+- longitudinal learning history;
+- full `合格への道` evidence/navigation;
+- supported field-study continuity;
+- parent `学習見守り`;
+- Trial100 longitudinal evidence.
+
+The future paid boundary is intentionally **not frozen**. Real use may show that some of these should remain free, that other recurring value matters more, or that the whole contract should change.
+
+`教えて源さん` should not be paywalled merely because it is useful. Its current role is fast exam-term clarification and trust/activation.
+
+## 5. What product work should continue now
+
+The highest-value work while payment remains OFF is:
+
+1. continue natural learner use and record concrete failures/confusions;
+2. improve the definition quality and coverage of `教えて源さん`;
+3. keep learner routes/regression safety stable while making only evidence-backed changes;
+4. use the internal developer console to shorten diagnosis when real-use issues occur;
+5. keep performance measurement targeted to actual slow learner/supporter paths;
+6. invite a very small external validation cohort only when current known issues are acceptable;
+7. measure activation, return use, route failures, confusion, and support burden before discussing real paid conversion.
+
+## 6. What not to do now
+
+Do not:
+
+- enable live Stripe;
+- enable paid enforcement;
+- publish ¥980 as a current subscription price;
+- remove useful learning access to manufacture a free/paid boundary;
+- turn the optional support message into a disguised subscription;
+- re-enable OpenAI billing merely to make the product look more AI-heavy;
+- add broad new features without evidence that they solve a real learner problem;
+- use current family success as proof of market-wide effectiveness.
+
+## 7. Promotion gate to real charging
+
+A paid launch requires a new explicit owner decision after a fresh readiness review.
+
+At minimum, that review should include:
+
+- broader real-user evidence;
+- current known defect list and severity;
+- route reliability evidence;
+- term-explainer quality/coverage evidence;
+- retention/repeat-use evidence;
+- parent value evidence where applicable;
+- actual operating/support cost;
+- willingness-to-pay evidence;
+- current payment fees;
+- final HP/terms/checkout/cancellation/refund consistency;
+- explicit owner approval to accept real money.
+
+Technical readiness alone is not sufficient.
+
+## 8. Current product decision
+
+The correct sequence is now:
+
+**build -> use -> discover -> fix -> validate -> repeat**.
+
+Monetization stays prepared but dormant.
+
+The working commercial position is:
+
+**Use is free while LicenseTown is still proving itself. ¥980/month is the current future-price candidate. Optional development support is separate and voluntary, and no money collection is activated without another explicit owner decision.**

--- a/docs/launch-offer-pricing-v02.md
+++ b/docs/launch-offer-pricing-v02.md
@@ -1,0 +1,107 @@
+# LicenseTown launch offer / pricing position v0.2
+
+Date: 2026-09-05
+Status: owner-approved future-price candidate; **not a current paid offer**
+
+## Owner decision now fixed
+
+The future single-plan candidate is **¥980/month**.
+
+This does **not** mean LicenseTown should start charging now.
+
+The current operating state is:
+
+- LicenseTown is still under real-use validation;
+- current normal use remains free;
+- live Stripe charging remains OFF;
+- paid access enforcement remains OFF;
+- the sandbox payment stack is retained only as future-ready infrastructure and test evidence;
+- no deadline is set for switching to paid use.
+
+## Why payment stays OFF
+
+The product may still contain defects, unclear behavior, educational weaknesses, missing safeguards, performance problems, or other issues that the current builders cannot yet see.
+
+The fact that the known routes work and the sandbox payment lifecycle is proven is not enough evidence to ask users to pay. LicenseTown should first accumulate broader natural-use evidence and fix what real users expose.
+
+The ethical/product rule is therefore:
+
+> **Do not charge for a product while we still reasonably expect important unknown problems to surface through validation.**
+
+## Current support / 応援 position
+
+During the free-validation phase, a person may independently want to support continued development.
+
+That is conceptually separate from a LicenseTown usage fee.
+
+If optional development support is ever enabled, it must be described as voluntary `応援` and must not:
+
+- unlock learning features;
+- remove restrictions that free users otherwise face;
+- be required to continue studying;
+- promise exam success;
+- be presented as the ¥980 future subscription;
+- create pressure that the learner owes payment for receiving help.
+
+Actual money collection for support remains a separate activation decision and must not be enabled implicitly.
+
+## Future ¥980 candidate
+
+If later validation supports a paid launch, the current candidate remains one plan at **¥980/month**.
+
+The likely future paid value is recurring learning-management value rather than access to a static pile of questions:
+
+- ongoing adaptive study continuity;
+- repair/recheck continuity and longitudinal history;
+- full `合格への道` navigation/evidence;
+- learner-selected field study continuity;
+- parent `学習見守り`;
+- Trial100 longitudinal evidence/tracking.
+
+`教えて源さん` term lookup should remain a trust/activation utility rather than being artificially paywalled merely to force conversion.
+
+## Free/paid boundary is not frozen yet
+
+The earlier candidate boundary is useful for architecture and future planning, but it is **not yet the current product contract**.
+
+Before real charging, re-evaluate the boundary using:
+
+1. more than one family/internal learner;
+2. actual external learner feedback;
+3. repeat-use and retention evidence;
+4. defect and support burden observed in real use;
+5. usefulness of parent monitoring;
+6. actual infrastructure/payment/support cost;
+7. willingness to pay;
+8. final legal/payment wording.
+
+A future paid launch may therefore keep, widen, or narrow the proposed free floor.
+
+## Price rationale retained
+
+¥980 remains preferable to the old sandbox ¥1,480 as the first candidate because:
+
+- the direct PT national-exam app market contains many low-cost products;
+- LicenseTown still lacks paid-cohort evidence supporting a premium price;
+- LicenseTown's differentiated value is continuity/direction, not question count alone;
+- core study and the term explainer do not require a per-question OpenAI call.
+
+The ¥980 value is a **future validation price candidate**, not a maturity-value claim and not a current invoice amount.
+
+## Future promotion gate
+
+A move from free validation to paid service requires a new explicit owner go/no-go.
+
+Before that decision:
+
+- keep live Stripe OFF;
+- keep `ENABLE_PAID_ACCESS_ENFORCEMENT` OFF;
+- keep any public support collection OFF unless the owner separately approves a voluntary-support mechanism;
+- do not change the current learner experience merely to prepare monetization;
+- prioritize real use, defect discovery, learning quality, and trust.
+
+Only after those gates are met should HP / terms / checkout / cancellation / refund wording be finalized around a real paid offer.
+
+## Current decision in one sentence
+
+**LicenseTown is free while we validate it; ¥980/month is only the current future-price candidate, and voluntary development support is separate from usage fees.**


### PR DESCRIPTION
## 目的
オーナー判断を正式化します。¥980は将来の候補価格ですが、LicenseTownはまだ検証中であり、現時点では通常利用料を取りません。

## 変更
- `current-free-validation-policy-v01.md` を基準に、現在の運用を「無料検証」と明文化
- `launch-offer-pricing-v02.md` で ¥980 を将来候補に固定しつつ、現在の有料オファーではないと明記
- `commercialization-gap-audit-v04.md` で収益化より実利用・未知不具合の発見・修正を優先
- 「応援」は将来の任意開発支援として利用料/有料機能解放と明確に分離

## 安全境界
- live Stripe変更なし
- paid access enforcement変更なし
- support collection変更なし
- learner/Question Bank/selector/DB変更なし
- documentation only