### PR TITLE
Keep HP overlays top-visible and restore full brand heading

### DIFF
--- a/site_marketing_viewport_fix.py
+++ b/site_marketing_viewport_fix.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from flask import request
+
+
+_STYLE = """<style id="marketing-viewport-fix-v05">
+/* Real-browser fixes: modal content must open from the top, never centered/cropped. */
+.marketing-modal-overlay:target{align-items:flex-start!important;justify-content:center!important;overflow-y:auto!important;overscroll-behavior:contain!important}
+.marketing-modal-overlay:target>.marketing-modal-card{margin:0 auto!important;max-height:calc(100dvh - 32px)!important;scroll-margin-top:0!important}
+/* The left bottom card headline must stay complete at PC widths. */
+.brand-panel h2{font-size:15px!important;line-height:1.35!important;letter-spacing:-.035em!important;white-space:nowrap!important;overflow:visible!important}
+@media(max-width:760px){
+  .marketing-modal-overlay:target>.marketing-modal-card{max-height:calc(100dvh - 16px)!important}
+}
+</style>
+<script id="marketing-viewport-fix-script-v05">
+(function(){
+  function resetOpenPanel(){
+    if(location.hash!=="#faq-all-panel" && location.hash!=="#line-start-panel") return;
+    requestAnimationFrame(function(){
+      var panel=document.querySelector(location.hash);
+      if(!panel) return;
+      panel.scrollTop=0;
+      var card=panel.querySelector('.marketing-modal-card');
+      if(card) card.scrollTop=0;
+    });
+  }
+  window.addEventListener('hashchange', resetOpenPanel);
+  window.addEventListener('load', resetOpenPanel);
+})();
+</script>"""
+
+
+def install_site_marketing_viewport_fix(app) -> None:
+    @app.after_request
+    def apply_site_marketing_viewport_fix(response):
+        if response.status_code != 200 or response.mimetype != "text/html" or response.direct_passthrough:
+            return response
+        if request.path not in {"/site/view/pc", "/site/view/mobile"}:
+            return response
+        html = response.get_data(as_text=True)
+        if 'id="marketing-viewport-fix-v05"' not in html:
+            html = html.replace("</head>", _STYLE + "</head>", 1)
+            response.set_data(html)
+            response.headers["Content-Length"] = str(len(response.get_data()))
+        return response

--- a/tests/test_site_marketing_viewport_fix.py
+++ b/tests/test_site_marketing_viewport_fix.py
@@ -1,0 +1,32 @@
+from flask import Flask
+
+from site_marketing_viewport_fix import install_site_marketing_viewport_fix
+
+
+def _app():
+    app = Flask(__name__)
+    app.add_url_rule(
+        "/site/view/pc",
+        "pc",
+        lambda: '''<html><head></head><body>
+        <section id="faq-all-panel" class="marketing-modal-overlay"><div class="marketing-modal-card">FAQ</div></section>
+        <section class="brand-panel"><h2>ライセンスタウンは、あなたの「合格したい」を応援します。</h2></section>
+        </body></html>''',
+    )
+    install_site_marketing_viewport_fix(app)
+    return app
+
+
+def test_overlay_is_forced_to_open_from_viewport_top():
+    html = _app().test_client().get("/site/view/pc").get_data(as_text=True)
+    assert '.marketing-modal-overlay:target{align-items:flex-start!important' in html
+    assert 'margin:0 auto!important' in html
+    assert 'panel.scrollTop=0' in html
+    assert 'card.scrollTop=0' in html
+
+
+def test_brand_headline_is_shrunk_without_truncating_text():
+    html = _app().test_client().get("/site/view/pc").get_data(as_text=True)
+    assert 'ライセンスタウンは、あなたの「合格したい」を応援します。' in html
+    assert '.brand-panel h2{font-size:15px!important' in html
+    assert 'white-space:nowrap!important' in html

--- a/wsgi.py
+++ b/wsgi.py
@@ -23,6 +23,7 @@ from linebot.models import (
 from prerequisite_attempt_cache import install_prerequisite_attempt_cache
 from site_marketing_hotfix import install_site_marketing_hotfix
 from site_marketing_refresh import install_site_marketing_refresh
+from site_marketing_viewport_fix import install_site_marketing_viewport_fix
 from term_explainer import explain_term
 
 
@@ -86,9 +87,9 @@ def _apply_rich_menu_v2_if_requested() -> None:
 install_prerequisite_attempt_cache(legacy)
 legacy.create_text_response = create_text_response
 legacy.create_home_message = create_home_message
-# Flask executes after_request handlers in reverse registration order. Register
-# the hotfix first so the normal marketing refresh runs first and the hotfix is
-# the final public rendering pass.
+# Flask executes after_request handlers in reverse registration order.
+# Register the viewport pass first so it runs last, after refresh + hotfix.
+install_site_marketing_viewport_fix(legacy.app)
 install_site_marketing_hotfix(legacy.app)
 install_site_marketing_refresh(legacy.app)
 


### PR DESCRIPTION
Real-browser follow-up for the public HP.

- force FAQ / LINE in-page overlays to open with the card at the top of the viewport
- reset overlay/card scroll positions on hash open so the user never lands halfway down
- keep the LINE and FAQ modals otherwise unchanged
- shrink the bottom-left brand headline enough to show the complete 「ライセンスタウンは、あなたの『合格したい』を応援します。」 text without clipping
- no learner, Question Bank, selector, dashboard, DB, payment, or LINE study behavior changes

Includes focused regression tests for both issues.