### PR TITLE
Refresh public HP onboarding and FAQ

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,5 @@ build>=1.0.3
 python-docx
 pypdf
 Pillow>=10.0.0
+qrcode>=7.4.2
 psycopg[binary]>=3.2.0

--- a/site_marketing_refresh.py
+++ b/site_marketing_refresh.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+import io
+import os
+import re
+from html import escape
+from urllib.parse import urlparse
+
+import qrcode
+import qrcode.image.svg
+from flask import Response, abort
+
+
+FAQ_ITEMS = (
+    (
+        "LicenseTownはどんなサービスですか？",
+        "理学療法士国家試験に向けて、問題演習・苦手の整理・復習・次にやる学習の提案までを、LINEを中心に行う伴走型の学習サービスです。",
+    ),
+    (
+        "現在、料金はかかりますか？",
+        "現在は検証期間中のため、利用料金はいただいていません。実際に使っていただきながら改善を続けています。",
+    ),
+    (
+        "あとから勝手に料金が発生することはありますか？",
+        "ありません。将来、有料化する場合は事前にHPなどでお知らせします。知らないうちに料金が発生することはありません。",
+    ),
+    (
+        "どうやって始めますか？",
+        "HPのQRコード、または「LINEで無料ではじめる」ボタンからLicenseTownのLINEを開き、そのまま始められます。",
+    ),
+    (
+        "会員登録やパスワードは必要ですか？",
+        "現在、HP上での会員登録やパスワード作成は必要ありません。LINEが学習の入口になります。",
+    ),
+    (
+        "どんな問題が出ますか？",
+        "理学療法士国家試験に必要な基礎・専門基礎・専門分野の問題を収録しています。過去問とLicenseTown独自問題を使って学習します。",
+    ),
+    (
+        "普通の問題集と何が違うんですか？",
+        "問題を解いて終わりではなく、回答結果や自信度などから、苦手や確認が必要な内容を整理し、次の学習につなげるところが特徴です。",
+    ),
+    (
+        "間違えた問題はどうなりますか？",
+        "間違えた内容を記録し、必要に応じて関連する別問題などで理解できたかを確認していきます。",
+    ),
+    (
+        "「合格への道」とは何ですか？",
+        "学習履歴から現在の状況を整理し、次に取り組む内容を確認するための画面です。合格を保証したり、合格確率を表示したりするものではありません。",
+    ),
+    (
+        "「教えて源さん」では何ができますか？",
+        "国試で分からない用語を入力すると、LicenseTownに保存されている正式な問題・解説をもとに、意味・国試で押さえるポイント・関連問題を確認できます。",
+    ),
+    (
+        "親の見守り機能では何が見えますか？",
+        "学習した問題数、学習時間、取り組んだ分野など、学習状況を確認できます。本人の個別の相談内容を見せるための機能ではありません。",
+    ),
+    (
+        "不具合や分かりにくいところを見つけたらどうすればいいですか？",
+        "ぜひお問い合わせから教えてください。LicenseTownは現在、実際の利用をもとに改善している段階です。いただいた声を今後の改善に活かします。",
+    ),
+)
+
+
+def _onboarding_url() -> str | None:
+    candidate = os.getenv("SITE_ONBOARDING_URL", "").strip()
+    parsed = urlparse(candidate)
+    if parsed.scheme == "https" and parsed.netloc:
+        return candidate
+    return None
+
+
+def _faq_details() -> str:
+    return "".join(
+        '<details><summary>{}</summary><p class="marketing-faq-answer">{}</p></details>'.format(
+            escape(question), escape(answer)
+        )
+        for question, answer in FAQ_ITEMS
+    )
+
+
+def _replace_login(html: str) -> str:
+    html = html.replace('<a class="btn login">ログイン</a>', "")
+    html = html.replace(
+        '<span class="btn login public-static-control" aria-disabled="true">ログイン（準備中）</span>',
+        "",
+    )
+    return html
+
+
+def _replace_pc_faq(html: str) -> str:
+    replacement = (
+        '<article class="faq-panel marketing-faq-panel" id="faq">'
+        '<h2>よくある質問</h2>'
+        f'<div class="marketing-faq-list">{_faq_details()}</div>'
+        '<a class="marketing-contact-link" href="/site/legal/contact">'
+        '解決しない場合はお問い合わせください　›</a>'
+        '</article>'
+    )
+    return re.sub(
+        r'<article class="faq-panel" id="faq">.*?</article>',
+        replacement,
+        html,
+        count=1,
+        flags=re.DOTALL,
+    )
+
+
+def _replace_mobile_faq(html: str) -> str:
+    replacement = (
+        '<article class="faq-card marketing-faq-card">'
+        '<h2>よくあるご質問</h2>'
+        f'<div class="faq-list marketing-faq-list">{_faq_details()}</div>'
+        '<a class="marketing-contact-link" href="/site/legal/contact">'
+        '解決しない場合はお問い合わせください　›</a>'
+        '</article>'
+    )
+    return re.sub(
+        r'<article class="faq-card">.*?</article>',
+        replacement,
+        html,
+        count=1,
+        flags=re.DOTALL,
+    )
+
+
+def _cta_contents() -> str:
+    target = _onboarding_url()
+    if target:
+        escaped_target = escape(target, quote=True)
+        qr = '<img class="marketing-line-qr" src="/site/line-qr.svg" alt="LicenseTownをLINEで始めるQRコード">'
+        button = f'<a class="marketing-line-button" href="{escaped_target}">LINEで無料ではじめる　›</a>'
+        desktop_help = '<p class="marketing-qr-help">PCの方は、QRコードをスマホで読み取ってください。</p>'
+    else:
+        qr = ''
+        button = '<a class="marketing-line-button" href="/site/legal/contact">利用開始について問い合わせる　›</a>'
+        desktop_help = '<p class="marketing-qr-help">LINEの利用開始リンクを準備中です。</p>'
+    return (
+        '<h2>検証期間中 無料公開</h2>'
+        '<p class="marketing-free-copy">LicenseTownは現在、実際に使っていただきながら改善を続けています。<br>'
+        '検証期間中は利用料金をいただいていません。</p>'
+        '<p class="marketing-line-copy"><strong>LINEですぐに始められます。</strong></p>'
+        f'<div class="marketing-line-start">{qr}<div>{button}{desktop_help}</div></div>'
+        '<small class="marketing-free-note">※将来、有料化する場合は事前にHPなどでお知らせします。'
+        '知らないうちに料金が発生することはありません。</small>'
+    )
+
+
+def _replace_pc_cta(html: str) -> str:
+    replacement = f'<article class="try-panel marketing-free-panel" id="try">{_cta_contents()}</article>'
+    return re.sub(
+        r'<article class="try-panel" id="try">.*?</article>',
+        replacement,
+        html,
+        count=1,
+        flags=re.DOTALL,
+    )
+
+
+def _replace_mobile_cta(html: str) -> str:
+    replacement = (
+        '<section class="final-cta marketing-mobile-free" id="try">'
+        f'<div class="marketing-mobile-free-inner">{_cta_contents()}</div>'
+        '</section>'
+    )
+    return re.sub(
+        r'<section class="final-cta" id="try">.*?</section>',
+        replacement,
+        html,
+        count=1,
+        flags=re.DOTALL,
+    )
+
+
+def _marketing_styles() -> str:
+    return """<style id="marketing-refresh-v01">
+.header-actions .btn.primary{margin-left:auto}
+.marketing-faq-list{display:flex;flex-direction:column;gap:0;margin-top:8px}
+.marketing-faq-list details{border-top:1px solid #d8e6da;padding:9px 0}
+.marketing-faq-list details:last-child{border-bottom:1px solid #d8e6da}
+.marketing-faq-list summary{cursor:pointer;font-weight:700;line-height:1.45;color:#173d24;list-style:none;padding-right:22px;position:relative}
+.marketing-faq-list summary::-webkit-details-marker{display:none}
+.marketing-faq-list summary::after{content:'＋';position:absolute;right:2px;top:0;color:#078329;font-weight:700}
+.marketing-faq-list details[open] summary::after{content:'－'}
+.marketing-faq-answer{margin:8px 0 2px!important;line-height:1.65!important;color:#37473d!important;font-size:13px!important}
+.marketing-contact-link{display:inline-block!important;margin-top:12px!important;color:#087d2d!important;font-weight:700!important;text-decoration:none!important}
+.marketing-free-panel{height:auto!important;min-height:300px!important;text-align:center!important;padding:24px 18px!important;box-sizing:border-box!important}
+.marketing-free-panel h2,.marketing-mobile-free h2{color:#087d2d!important;margin:0 0 10px!important}
+.marketing-free-copy{line-height:1.7!important;margin:0 auto 8px!important;max-width:540px!important}
+.marketing-line-copy{margin:8px 0 12px!important}
+.marketing-line-start{display:flex;align-items:center;justify-content:center;gap:16px;margin:10px auto!important}
+.marketing-line-qr{width:112px!important;height:112px!important;background:#fff;padding:6px;border:1px solid #d8e6da;border-radius:8px;box-sizing:border-box;object-fit:contain}
+.marketing-line-button{display:inline-block!important;background:#078329!important;color:#fff!important;border-radius:8px!important;padding:12px 18px!important;text-decoration:none!important;font-weight:700!important}
+.marketing-qr-help{font-size:12px!important;line-height:1.5!important;margin:8px 0 0!important;color:#57645b!important}
+.marketing-free-note{display:block!important;line-height:1.55!important;margin-top:12px!important;color:#59645d!important}
+.marketing-mobile-free{padding:30px 36px!important;background:#f7fbf7!important}
+.marketing-mobile-free-inner{background:#fff;border:1px solid #d8e6da;border-radius:18px;padding:28px 24px;text-align:center}
+.marketing-mobile-free .marketing-line-start{flex-direction:column}
+.marketing-mobile-free .marketing-line-qr{width:150px!important;height:150px!important}
+.marketing-mobile-free .marketing-line-button{font-size:20px!important;padding:15px 24px!important}
+.marketing-faq-card .marketing-faq-answer{font-size:15px!important}
+@media(max-width:760px){.marketing-line-start{flex-direction:column}.marketing-qr-help{display:none}.marketing-free-copy br{display:none}}
+</style>"""
+
+
+def refresh_public_site_html(html: str, mobile: bool) -> str:
+    html = _replace_login(html)
+    html = _replace_mobile_faq(html) if mobile else _replace_pc_faq(html)
+    html = _replace_mobile_cta(html) if mobile else _replace_pc_cta(html)
+    html = html.replace("提供条件を準備中", "検証期間中 無料公開")
+    html = html.replace("料金・提供条件は公開準備中", "検証期間中 無料公開")
+    if 'id="marketing-refresh-v01"' not in html:
+        html = html.replace("</head>", _marketing_styles() + "</head>", 1)
+    return html
+
+
+def install_site_marketing_refresh(app) -> None:
+    @app.get("/site/line-qr.svg")
+    def site_line_qr():
+        target = _onboarding_url()
+        if not target:
+            abort(404)
+        image = qrcode.make(target, image_factory=qrcode.image.svg.SvgPathImage, box_size=8, border=2)
+        buffer = io.BytesIO()
+        image.save(buffer)
+        return Response(buffer.getvalue(), mimetype="image/svg+xml", headers={"Cache-Control": "public, max-age=3600"})
+
+    @app.after_request
+    def apply_site_marketing_refresh(response):
+        if response.status_code != 200 or response.mimetype != "text/html":
+            return response
+        if response.direct_passthrough:
+            return response
+        path = getattr(__import__("flask").request, "path", "")
+        if path not in {"/site/view/pc", "/site/view/mobile"}:
+            return response
+        html = response.get_data(as_text=True)
+        response.set_data(refresh_public_site_html(html, mobile=path.endswith("/mobile")))
+        response.headers["Content-Length"] = str(len(response.get_data()))
+        return response

