### PR TITLE
Show daily goal completion with correct and incorrect counts

### DIFF
--- a/static/goukaku/recommendation-daily-summary.js
+++ b/static/goukaku/recommendation-daily-summary.js
@@ -1,0 +1,24 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const target = document.querySelector('.recommend-card .daily-target');
+  const summary = window.LT_RECOMMENDATION_DAILY_SUMMARY;
+  if (!target || !summary) return;
+
+  const goal = Number(summary.goal) || 0;
+  const answered = Math.max(Number(summary.answered) || 0, 0);
+  const correct = Math.max(Number(summary.correct) || 0, 0);
+  const incorrect = Math.max(answered - correct, 0);
+  if (goal <= 0) return;
+
+  const achieved = answered >= goal;
+  const remaining = Math.max(goal - answered, 0);
+  const status = achieved ? '達成！' : `未達（あと${remaining}問）`;
+
+  target.classList.add('lt-daily-summary');
+  target.setAttribute(
+    'aria-label',
+    `今日の目標${goal}問：${status}。正解${correct}問、誤答${incorrect}問`
+  );
+  target.innerHTML =
+    `今日の目標${goal}問：<strong>${status}</strong><br>` +
+    `正解：${correct}問　誤答：${incorrect}問`;
+});

--- a/templates/goukaku/base.html
+++ b/templates/goukaku/base.html
@@ -7,11 +7,26 @@
   <title>{% block title %}合格への道{% endblock %}</title>
   <link rel="stylesheet" href="{{ url_for('static', filename='goukaku/goukaku.css', v='20260830-fixed-demo-cleanup1-20260903-dashboard-layout1') }}">
   <link rel="stylesheet" href="{{ url_for('static', filename='goukaku/learner-navigation-v02.css', v='20260903-single-cta1') }}">
-  <style>.dashboard-grid>.learner-navigation{grid-column:1/-1}</style>
+  <style>
+    .dashboard-grid>.learner-navigation{grid-column:1/-1}
+    .daily-target.lt-daily-summary{display:block;line-height:1.7}
+    .daily-target.lt-daily-summary strong{font-size:15px}
+  </style>
 </head>
 <body>
   <main class="app-shell">{% block content %}{% endblock %}</main>
+  {% if dashboard is defined %}
+    {% set lt_today_row = dashboard.daily[-1] if dashboard.daily else none %}
+    <script>
+      window.LT_RECOMMENDATION_DAILY_SUMMARY = {
+        goal: {{ dashboard.recommendation_goal|default(0)|int }},
+        answered: {{ dashboard.today_progress|default(0)|int }},
+        correct: {{ (lt_today_row.correct_count if lt_today_row else 0)|int }}
+      };
+    </script>
+  {% endif %}
   {% if liff_id %}<script src="https://static.line-scdn.net/liff/edge/2/sdk.js"></script>{% endif %}
   <script src="{{ url_for('static', filename='goukaku/goukaku.js', v='20260830-weekly-history1') }}" defer></script>
+  <script src="{{ url_for('static', filename='goukaku/recommendation-daily-summary.js', v='20260905-v01') }}" defer></script>
 </body>
 </html>

--- a/tests/test_recommendation_daily_summary.py
+++ b/tests/test_recommendation_daily_summary.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+
+def test_recommendation_daily_summary_uses_today_answered_correct_and_wrong_counts():
+    root = Path(__file__).resolve().parents[1]
+    base = (root / "templates" / "goukaku" / "base.html").read_text(encoding="utf-8")
+    js = (root / "static" / "goukaku" / "recommendation-daily-summary.js").read_text(encoding="utf-8")
+
+    assert "dashboard.today_progress" in base
+    assert "lt_today_row.correct_count" in base
+    assert "今日の目標${goal}問" in js
+    assert "達成！" in js
+    assert "未達（あと${remaining}問）" in js
+    assert "正解：${correct}問" in js
+    assert "誤答：${incorrect}問" in js
+    assert "answered - correct" in js


### PR DESCRIPTION
Clarify 「今日のおすすめ学習」 for supporter/learner views so it is obvious at a glance whether today's target was completed and what the result was.

Visible summary becomes, for example:
- 今日の目標10問：達成！
- 正解：8問　誤答：2問

If fewer than 10 questions were answered, it shows 未達（あとN問）.

The summary uses the existing daily answered/correct totals already calculated by the dashboard, avoiding the misleading field-level progress value that could omit invalid legacy question_result rows. No Question Bank, selector, DB schema, recommendation policy, or payment changes.