### PR TITLE
Rebalance public HP bottom cards and move full FAQ

### DIFF
--- a/site_marketing_refresh.py
+++ b/site_marketing_refresh.py
@@ -52,15 +52,9 @@ FAQ_ITEMS = (
         "「教えて源さん」では何ができますか？",
         "国試で分からない用語を入力すると、LicenseTownに保存されている正式な問題・解説をもとに、意味・国試で押さえるポイント・関連問題を確認できます。",
     ),
-    (
-        "親の見守り機能では何が見えますか？",
-        "学習した問題数、学習時間、取り組んだ分野など、学習状況を確認できます。本人の個別の相談内容を見せるための機能ではありません。",
-    ),
-    (
-        "不具合や分かりにくいところを見つけたらどうすればいいですか？",
-        "ぜひお問い合わせから教えてください。LicenseTownは現在、実際の利用をもとに改善している段階です。いただいた声を今後の改善に活かします。",
-    ),
 )
+
+FAQ_PREVIEW_ITEMS = FAQ_ITEMS[:3]
 
 
 def _onboarding_url() -> str | None:
@@ -71,12 +65,12 @@ def _onboarding_url() -> str | None:
     return None
 
 
-def _faq_details() -> str:
+def _faq_details(items=FAQ_ITEMS) -> str:
     return "".join(
         '<details><summary>{}</summary><p class="faq-answer">{}</p></details>'.format(
             escape(question), escape(answer)
         )
-        for question, answer in FAQ_ITEMS
+        for question, answer in items
     )
 
 
@@ -89,17 +83,41 @@ def _replace_login(html: str) -> str:
     return html
 
 
