### PR TITLE
Reuse adaptive attempt history for prerequisite pilot

### DIFF
--- a/prerequisite_attempt_cache.py
+++ b/prerequisite_attempt_cache.py
@@ -1,0 +1,171 @@
+"""Reuse adaptive-session attempt history for prerequisite backtrack checks.
+
+The prerequisite pilot originally re-read all question attempts from Neon after
+persisting every 5-answer batch. Adaptive daily selection already reads that
+history when the session starts. This module captures that already-authoritative
+snapshot, appends only successfully persisted batches in session order, and
+lets the prerequisite pilot reuse it.
+
+If a safe cache is not available, behavior falls back to the legacy DB read.
+The selector, prerequisite diagnosis, Safety, repair, and cooldown rules are
+not changed here.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from threading import Lock
+from typing import Any
+
+
+_SESSION_CACHE_KEY = "_prerequisite_attempt_cache"
+_PENDING: dict[str, list[dict[str, Any]]] = {}
+_PENDING_LOCK = Lock()
+
+
+def _copy_attempts(attempts) -> list[dict[str, Any]]:
+    return [dict(item) for item in attempts]
+
+
+def _pilot_enabled(legacy, user_id: str, session: dict | None = None) -> bool:
+    if not legacy.is_prerequisite_backtrack_pilot_enabled(
+        legacy.ENABLE_PREREQUISITE_BACKTRACK,
+        user_id,
+        legacy.PREREQUISITE_BACKTRACK_PILOT_USER_IDS,
+    ):
+        return False
+    if session is None:
+        return True
+    return (
+        session.get("mode", "study") == "study"
+        and session.get("session_kind") != "initial_assessment"
+    )
+
+
+def _selector_user_id(attempts: list[dict[str, Any]]) -> str | None:
+    user_ids = {
+        str(item.get("user_id"))
+        for item in attempts
+        if item.get("user_id")
+    }
+    if len(user_ids) != 1:
+        return None
+    return next(iter(user_ids))
+
+
+def _current_batch_attempts(legacy, user_id: str, session: dict) -> list[dict[str, Any]]:
+    current_set = int(session["current_set"])
+    questions_per_set = int(session["questions_per_set"])
+    start_number = ((current_set - 1) * questions_per_set) + 1
+    event_key = f'{session["session_id"]}:{current_set}'
+    answered_at = datetime.now(timezone.utc)
+    attempts: list[dict[str, Any]] = []
+
+    for attempt_position, question in enumerate(session["questions"], start=1):
+        answer_data = session["all_answers"][start_number + attempt_position - 1]
+        question_id = str(question.get("id"))
+        confidence = answer_data.get("confidence")
+        attempts.append({
+            "event_key": event_key,
+            "user_id": user_id,
+            "question_id": question_id,
+            "knowledge_node_id": legacy.get_question_tag(question_id).get("knowledge_node_id"),
+            "is_correct": legacy.is_answer_correct(question, answer_data.get("answer")),
+            "confidence": int(confidence) if str(confidence) in {"1", "2", "3"} else None,
+            "answer_status": answer_data.get("answer_status", "answered"),
+            "answered_at": answered_at,
+            "attempt_position": attempt_position,
+        })
+    return attempts
+
+
+def _queue_from_cache(legacy, user_id: str, session: dict):
+    if (
+        not _pilot_enabled(legacy, user_id, session)
+        or session.get("current_set", 1) >= session.get("total_sets", 1)
+        or session.get("prerequisite_backtrack_set") == session.get("current_set")
+        or session.get("pending_prerequisite_backtrack")
+    ):
+        return None
+
+    attempts = session.get(_SESSION_CACHE_KEY)
+    if not isinstance(attempts, list) or not attempts:
+        return legacy._lt_original_queue_prerequisite_backtrack_for_next_set(user_id, session)
+
+    event_key = f'{session["session_id"]}:{session["current_set"]}'
+    current_attempts = [item for item in attempts if item.get("event_key") == event_key]
+    if not current_attempts:
+        # Never trade correctness for speed: an incomplete cache uses the old path.
+        return legacy._lt_original_queue_prerequisite_backtrack_for_next_set(user_id, session)
+
+    current_end = session["current_set"] * session["questions_per_set"]
+    excluded = {
+        str(question.get("id"))
+        for question in session.get("all_questions", ())[:current_end]
+    }
+    excluded.update(session.get("prerequisite_backtrack_used_ids", ()))
+    candidate = legacy.build_pending_backtrack_candidate(
+        current_attempts,
+        attempts,
+        legacy.get_reviewed_node_relations(),
+        excluded_question_ids=excluded,
+    )
+    if candidate:
+        session["pending_prerequisite_backtrack"] = candidate
+    return candidate
+
+
+def install_prerequisite_attempt_cache(legacy) -> None:
+    """Patch the legacy module once, preserving DB fallback semantics."""
+    if getattr(legacy, "_lt_prerequisite_attempt_cache_installed", False):
+        return
+
+    original_build = legacy.build_node_adaptive_session
+    original_start = legacy.start_quiz
+    original_record = legacy.record_confirmed_learning_batch
+    original_queue = legacy.queue_prerequisite_backtrack_for_next_set
+
+    # Kept on the legacy module so the cached queue can explicitly fall back.
+    legacy._lt_original_queue_prerequisite_backtrack_for_next_set = original_queue
+
+    def build_node_adaptive_session(attempts, *args, **kwargs):
+        attempt_list = _copy_attempts(attempts)
+        result = original_build(attempt_list, *args, **kwargs)
+        user_id = _selector_user_id(attempt_list)
+        if user_id and _pilot_enabled(legacy, user_id):
+            with _PENDING_LOCK:
+                _PENDING[user_id] = attempt_list
+        return result
+
+    def start_quiz(user_id, *args, **kwargs):
+        # Prevent a pending snapshot from an unrelated web selector call from
+        # being attached if this start does not perform adaptive selection.
+        with _PENDING_LOCK:
+            _PENDING.pop(user_id, None)
+        result = original_start(user_id, *args, **kwargs)
+        session = legacy.study_sessions.get(user_id)
+        if session and session.get("session_kind") == "adaptive_daily" and _pilot_enabled(
+            legacy, user_id, session
+        ):
+            with _PENDING_LOCK:
+                cached = _PENDING.pop(user_id, None)
+            if cached is not None:
+                session[_SESSION_CACHE_KEY] = cached
+        return result
+
+    def record_confirmed_learning_batch(user_id, session):
+        inserted = original_record(user_id, session)
+        if inserted and _pilot_enabled(legacy, user_id, session):
+            cached = session.get(_SESSION_CACHE_KEY)
+            if isinstance(cached, list):
+                cached.extend(_current_batch_attempts(legacy, user_id, session))
+        return inserted
+
+    def queue_prerequisite_backtrack_for_next_set(user_id, session):
+        return _queue_from_cache(legacy, user_id, session)
+
+    legacy.build_node_adaptive_session = build_node_adaptive_session
+    legacy.start_quiz = start_quiz
+    legacy.record_confirmed_learning_batch = record_confirmed_learning_batch
+    legacy.queue_prerequisite_backtrack_for_next_set = queue_prerequisite_backtrack_for_next_set
+    legacy._lt_prerequisite_attempt_cache_installed = True

--- a/tests/test_prerequisite_attempt_cache.py
+++ b/tests/test_prerequisite_attempt_cache.py
@@ -1,0 +1,128 @@
+from types import SimpleNamespace
+
+from prerequisite_attempt_cache import install_prerequisite_attempt_cache
+
+
+def _legacy():
+    user_id = "pilot-user"
+    old_attempt = {
+        "event_key": "old:1",
+        "user_id": user_id,
+        "question_id": "Q260",
+        "knowledge_node_id": "source-node",
+        "is_correct": True,
+        "confidence": 2,
+        "answered_at": "2026-09-05T00:00:00+00:00",
+        "attempt_position": 1,
+    }
+    target_question = {"id": "Q386"}
+    filler = [{"id": f"Q{number}"} for number in range(2, 31)]
+    all_questions = [target_question, *filler]
+    legacy = SimpleNamespace(
+        ENABLE_PREREQUISITE_BACKTRACK=True,
+        PREREQUISITE_BACKTRACK_PILOT_USER_IDS={user_id},
+        study_sessions={},
+        db_queue_calls=0,
+    )
+
+    legacy.is_prerequisite_backtrack_pilot_enabled = (
+        lambda enabled, uid, allowlist: bool(enabled and uid in allowlist)
+    )
+    legacy.get_question_tag = lambda question_id: {
+        "knowledge_node_id": "target-node" if question_id == "Q386" else "other-node"
+    }
+    legacy.is_answer_correct = lambda question, answer: answer == "A"
+    legacy.get_reviewed_node_relations = lambda: ["relation"]
+
+    def build_pending(current_attempts, attempts, relations, excluded_question_ids=()):
+        assert current_attempts[0]["event_key"] == "session-1:1"
+        assert old_attempt in attempts
+        assert relations == ["relation"]
+        return {"question_id": "Q260", "depth": 1}
+
+    legacy.build_pending_backtrack_candidate = build_pending
+
+    def original_build(attempts, *args, **kwargs):
+        assert attempts == [old_attempt]
+        return all_questions
+
+    legacy.build_node_adaptive_session = original_build
+
+    def original_start(uid, *args, **kwargs):
+        selected = legacy.build_node_adaptive_session([old_attempt], 30)
+        legacy.study_sessions[uid] = {
+            "session_id": "session-1",
+            "status": "waiting_for_answers",
+            "current_set": 1,
+            "question_count": 30,
+            "questions_per_set": 5,
+            "total_sets": 6,
+            "questions": selected[:5],
+            "all_questions": selected,
+            "all_answers": {
+                1: {"answer": "B", "confidence": "2"},
+                2: {"answer": "A", "confidence": "1"},
+                3: {"answer": "A", "confidence": "1"},
+                4: {"answer": "A", "confidence": "1"},
+                5: {"answer": "A", "confidence": "1"},
+            },
+            "mode": "study",
+            "session_kind": "adaptive_daily",
+        }
+        return ["quiz"]
+
+    legacy.start_quiz = original_start
+    legacy.record_confirmed_learning_batch = lambda uid, session: True
+
+    def original_queue(uid, session):
+        legacy.db_queue_calls += 1
+        return "db-fallback"
+
+    legacy.queue_prerequisite_backtrack_for_next_set = original_queue
+    return legacy, user_id
+
+
+def test_pilot_reuses_selector_history_after_successful_persist():
+    legacy, user_id = _legacy()
+    install_prerequisite_attempt_cache(legacy)
+
+    legacy.start_quiz(user_id, session_kind="adaptive_daily")
+    session = legacy.study_sessions[user_id]
+    assert legacy.record_confirmed_learning_batch(user_id, session) is True
+
+    candidate = legacy.queue_prerequisite_backtrack_for_next_set(user_id, session)
+
+    assert candidate["question_id"] == "Q260"
+    assert session["pending_prerequisite_backtrack"]["question_id"] == "Q260"
+    assert legacy.db_queue_calls == 0
+
+
+def test_missing_cache_falls_back_to_original_queue():
+    legacy, user_id = _legacy()
+    install_prerequisite_attempt_cache(legacy)
+    session = {
+        "session_id": "session-1",
+        "current_set": 1,
+        "total_sets": 6,
+        "questions_per_set": 5,
+        "all_questions": [{"id": "Q386"}],
+        "mode": "study",
+        "session_kind": "adaptive_daily",
+    }
+
+    assert legacy.queue_prerequisite_backtrack_for_next_set(user_id, session) == "db-fallback"
+    assert legacy.db_queue_calls == 1
+
+
+def test_failed_duplicate_persist_is_not_added_to_cache():
+    legacy, user_id = _legacy()
+    legacy.record_confirmed_learning_batch = lambda uid, session: False
+    install_prerequisite_attempt_cache(legacy)
+    legacy.start_quiz(user_id, session_kind="adaptive_daily")
+    session = legacy.study_sessions[user_id]
+
+    assert legacy.record_confirmed_learning_batch(user_id, session) is False
+    # Current event was not inserted, so cache is deliberately incomplete and
+    # the queue must choose correctness-preserving DB fallback.
+    assert legacy.queue_prerequisite_backtrack_for_next_set(user_id, session) == "db-fallback"
+    assert legacy.db_queue_calls == 1

--- a/wsgi.py
+++ b/wsgi.py
@@ -20,6 +20,7 @@ from linebot.models import (
     URIAction,
 )
 
+from prerequisite_attempt_cache import install_prerequisite_attempt_cache
 from term_explainer import explain_term
 
 
@@ -80,6 +81,7 @@ def _apply_rich_menu_v2_if_requested() -> None:
 
 # Registered LINE callbacks resolve these names from the legacy app module at
 # call time, so production behavior can be composed without rewriting app.py.
+install_prerequisite_attempt_cache(legacy)
 legacy.create_text_response = create_text_response
 legacy.create_home_message = create_home_message
 


### PR DESCRIPTION
## 目的
Issue #199 の measured answer-submit latency (~7.5s median) を静的監査した結果、persist 後に prerequisite pilot が `get_question_attempts(user_id)` を再読込していることを確認しました。adaptive_daily はセッション開始時に同じ attempt history を selector 用に既に読み込んでいます。

## 変更
- adaptive selector に渡された既存 attempts を pilot session 内へ再利用可能な形で保持
- `record_confirmed_learning_batch` が実際に insert 成功した場合だけ、現在5問の attempt-shaped evidence を session cache へ追記
- prerequisite backtrack 判定は cache が完全な場合にそれを利用
- cache が無い/不完全なら従来の DB read へ fail-safe fallback
- production composition (`wsgi.py`) のみで配線し、大きな `app.py` は変更しない

## 非変更
- Question Bank
- selector / Safety / repair / Recent Cooldown semantics
- DB schema/index
- prerequisite diagnosis rules
- paid/payment behavior

## 期待効果
prerequisite pilot 対象の adaptive_daily 5問回答時に、persist 後の重複 `get_question_attempts` 1回を除去。実効時間の改善幅は deploy 後の実測まで断定しません。

Closes neither #199 nor any performance claim until post-deploy evidence is collected.