--- a/site_marketing_refresh.py
+++ b/site_marketing_refresh.py
@@ -8,7 +8,7 @@ from urllib.parse import urlparse
 
 import qrcode
 import qrcode.image.svg
-from flask import Response, abort
+from flask import Response, abort, request
 
 
 FAQ_ITEMS = (
@@ -73,7 +73,7 @@ def _onboarding_url() -> str | None:
 
 def _faq_details() -> str:
     return "".join(
-        '<details><summary>{}</summary><p class="marketing-faq-answer">{}</p></details>'.format(
+        '<details><summary>{}</summary><p class="faq-answer">{}</p></details>'.format(
             escape(question), escape(answer)
         )
         for question, answer in FAQ_ITEMS
@@ -133,7 +133,7 @@ def _cta_contents() -> str:
         button = f'<a class="marketing-line-button" href="{escaped_target}">LINEで無料ではじめる　›</a>'
         desktop_help = '<p class="marketing-qr-help">PCの方は、QRコードをスマホで読み取ってください。</p>'
     else:
-        qr = ''
+        qr = ""
         button = '<a class="marketing-line-button" href="/site/legal/contact">利用開始について問い合わせる　›</a>'
         desktop_help = '<p class="marketing-qr-help">LINEの利用開始リンクを準備中です。</p>'
     return (
@@ -160,9 +160,10 @@ def _replace_pc_cta(html: str) -> str:
 
 def _replace_mobile_cta(html: str) -> str:
     replacement = (
-        '<section class="final-cta marketing-mobile-free" id="try">'
+        '<section class="final-cta" id="try">'
+        '<div class="marketing-mobile-free">'
         f'<div class="marketing-mobile-free-inner">{_cta_contents()}</div>'
-        '</section>'
+        '</div></section>'
     )
     return re.sub(
         r'<section class="final-cta" id="try">.*?</section>',
@@ -176,16 +177,20 @@ def _replace_mobile_cta(html: str) -> str:
 def _marketing_styles() -> str:
     return """<style id="marketing-refresh-v01">
 .header-actions .btn.primary{margin-left:auto}
+.bottom{height:580px!important;padding-top:16px!important;overflow:visible!important}
+.bottom-grid{align-items:stretch!important}
+.bottom-grid>.brand-panel,.marketing-faq-panel,.marketing-free-panel{height:540px!important;min-height:540px!important}
+.marketing-faq-panel{padding:18px!important;overflow:auto!important}
 .marketing-faq-list{display:flex;flex-direction:column;gap:0;margin-top:8px}
-.marketing-faq-list details{border-top:1px solid #d8e6da;padding:9px 0}
+.marketing-faq-list details{border-top:1px solid #d8e6da;padding:7px 0}
 .marketing-faq-list details:last-child{border-bottom:1px solid #d8e6da}
-.marketing-faq-list summary{cursor:pointer;font-weight:700;line-height:1.45;color:#173d24;list-style:none;padding-right:22px;position:relative}
+.marketing-faq-list summary{cursor:pointer;font-weight:700;line-height:1.45;color:#173d24;list-style:none;padding-right:22px;position:relative;font-size:12px}
 .marketing-faq-list summary::-webkit-details-marker{display:none}
 .marketing-faq-list summary::after{content:'＋';position:absolute;right:2px;top:0;color:#078329;font-weight:700}
 .marketing-faq-list details[open] summary::after{content:'－'}
-.marketing-faq-answer{margin:8px 0 2px!important;line-height:1.65!important;color:#37473d!important;font-size:13px!important}
+.marketing-faq-list .faq-answer{margin:8px 0 2px!important;line-height:1.6!important;color:#37473d!important;font-size:12px!important;height:auto!important;padding:0 4px!important}
 .marketing-contact-link{display:inline-block!important;margin-top:12px!important;color:#087d2d!important;font-weight:700!important;text-decoration:none!important}
-.marketing-free-panel{height:auto!important;min-height:300px!important;text-align:center!important;padding:24px 18px!important;box-sizing:border-box!important}
+.marketing-free-panel{text-align:center!important;padding:28px 18px!important;box-sizing:border-box!important;overflow:visible!important}
 .marketing-free-panel h2,.marketing-mobile-free h2{color:#087d2d!important;margin:0 0 10px!important}
 .marketing-free-copy{line-height:1.7!important;margin:0 auto 8px!important;max-width:540px!important}
 .marketing-line-copy{margin:8px 0 12px!important}
@@ -194,12 +199,23 @@ def _marketing_styles() -> str:
 .marketing-line-button{display:inline-block!important;background:#078329!important;color:#fff!important;border-radius:8px!important;padding:12px 18px!important;text-decoration:none!important;font-weight:700!important}
 .marketing-qr-help{font-size:12px!important;line-height:1.5!important;margin:8px 0 0!important;color:#57645b!important}
 .marketing-free-note{display:block!important;line-height:1.55!important;margin-top:12px!important;color:#59645d!important}
-.marketing-mobile-free{padding:30px 36px!important;background:#f7fbf7!important}
-.marketing-mobile-free-inner{background:#fff;border:1px solid #d8e6da;border-radius:18px;padding:28px 24px;text-align:center}
-.marketing-mobile-free .marketing-line-start{flex-direction:column}
-.marketing-mobile-free .marketing-line-qr{width:150px!important;height:150px!important}
-.marketing-mobile-free .marketing-line-button{font-size:20px!important;padding:15px 24px!important}
-.marketing-faq-card .marketing-faq-answer{font-size:15px!important}
+.page{height:3500px!important}
+.story-faq{height:696px!important;overflow:visible!important}
+.marketing-faq-card{height:680px!important;overflow:visible!important}
+.marketing-faq-card .faq-list{height:auto!important;min-height:500px!important;overflow:visible!important}
+.marketing-faq-card .marketing-faq-list details{min-height:38px!important;padding:5px 0!important}
+.marketing-faq-card .marketing-faq-list summary{font-size:10px!important;padding:8px 28px 8px 10px!important}
+.marketing-faq-card .marketing-faq-list .faq-answer{font-size:8px!important;line-height:13px!important;padding:0 28px 8px 10px!important}
+.marketing-faq-card>.marketing-contact-link{position:absolute;left:26px;bottom:12px;margin:0!important;font-size:9px!important}
+.final-cta{height:390px!important;background:#f7fbf7!important;overflow:visible!important}
+.marketing-mobile-free{height:390px!important;padding:24px 36px!important;background:#f7fbf7!important;box-sizing:border-box!important}
+.marketing-mobile-free-inner{background:#fff;border:1px solid #d8e6da;border-radius:18px;padding:22px 24px;text-align:center;min-height:340px}
+.marketing-mobile-free .marketing-line-start{flex-direction:column;gap:8px!important}
+.marketing-mobile-free .marketing-line-qr{width:132px!important;height:132px!important}
+.marketing-mobile-free .marketing-line-button{font-size:15px!important;padding:12px 20px!important}
+.marketing-mobile-free .marketing-free-copy{font-size:10px!important;line-height:16px!important}
+.marketing-mobile-free .marketing-line-copy{font-size:11px!important}
+.marketing-mobile-free .marketing-free-note{font-size:8px!important;line-height:12px!important}
 @media(max-width:760px){.marketing-line-start{flex-direction:column}.marketing-qr-help{display:none}.marketing-free-copy br{display:none}}
 </style>"""
 
@@ -224,7 +240,11 @@ def install_site_marketing_refresh(app) -> None:
         image = qrcode.make(target, image_factory=qrcode.image.svg.SvgPathImage, box_size=8, border=2)
         buffer = io.BytesIO()
         image.save(buffer)
-        return Response(buffer.getvalue(), mimetype="image/svg+xml", headers={"Cache-Control": "public, max-age=3600"})
+        return Response(
+            buffer.getvalue(),
+            mimetype="image/svg+xml",
+            headers={"Cache-Control": "public, max-age=3600"},
+        )
 
     @app.after_request
     def apply_site_marketing_refresh(response):
@@ -232,7 +252,7 @@ def install_site_marketing_refresh(app) -> None:
             return response
         if response.direct_passthrough:
             return response
-        path = getattr(__import__("flask").request, "path", "")
+        path = request.path
         if path not in {"/site/view/pc", "/site/view/mobile"}:
             return response
         html = response.get_data(as_text=True)

--- a/tests/test_site_marketing_refresh.py
+++ b/tests/test_site_marketing_refresh.py
@@ -1,0 +1,66 @@
+from flask import Flask
+
+from site_marketing_refresh import FAQ_ITEMS, install_site_marketing_refresh, refresh_public_site_html
+
+
+def test_pc_refresh_removes_login_and_expands_faq_and_free_cta(monkeypatch):
+    monkeypatch.setenv("SITE_ONBOARDING_URL", "https://example.com/line-start")
+    source = '''
+    <html><head></head><body>
+      <div class="header-actions"><span class="btn login public-static-control" aria-disabled="true">ログイン（準備中）</span></div>
+      <article class="faq-panel" id="faq"><h2>よくある質問</h2><p>古い質問</p><a>その他の質問はこちら　›</a></article>
+      <article class="try-panel" id="try"><h2>サービス提供準備中</h2><p>正式な料金・提供条件は、公開前にこのページでご案内します。</p><a>まずは使ってみる　›</a></article>
+    </body></html>
+    '''
+    html = refresh_public_site_html(source, mobile=False)
+    assert "ログイン" not in html
+    assert "サービス提供準備中" not in html
+    assert "検証期間中 無料公開" in html
+    assert "LINEで無料ではじめる" in html
+    assert "/site/line-qr.svg" in html
+    assert "解決しない場合はお問い合わせください" in html
+    assert html.count("<details>") == len(FAQ_ITEMS) == 12
+    for question, _answer in FAQ_ITEMS:
+        assert question in html
+
+
+def test_mobile_refresh_replaces_existing_four_item_faq(monkeypatch):
+    monkeypatch.setenv("SITE_ONBOARDING_URL", "https://example.com/line-start")
+    source = '''
+    <html><head></head><body>
+      <article class="faq-card"><h2>よくあるご質問</h2><div class="faq-list"><details><summary>料金はかかりますか？</summary><p class="faq-answer">old</p></details></div></article>
+      <section class="final-cta" id="try"><div class="cta-banner"><h2>まずは使ってみる</h2></div></section>
+    </body></html>
+    '''
+    html = refresh_public_site_html(source, mobile=True)
+    assert html.count("<details>") == 12
+    assert "検証期間中 無料公開" in html
+    assert "marketing-mobile-free" in html
+    assert "あとから勝手に料金が発生することはありますか？" in html
+
+
+def test_missing_onboarding_url_fails_closed_without_broken_qr(monkeypatch):
+    monkeypatch.delenv("SITE_ONBOARDING_URL", raising=False)
+    source = '<html><head></head><body><article class="try-panel" id="try"><h2>サービス提供準備中</h2></article></body></html>'
+    html = refresh_public_site_html(source, mobile=False)
+    assert "/site/line-qr.svg" not in html
+    assert "利用開始について問い合わせる" in html
+    assert "LINEの利用開始リンクを準備中" in html
+
+
+def test_qr_route_returns_svg_for_verified_https_target(monkeypatch):
+    monkeypatch.setenv("SITE_ONBOARDING_URL", "https://example.com/line-start")
+    app = Flask(__name__)
+    install_site_marketing_refresh(app)
+    response = app.test_client().get("/site/line-qr.svg")
+    assert response.status_code == 200
+    assert response.mimetype == "image/svg+xml"
+    assert b"<svg" in response.data
+
+
+def test_qr_route_is_404_without_verified_target(monkeypatch):
+    monkeypatch.setenv("SITE_ONBOARDING_URL", "javascript:alert(1)")
+    app = Flask(__name__)
+    install_site_marketing_refresh(app)
+    response = app.test_client().get("/site/line-qr.svg")
+    assert response.status_code == 404

--- a/tests/test_site_public_interactions.py
+++ b/tests/test_site_public_interactions.py
@@ -45,10 +45,10 @@ def test_mobile_faq_has_answers_and_single_open_accordion_behavior():
     html = client.get("/site/view/mobile").get_data(as_text=True)
     css = client.get("/site/preview-responsive/mobile.css").get_data(as_text=True)
 
-    assert html.count('class="faq-answer"') == 4
-    assert "月額料金はお願いしていません" in html
-    assert "一部の画面はブラウザで開いて確認します" in html
-    assert "個別の相談内容は共有されません" in html
+    assert html.count('class="faq-answer"') == 12
+    assert "検証期間中のため、利用料金はいただいていません" in html
+    assert "LINEが学習の入口になります" in html
+    assert "本人の個別の相談内容を見せるための機能ではありません" in html
     assert "理学療法士国家試験に向けて" in html
     assert "if (other !== item) other.open = false" in html
     assert '.faq-list details[open] summary:after{content:"−"}' in css
@@ -60,10 +60,10 @@ def test_pc_public_document_has_no_href_less_anchor_affordances():
     html = app.test_client().get("/site/view/pc").get_data(as_text=True)
 
     assert not re.search(r"<a\b(?![^>]*\bhref=)[^>]*>", html)
-    assert "ログイン（準備中）" in html
+    assert "ログイン（準備中）" not in html
     assert '<span class="detail public-static-control"' in html
     assert '表示イメージ</span>' in html
-    assert '<a href="/site/legal/contact">その他の質問はこちら' in html
+    assert '<a class="marketing-contact-link" href="/site/legal/contact">解決しない場合はお問い合わせください' in html
 
 
 def test_mobile_public_video_is_static_and_clearly_not_ready():

--- a/wsgi.py
+++ b/wsgi.py
@@ -21,6 +21,7 @@ from linebot.models import (
 )
 
 from prerequisite_attempt_cache import install_prerequisite_attempt_cache
+from site_marketing_refresh import install_site_marketing_refresh
 from term_explainer import explain_term
 
 
@@ -84,6 +85,7 @@ def _apply_rich_menu_v2_if_requested() -> None:
 install_prerequisite_attempt_cache(legacy)
 legacy.create_text_response = create_text_response
 legacy.create_home_message = create_home_message
+install_site_marketing_refresh(legacy.app)
 
 _apply_rich_menu_v2_if_requested()
 


### PR DESCRIPTION
Public HP only. No learner/QB/selector/dashboard logic changes.

- remove temporary login/member affordance
- replace service-preparation copy with validation-period free access copy
- add LINE onboarding CTA + QR endpoint using SITE_ONBOARDING_URL
- expand FAQ to 12 answered questions and route unresolved questions to contact
- cover PC/mobile public views with focused tests

Production merge should wait until the current learner session is no longer active because Render auto-deploy restarts the service.