### PR TITLE
Fix today recommendation result summary to use recommendation answers only

### DIFF
--- a/dashboard_read_bundle.py
+++ b/dashboard_read_bundle.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from typing import Any
 
 import database
+from recommendation_daily_summary import build_today_recommendation_summary
 from trial100_store import get_trial100_records
 
 
@@ -93,17 +94,29 @@ def get_dashboard_read_bundle(
         }
 
     if not database.database_is_available():
+        learning_data = database.get_dashboard_learning_data(user_id)
+        learning_data.setdefault("activity", {}).update(
+            build_today_recommendation_summary(user_id)
+        )
         return {
-            "learning_data": database.get_dashboard_learning_data(user_id),
+            "learning_data": learning_data,
             "attempts": database.get_question_attempts(user_id) if include_attempts else [],
             "trial100_records": get_trial100_records(user_id) if include_trial100 else [],
         }
 
     with database.get_db_connection() as conn:
         question_rows = database._get_question_result_rows(user_id, conn)
+        activity = database.get_learning_activity(user_id, _connection=conn)
+        activity.update(
+            build_today_recommendation_summary(
+                user_id,
+                connection=conn,
+                question_result_rows=question_rows,
+            )
+        )
         learning_data = {
             "summary": database.get_learning_summary(user_id, _connection=conn),
-            "activity": database.get_learning_activity(user_id, _connection=conn),
+            "activity": activity,
             "fields": database.get_field_learning_summary(
                 user_id,
                 _connection=conn,

--- a/recommendation_daily_summary.py
+++ b/recommendation_daily_summary.py
@@ -1,0 +1,59 @@
+"""Daily result summary for dashboard recommendation sessions.
+
+This keeps the supporter/learner card grounded in the questions actually
+answered from 「今日のおすすめ学習」 instead of lifetime or unrelated daily totals.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
+
+import database
+
+
+def build_today_recommendation_summary(
+    user_id: str,
+    *,
+    now: datetime | None = None,
+    connection=None,
+    question_result_rows=None,
+) -> dict[str, int]:
+    current = now or datetime.now(timezone.utc)
+    today = current.astimezone(ZoneInfo("Asia/Tokyo")).date()
+    rows = (
+        question_result_rows
+        if question_result_rows is not None
+        else database._get_question_result_rows(user_id, connection)
+    )
+
+    answered = 0
+    correct = 0
+    for question_results, answered_at in rows:
+        timestamp = answered_at
+        if timestamp.tzinfo is None:
+            timestamp = timestamp.replace(tzinfo=timezone.utc)
+        if timestamp.astimezone(ZoneInfo("Asia/Tokyo")).date() != today:
+            continue
+        if isinstance(question_results, str):
+            try:
+                question_results = json.loads(question_results)
+            except json.JSONDecodeError:
+                continue
+        if not isinstance(question_results, list):
+            continue
+        for result in question_results:
+            if not isinstance(result, dict):
+                continue
+            if result.get("learning_source") != "dashboard_recommendation":
+                continue
+            answered += 1
+            if result.get("is_correct") is True:
+                correct += 1
+
+    return {
+        "recommendation_today_answered": answered,
+        "recommendation_today_correct": correct,
+        "recommendation_today_incorrect": max(answered - correct, 0),
+    }

--- a/templates/goukaku/base.html
+++ b/templates/goukaku/base.html
@@ -16,17 +16,16 @@
 <body>
   <main class="app-shell">{% block content %}{% endblock %}</main>
   {% if dashboard is defined %}
-    {% set lt_today_row = dashboard.daily[-1] if dashboard.daily else none %}
     <script>
       window.LT_RECOMMENDATION_DAILY_SUMMARY = {
         goal: {{ dashboard.recommendation_goal|default(0)|int }},
-        answered: {{ dashboard.today_progress|default(0)|int }},
-        correct: {{ (lt_today_row.correct_count if lt_today_row else 0)|int }}
+        answered: {{ dashboard.recommendation_today_answered|default(0)|int }},
+        correct: {{ dashboard.recommendation_today_correct|default(0)|int }}
       };
     </script>
   {% endif %}
   {% if liff_id %}<script src="https://static.line-scdn.net/liff/edge/2/sdk.js"></script>{% endif %}
   <script src="{{ url_for('static', filename='goukaku/goukaku.js', v='20260830-weekly-history1') }}" defer></script>
-  <script src="{{ url_for('static', filename='goukaku/recommendation-daily-summary.js', v='20260905-v01') }}" defer></script>
+  <script src="{{ url_for('static', filename='goukaku/recommendation-daily-summary.js', v='20260905-v02') }}" defer></script>
 </body>
 </html>

--- a/tests/test_recommendation_daily_summary.py
+++ b/tests/test_recommendation_daily_summary.py
@@ -1,13 +1,48 @@
+from datetime import datetime, timezone
 from pathlib import Path
 
+from recommendation_daily_summary import build_today_recommendation_summary
 
-def test_recommendation_daily_summary_uses_today_answered_correct_and_wrong_counts():
+
+def test_recommendation_daily_summary_counts_only_today_recommendation_questions():
+    now = datetime(2026, 9, 5, 10, 0, tzinfo=timezone.utc)
+    rows = [
+        ([
+            {"learning_source": "dashboard_recommendation", "is_correct": True},
+            {"learning_source": "dashboard_recommendation", "is_correct": True},
+            {"learning_source": "dashboard_recommendation", "is_correct": False},
+        ], datetime(2026, 9, 5, 9, 0, tzinfo=timezone.utc)),
+        ([
+            {"learning_source": "manual", "is_correct": True},
+            {"learning_source": "dashboard_recommendation", "is_correct": False},
+        ], datetime(2026, 9, 5, 9, 30, tzinfo=timezone.utc)),
+        ([
+            {"learning_source": "dashboard_recommendation", "is_correct": True},
+        ], datetime(2026, 9, 4, 9, 0, tzinfo=timezone.utc)),
+    ]
+
+    summary = build_today_recommendation_summary(
+        "user",
+        now=now,
+        question_result_rows=rows,
+    )
+
+    assert summary == {
+        "recommendation_today_answered": 4,
+        "recommendation_today_correct": 2,
+        "recommendation_today_incorrect": 2,
+    }
+
+
+def test_dashboard_card_uses_recommendation_specific_counts():
     root = Path(__file__).resolve().parents[1]
     base = (root / "templates" / "goukaku" / "base.html").read_text(encoding="utf-8")
     js = (root / "static" / "goukaku" / "recommendation-daily-summary.js").read_text(encoding="utf-8")
 
-    assert "dashboard.today_progress" in base
-    assert "lt_today_row.correct_count" in base
+    assert "dashboard.recommendation_today_answered" in base
+    assert "dashboard.recommendation_today_correct" in base
+    assert "dashboard.today_progress" not in base
+    assert "lt_today_row.correct_count" not in base
     assert "今日の目標${goal}問" in js
     assert "達成！" in js
     assert "未達（あと${remaining}問）" in js


### PR DESCRIPTION
Correct the 「今日のおすすめ学習」 summary so it reports only today's questions answered through the dashboard recommendation flow.

Example:
- 今日の目標10問：達成！
- 正解：8問　誤答：2問

The previous implementation accidentally mixed in unrelated/lifetime totals. This change derives counts from today's `question_results` with `learning_source == "dashboard_recommendation"` and exposes those values through the existing dashboard read bundle.

No Question Bank, selector, DB schema, recommendation policy, or payment changes.