+def _replace_pc_brand(html: str) -> str:
+    replacement = (
+        '<article class="brand-panel marketing-brand-panel">'
+        '<h2>ライセンスタウンは、あなたの「合格したい」を応援します。</h2>'
+        '<p class="marketing-brand-lead">理学療法士国家試験の学習を支える伴走型学習サービス</p>'
+        '<p class="marketing-brand-copy">問題を解くだけで終わらせず、苦手を整理し、次にやることまでつなげる。'
+        '毎日の小さな学習を、合格へ向かう積み重ねに変えていきます。</p>'
+        '<div class="marketing-brand-values">'
+        '<span>▣<b>国試に特化した<br>豊富な問題</b></span>'
+        '<span>◉<b>苦手を整理する<br>学習サポート</b></span>'
+        '<span>✓<b>続けやすい<br>学習設計</b></span>'
+        '<span>♜<b>本人と家族を<br>支える見守り</b></span>'
+        '</div>'
+        '<small>迷ったときに「次に何をやるか」がわかる場所を目指しています。</small>'
+        '</article>'
+    )
+    return re.sub(
+        r'<article class="brand-panel">.*?</article>',
+        replacement,
+        html,
+        count=1,
+        flags=re.DOTALL,
+    )
+
+
 def _replace_pc_faq(html: str) -> str:
     replacement = (
         '<article class="faq-panel marketing-faq-panel" id="faq">'
         '<h2>よくある質問</h2>'
-        f'<div class="marketing-faq-list">{_faq_details()}</div>'
-        '<a class="marketing-contact-link" href="/site/legal/contact">'
-        '解決しない場合はお問い合わせください　›</a>'
+        f'<div class="marketing-faq-list">{_faq_details(FAQ_PREVIEW_ITEMS)}</div>'
+        '<a class="marketing-contact-link" href="/site/faq">その他の質問はこちら　›</a>'
         '</article>'
     )
     return re.sub(
-        r'<article class="faq-panel" id="faq">.*?</article>',
+        r'<article class="faq-panel(?: marketing-faq-panel)?" id="faq">.*?</article>',
         replacement,
         html,
         count=1,
@@ -111,13 +129,12 @@ def _replace_mobile_faq(html: str) -> str:
     replacement = (
         '<article class="faq-card marketing-faq-card">'
         '<h2>よくあるご質問</h2>'
-        f'<div class="faq-list marketing-faq-list">{_faq_details()}</div>'
-        '<a class="marketing-contact-link" href="/site/legal/contact">'
-        '解決しない場合はお問い合わせください　›</a>'
+        f'<div class="faq-list marketing-faq-list">{_faq_details(FAQ_PREVIEW_ITEMS)}</div>'
+        '<a class="marketing-contact-link" href="/site/faq">その他の質問はこちら　›</a>'
         '</article>'
     )
     return re.sub(
-        r'<article class="faq-card">.*?</article>',
+        r'<article class="faq-card(?: marketing-faq-card)?">.*?</article>',
         replacement,
         html,
         count=1,
@@ -150,7 +167,7 @@ def _cta_contents() -> str:
 def _replace_pc_cta(html: str) -> str:
     replacement = f'<article class="try-panel marketing-free-panel" id="try">{_cta_contents()}</article>'
     return re.sub(
-        r'<article class="try-panel" id="try">.*?</article>',
+        r'<article class="try-panel(?: marketing-free-panel)?" id="try">.*?</article>',
         replacement,
         html,
         count=1,
@@ -175,43 +192,52 @@ def _replace_mobile_cta(html: str) -> str:
 
 
 def _marketing_styles() -> str:
-    return """<style id="marketing-refresh-v01">
+    return """<style id="marketing-refresh-v02">
 .header-actions .btn.primary{margin-left:auto}
-.bottom{height:580px!important;padding-top:16px!important;overflow:visible!important}
-.bottom-grid{align-items:stretch!important}
-.bottom-grid>.brand-panel,.marketing-faq-panel,.marketing-free-panel{height:540px!important;min-height:540px!important}
-.marketing-faq-panel{padding:18px!important;overflow:auto!important}
-.marketing-faq-list{display:flex;flex-direction:column;gap:0;margin-top:8px}
-.marketing-faq-list details{border-top:1px solid #d8e6da;padding:7px 0}
+.bottom{height:370px!important;padding-top:18px!important;overflow:visible!important}
+.bottom-grid{align-items:stretch!important;grid-template-columns:1.35fr .9fr 1.05fr!important;gap:16px!important}
+.bottom-grid>.marketing-brand-panel,.marketing-faq-panel,.marketing-free-panel{height:330px!important;min-height:330px!important}
+.marketing-brand-panel{padding:24px 24px 18px!important;text-align:center!important;overflow:hidden!important}
+.marketing-brand-panel h2{margin:0!important;font-size:20px!important;line-height:1.45!important}
+.marketing-brand-lead{margin:8px 0 0!important;color:#1681d4!important;font-size:13px!important}
+.marketing-brand-copy{max-width:560px;margin:18px auto 0!important;color:#34443a!important;font-size:13px!important;line-height:1.8!important}
+.marketing-brand-values{display:grid!important;grid-template-columns:repeat(4,1fr)!important;gap:10px!important;margin:20px 0 0!important}
+.marketing-brand-values span{display:flex!important;align-items:center!important;justify-content:center!important;gap:8px!important;min-height:72px!important;border:1px solid #dce8de!important;border-radius:9px!important;background:#f8fbf8!important;color:#078329!important;font-size:24px!important}
+.marketing-brand-values b{color:#233128!important;font-size:11px!important;line-height:1.55!important;text-align:left!important}
+.marketing-brand-panel small{display:block!important;margin-top:15px!important;color:#5b675f!important;font-size:11px!important}
+.marketing-faq-panel{padding:22px 18px!important;overflow:hidden!important}
+.marketing-faq-panel h2{margin:0 0 12px!important;font-size:20px!important}
+.marketing-faq-list{display:flex;flex-direction:column;gap:0;margin-top:4px}
+.marketing-faq-list details{border-top:1px solid #d8e6da;padding:10px 0}
 .marketing-faq-list details:last-child{border-bottom:1px solid #d8e6da}
 .marketing-faq-list summary{cursor:pointer;font-weight:700;line-height:1.45;color:#173d24;list-style:none;padding-right:22px;position:relative;font-size:12px}
 .marketing-faq-list summary::-webkit-details-marker{display:none}
 .marketing-faq-list summary::after{content:'＋';position:absolute;right:2px;top:0;color:#078329;font-weight:700}
 .marketing-faq-list details[open] summary::after{content:'－'}
-.marketing-faq-list .faq-answer{margin:8px 0 2px!important;line-height:1.6!important;color:#37473d!important;font-size:12px!important;height:auto!important;padding:0 4px!important}
-.marketing-contact-link{display:inline-block!important;margin-top:12px!important;color:#087d2d!important;font-weight:700!important;text-decoration:none!important}
-.marketing-free-panel{text-align:center!important;padding:28px 18px!important;box-sizing:border-box!important;overflow:visible!important}
-.marketing-free-panel h2,.marketing-mobile-free h2{color:#087d2d!important;margin:0 0 10px!important}
-.marketing-free-copy{line-height:1.7!important;margin:0 auto 8px!important;max-width:540px!important}
-.marketing-line-copy{margin:8px 0 12px!important}
-.marketing-line-start{display:flex;align-items:center;justify-content:center;gap:16px;margin:10px auto!important}
-.marketing-line-qr{width:112px!important;height:112px!important;background:#fff;padding:6px;border:1px solid #d8e6da;border-radius:8px;box-sizing:border-box;object-fit:contain}
-.marketing-line-button{display:inline-block!important;background:#078329!important;color:#fff!important;border-radius:8px!important;padding:12px 18px!important;text-decoration:none!important;font-weight:700!important}
-.marketing-qr-help{font-size:12px!important;line-height:1.5!important;margin:8px 0 0!important;color:#57645b!important}
-.marketing-free-note{display:block!important;line-height:1.55!important;margin-top:12px!important;color:#59645d!important}
-.page{height:3500px!important}
-.story-faq{height:696px!important;overflow:visible!important}
-.marketing-faq-card{height:680px!important;overflow:visible!important}
-.marketing-faq-card .faq-list{height:auto!important;min-height:500px!important;overflow:visible!important}
-.marketing-faq-card .marketing-faq-list details{min-height:38px!important;padding:5px 0!important}
+.marketing-faq-list .faq-answer{margin:8px 0 2px!important;line-height:1.6!important;color:#37473d!important;font-size:11px!important;height:auto!important;padding:0 4px!important}
+.marketing-contact-link{display:inline-block!important;margin-top:14px!important;color:#087d2d!important;font-weight:700!important;text-decoration:none!important;font-size:12px!important}
+.marketing-free-panel{text-align:center!important;padding:22px 16px!important;box-sizing:border-box!important;overflow:hidden!important;background:#fafcf9!important}
+.marketing-free-panel h2,.marketing-mobile-free h2{color:#087d2d!important;margin:0 0 8px!important}
+.marketing-free-copy{line-height:1.65!important;margin:0 auto 5px!important;max-width:540px!important;font-size:13px!important}
+.marketing-line-copy{margin:7px 0 8px!important}
+.marketing-line-start{display:flex;align-items:center;justify-content:center;gap:14px;margin:8px auto!important}
+.marketing-line-qr{width:100px!important;height:100px!important;background:#fff;padding:5px;border:1px solid #d8e6da;border-radius:8px;box-sizing:border-box;object-fit:contain}
+.marketing-line-button{display:inline-block!important;background:#078329!important;color:#fff!important;border-radius:8px!important;padding:11px 16px!important;text-decoration:none!important;font-weight:700!important}
+.marketing-qr-help{font-size:10px!important;line-height:1.45!important;margin:7px 0 0!important;color:#57645b!important}
+.marketing-free-note{display:block!important;line-height:1.5!important;margin-top:8px!important;color:#59645d!important;font-size:10px!important}
+.page{height:2850px!important}
+.story-faq{height:350px!important;overflow:visible!important}
+.marketing-faq-card{height:334px!important;overflow:visible!important}
+.marketing-faq-card .faq-list{height:auto!important;min-height:190px!important;overflow:visible!important}
+.marketing-faq-card .marketing-faq-list details{min-height:46px!important;padding:5px 0!important}
 .marketing-faq-card .marketing-faq-list summary{font-size:10px!important;padding:8px 28px 8px 10px!important}
 .marketing-faq-card .marketing-faq-list .faq-answer{font-size:8px!important;line-height:13px!important;padding:0 28px 8px 10px!important}
 .marketing-faq-card>.marketing-contact-link{position:absolute;left:26px;bottom:12px;margin:0!important;font-size:9px!important}
-.final-cta{height:390px!important;background:#f7fbf7!important;overflow:visible!important}
-.marketing-mobile-free{height:390px!important;padding:24px 36px!important;background:#f7fbf7!important;box-sizing:border-box!important}
-.marketing-mobile-free-inner{background:#fff;border:1px solid #d8e6da;border-radius:18px;padding:22px 24px;text-align:center;min-height:340px}
-.marketing-mobile-free .marketing-line-start{flex-direction:column;gap:8px!important}
-.marketing-mobile-free .marketing-line-qr{width:132px!important;height:132px!important}
+.final-cta{height:360px!important;background:#f7fbf7!important;overflow:visible!important}
+.marketing-mobile-free{height:360px!important;padding:20px 36px!important;background:#f7fbf7!important;box-sizing:border-box!important}
+.marketing-mobile-free-inner{background:#fff;border:1px solid #d8e6da;border-radius:18px;padding:20px 24px;text-align:center;min-height:320px}
+.marketing-mobile-free .marketing-line-start{flex-direction:column;gap:7px!important}
+.marketing-mobile-free .marketing-line-qr{width:124px!important;height:124px!important}
 .marketing-mobile-free .marketing-line-button{font-size:15px!important;padding:12px 20px!important}
 .marketing-mobile-free .marketing-free-copy{font-size:10px!important;line-height:16px!important}
 .marketing-mobile-free .marketing-line-copy{font-size:11px!important}
@@ -220,14 +246,38 @@ def _marketing_styles() -> str:
 </style>"""
 
 
+def _faq_page() -> str:
+    items = _faq_details(FAQ_ITEMS)
+    return f"""<!doctype html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>よくある質問 | LicenseTown</title>
+<style>
+:root{{--green:#087d2d;--ink:#172019;--line:#dbe6dd;--soft:#f7fbf7}}
+*{{box-sizing:border-box}}body{{margin:0;background:#f6f8f6;color:var(--ink);font-family:"Yu Gothic","Hiragino Kaku Gothic ProN",Meiryo,sans-serif}}
+.wrap{{width:min(920px,calc(100% - 32px));margin:42px auto 64px}}.back{{display:inline-block;margin-bottom:18px;color:var(--green);font-weight:700;text-decoration:none}}
+.card{{background:#fff;border:1px solid var(--line);border-radius:14px;padding:34px 38px;box-shadow:0 4px 18px rgba(30,60,40,.05)}}
+h1{{margin:0;color:#173d24;font-size:30px}}.lead{{margin:10px 0 26px;color:#59655d;line-height:1.7}}
+details{{border-top:1px solid var(--line);padding:17px 2px}}details:last-of-type{{border-bottom:1px solid var(--line)}}summary{{cursor:pointer;list-style:none;position:relative;padding-right:34px;font-weight:700;line-height:1.6}}summary::-webkit-details-marker{{display:none}}summary:after{{content:'＋';position:absolute;right:4px;color:var(--green)}}details[open] summary:after{{content:'－'}}.faq-answer{{margin:12px 0 2px;padding:0 28px 0 2px;color:#435047;line-height:1.8}}
+.contact{{margin:26px 0 0;padding:18px 20px;border-radius:10px;background:var(--soft);text-align:center}}.contact a{{color:var(--green);font-weight:700;text-decoration:none}}
+@media(max-width:640px){{.wrap{{margin-top:20px}}.card{{padding:24px 20px}}h1{{font-size:24px}}details{{padding:15px 0}}}}
+</style>
+</head>
+<body><main class="wrap"><a class="back" href="/site">← LicenseTownへ戻る</a><section class="card"><h1>よくある質問</h1><p class="lead">LicenseTownを始める前によくいただく質問をまとめています。</p>{items}<p class="contact">解決しない場合は <a href="/site/legal/contact">お問い合わせください　›</a></p></section></main></body></html>"""
+
+
 def refresh_public_site_html(html: str, mobile: bool) -> str:
     html = _replace_login(html)
+    if not mobile:
+        html = _replace_pc_brand(html)
     html = _replace_mobile_faq(html) if mobile else _replace_pc_faq(html)
     html = _replace_mobile_cta(html) if mobile else _replace_pc_cta(html)
     html = html.replace("提供条件を準備中", "検証期間中 無料公開")
     html = html.replace("料金・提供条件は公開準備中", "検証期間中 無料公開")
-    if 'id="marketing-refresh-v01"' not in html:
-        html = html.replace("</head>", _marketing_styles() + "</head>", 1)
+    html = re.sub(r'<style id="marketing-refresh-v0[12]">.*?</style>', "", html, flags=re.DOTALL)
+    html = html.replace("</head>", _marketing_styles() + "</head>", 1)
     return html
 
 
@@ -245,6 +295,10 @@ def install_site_marketing_refresh(app) -> None:
             mimetype="image/svg+xml",
             headers={"Cache-Control": "public, max-age=3600"},
         )
+
+    @app.get("/site/faq")
+    def site_faq():
+        return Response(_faq_page(), mimetype="text/html")
 
     @app.after_request
     def apply_site_marketing_refresh(response):

--- a/tests/test_site_marketing_refresh.py
+++ b/tests/test_site_marketing_refresh.py
@@ -1,13 +1,19 @@
 from flask import Flask
 
-from site_marketing_refresh import FAQ_ITEMS, install_site_marketing_refresh, refresh_public_site_html
+from site_marketing_refresh import (
+    FAQ_ITEMS,
+    FAQ_PREVIEW_ITEMS,
+    install_site_marketing_refresh,
+    refresh_public_site_html,
+)
 
 
-def test_pc_refresh_removes_login_and_expands_faq_and_free_cta(monkeypatch):
+def test_pc_refresh_balances_bottom_cards_and_keeps_three_faq_items(monkeypatch):
     monkeypatch.setenv("SITE_ONBOARDING_URL", "https://example.com/line-start")
     source = '''
     <html><head></head><body>
       <div class="header-actions"><span class="btn login public-static-control" aria-disabled="true">ログイン（準備中）</span></div>
+      <article class="brand-panel"><h2>old brand</h2></article>
       <article class="faq-panel" id="faq"><h2>よくある質問</h2><p>古い質問</p><a>その他の質問はこちら　›</a></article>
       <article class="try-panel" id="try"><h2>サービス提供準備中</h2><p>正式な料金・提供条件は、公開前にこのページでご案内します。</p><a>まずは使ってみる　›</a></article>
     </body></html>
@@ -18,13 +24,15 @@ def test_pc_refresh_removes_login_and_expands_faq_and_free_cta(monkeypatch):
     assert "検証期間中 無料公開" in html
     assert "LINEで無料ではじめる" in html
     assert "/site/line-qr.svg" in html
-    assert "解決しない場合はお問い合わせください" in html
-    assert html.count("<details>") == len(FAQ_ITEMS) == 12
-    for question, _answer in FAQ_ITEMS:
-        assert question in html
+    assert 'href="/site/faq">その他の質問はこちら' in html
+    assert html.count("<details>") == len(FAQ_PREVIEW_ITEMS) == 3
+    assert "毎日の小さな学習を、合格へ向かう積み重ねに変えていきます" in html
+    assert "marketing-brand-values" in html
+    assert ".bottom{height:370px!important" in html
+    assert "height:330px!important" in html
 
 
-def test_mobile_refresh_replaces_existing_four_item_faq(monkeypatch):
+def test_mobile_refresh_keeps_three_preview_questions_and_full_faq_link(monkeypatch):
     monkeypatch.setenv("SITE_ONBOARDING_URL", "https://example.com/line-start")
     source = '''
     <html><head></head><body>
@@ -33,10 +41,26 @@ def test_mobile_refresh_replaces_existing_four_item_faq(monkeypatch):
     </body></html>
     '''
     html = refresh_public_site_html(source, mobile=True)
-    assert html.count("<details>") == 12
+    assert html.count("<details>") == 3
+    assert 'href="/site/faq">その他の質問はこちら' in html
     assert "検証期間中 無料公開" in html
     assert "marketing-mobile-free" in html
-    assert "あとから勝手に料金が発生することはありますか？" in html
+
+
+def test_full_faq_page_has_ten_questions_and_contact_link(monkeypatch):
+    monkeypatch.setenv("SITE_ONBOARDING_URL", "https://example.com/line-start")
+    app = Flask(__name__)
+    install_site_marketing_refresh(app)
+    response = app.test_client().get("/site/faq")
+    html = response.get_data(as_text=True)
+    assert response.status_code == 200
+    assert len(FAQ_ITEMS) == 10
+    assert html.count("<details>") == 10
+    for question, answer in FAQ_ITEMS:
+        assert question in html
+        assert answer in html
+    assert 'href="/site/legal/contact"' in html
+    assert 'href="/site">← LicenseTownへ戻る</a>' in html
 
 
 def test_missing_onboarding_url_fails_closed_without_broken_qr(monkeypatch):

--- a/tests/test_site_public_interactions.py
+++ b/tests/test_site_public_interactions.py
@@ -40,16 +40,16 @@ def test_mobile_footer_operator_and_legal_links_are_public_routes():
         assert client.get(path).status_code == 200, path
 
 
-def test_mobile_faq_has_answers_and_single_open_accordion_behavior():
+def test_mobile_faq_has_compact_answer_preview_and_single_open_accordion_behavior():
     client = app.test_client()
     html = client.get("/site/view/mobile").get_data(as_text=True)
     css = client.get("/site/preview-responsive/mobile.css").get_data(as_text=True)
 
-    assert html.count('class="faq-answer"') == 12
+    assert html.count('class="faq-answer"') == 3
     assert "検証期間中のため、利用料金はいただいていません" in html
-    assert "LINEが学習の入口になります" in html
-    assert "本人の個別の相談内容を見せるための機能ではありません" in html
     assert "理学療法士国家試験に向けて" in html
+    assert 'href="/site/faq">その他の質問はこちら' in html
+    assert client.get("/site/faq").status_code == 200
     assert "if (other !== item) other.open = false" in html
     assert '.faq-list details[open] summary:after{content:"−"}' in css
     assert ".faq-answer{" in css
@@ -63,7 +63,7 @@ def test_pc_public_document_has_no_href_less_anchor_affordances():
     assert "ログイン（準備中）" not in html
     assert '<span class="detail public-static-control"' in html
     assert '表示イメージ</span>' in html
-    assert '<a class="marketing-contact-link" href="/site/legal/contact">解決しない場合はお問い合わせください' in html
+    assert '<a class="marketing-contact-link" href="/site/faq">その他の質問はこちら' in html
 
 
 def test_mobile_public_video_is_static_and_clearly_not_ready():


### PR DESCRIPTION
Public HP refinement only.

- rebalance the three bottom cards to remove large empty areas
- enrich the LicenseTown support/value card instead of leaving blank space
- keep only three FAQ previews on the HP
- add a dedicated `/site/faq` page with 10 answered questions
- keep the free-validation + QR/LINE onboarding card compact and balanced
- no learner, Question Bank, selector, dashboard, DB, or payment behavior changes