### PR TITLE
Open HP FAQ and LINE panels without page jump

### DIFF
--- a/site_marketing_viewport_fix.py
+++ b/site_marketing_viewport_fix.py
@@ -3,30 +3,80 @@ from __future__ import annotations
 from flask import request
 
 
-_STYLE = """<style id="marketing-viewport-fix-v05">
-/* Real-browser fixes: modal content must open from the top, never centered/cropped. */
+_STYLE = """<style id="marketing-viewport-fix-v06">
+/* Real-browser fixes: open overlays independently of the page scroll position. */
+.marketing-modal-overlay.is-open{display:flex!important;align-items:flex-start!important;justify-content:center!important;overflow-y:auto!important;overscroll-behavior:contain!important}
+.marketing-modal-overlay.is-open>.marketing-modal-card{margin:0 auto!important;max-height:calc(100dvh - 32px)!important;scroll-margin-top:0!important}
+/* Keep hash-based :target as a no-JS fallback. */
 .marketing-modal-overlay:target{align-items:flex-start!important;justify-content:center!important;overflow-y:auto!important;overscroll-behavior:contain!important}
 .marketing-modal-overlay:target>.marketing-modal-card{margin:0 auto!important;max-height:calc(100dvh - 32px)!important;scroll-margin-top:0!important}
 /* The left bottom card headline must stay complete at PC widths. */
 .brand-panel h2{font-size:15px!important;line-height:1.35!important;letter-spacing:-.035em!important;white-space:nowrap!important;overflow:visible!important}
 @media(max-width:760px){
-  .marketing-modal-overlay:target>.marketing-modal-card{max-height:calc(100dvh - 16px)!important}
+  .marketing-modal-overlay.is-open>.marketing-modal-card,.marketing-modal-overlay:target>.marketing-modal-card{max-height:calc(100dvh - 16px)!important}
 }
 </style>
-<script id="marketing-viewport-fix-script-v05">
+<script id="marketing-viewport-fix-script-v06">
 (function(){
-  function resetOpenPanel(){
-    if(location.hash!=="#faq-all-panel" && location.hash!=="#line-start-panel") return;
-    requestAnimationFrame(function(){
-      var panel=document.querySelector(location.hash);
-      if(!panel) return;
-      panel.scrollTop=0;
-      var card=panel.querySelector('.marketing-modal-card');
-      if(card) card.scrollTop=0;
+  function resetPanel(panel){
+    if(!panel) return;
+    panel.scrollTop=0;
+    var card=panel.querySelector('.marketing-modal-card');
+    if(card) card.scrollTop=0;
+  }
+  function openPanel(panel){
+    if(!panel) return;
+    panel.classList.add('is-open');
+    document.documentElement.classList.add('marketing-modal-open');
+    document.body.style.overflow='hidden';
+    requestAnimationFrame(function(){ resetPanel(panel); });
+  }
+  function closePanels(){
+    document.querySelectorAll('.marketing-modal-overlay.is-open').forEach(function(panel){
+      panel.classList.remove('is-open');
+    });
+    document.documentElement.classList.remove('marketing-modal-open');
+    document.body.style.overflow='';
+  }
+  function bind(){
+    var faqLink=document.querySelector('.marketing-contact-link');
+    var lineLink=document.querySelector('.marketing-line-button');
+    var faqPanel=document.getElementById('faq-all-panel');
+    var linePanel=document.getElementById('line-start-panel');
+    if(faqLink && faqPanel){
+      faqLink.addEventListener('click',function(event){
+        event.preventDefault();
+        openPanel(faqPanel);
+      });
+    }
+    if(lineLink && linePanel){
+      lineLink.addEventListener('click',function(event){
+        event.preventDefault();
+        openPanel(linePanel);
+      });
+    }
+    document.querySelectorAll('.marketing-modal-close').forEach(function(link){
+      link.addEventListener('click',function(event){
+        event.preventDefault();
+        closePanels();
+      });
+    });
+    document.querySelectorAll('.marketing-modal-overlay').forEach(function(panel){
+      panel.addEventListener('click',function(event){
+        if(event.target===panel) closePanels();
+      });
+    });
+    document.addEventListener('keydown',function(event){
+      if(event.key==='Escape') closePanels();
     });
   }
-  window.addEventListener('hashchange', resetOpenPanel);
-  window.addEventListener('load', resetOpenPanel);
+  function resetHashFallback(){
+    if(location.hash!=="#faq-all-panel" && location.hash!=="#line-start-panel") return;
+    requestAnimationFrame(function(){ resetPanel(document.querySelector(location.hash)); });
+  }
+  if(document.readyState==='loading') document.addEventListener('DOMContentLoaded',bind); else bind();
+  window.addEventListener('hashchange', resetHashFallback);
+  window.addEventListener('load', resetHashFallback);
 })();
 </script>"""
 
@@ -39,7 +89,7 @@ def install_site_marketing_viewport_fix(app) -> None:
         if request.path not in {"/site/view/pc", "/site/view/mobile"}:
             return response
         html = response.get_data(as_text=True)
-        if 'id="marketing-viewport-fix-v05"' not in html:
+        if 'id="marketing-viewport-fix-v06"' not in html:
             html = html.replace("</head>", _STYLE + "</head>", 1)
             response.set_data(html)
             response.headers["Content-Length"] = str(len(response.get_data()))

--- a/tests/test_site_marketing_viewport_fix.py
+++ b/tests/test_site_marketing_viewport_fix.py
@@ -9,7 +9,10 @@ def _app():
         "/site/view/pc",
         "pc",
         lambda: '''<html><head></head><body>
-        <section id="faq-all-panel" class="marketing-modal-overlay"><div class="marketing-modal-card">FAQ</div></section>
+        <a class="marketing-contact-link" href="/site/view/pc#faq-all-panel">その他の質問はこちら</a>
+        <a class="marketing-line-button" href="/site/view/pc#line-start-panel">LINEで無料ではじめる</a>
+        <section id="faq-all-panel" class="marketing-modal-overlay"><div class="marketing-modal-card"><a class="marketing-modal-close" href="/site/view/pc#faq">×</a>FAQ</div></section>
+        <section id="line-start-panel" class="marketing-modal-overlay"><div class="marketing-modal-card"><a class="marketing-modal-close" href="/site/view/pc#try">×</a>LINE</div></section>
         <section class="brand-panel"><h2>ライセンスタウンは、あなたの「合格したい」を応援します。</h2></section>
         </body></html>''',
     )
@@ -17,12 +20,15 @@ def _app():
     return app
 
 
-def test_overlay_is_forced_to_open_from_viewport_top():
+def test_overlay_clicks_are_intercepted_without_hash_navigation():
     html = _app().test_client().get("/site/view/pc").get_data(as_text=True)
-    assert '.marketing-modal-overlay:target{align-items:flex-start!important' in html
-    assert 'margin:0 auto!important' in html
-    assert 'panel.scrollTop=0' in html
-    assert 'card.scrollTop=0' in html
+    assert '.marketing-modal-overlay.is-open{display:flex!important' in html
+    assert "faqLink.addEventListener('click'" in html
+    assert "lineLink.addEventListener('click'" in html
+    assert "event.preventDefault();" in html
+    assert "panel.classList.add('is-open')" in html
+    assert "panel.scrollTop=0" in html
+    assert "card.scrollTop=0" in html
 
 
 def test_brand_headline_is_shrunk_without_truncating_text():


### PR DESCRIPTION
Real-browser follow-up after the user confirmed that hash-target opening still jumped the underlying long page and made the overlays appear halfway down.

Changes:
- intercept FAQ and LINE CTA clicks with JavaScript and open the fixed overlay via an `is-open` class, without changing the page hash or scroll position
- reset overlay/card scroll positions to top on every open
- close without navigation via close button, backdrop click, or Escape
- keep existing hash `:target` behavior only as a no-JS fallback
- preserve the full bottom-left brand heading sizing fix
- no learner, Question Bank, selector, dashboard, DB, payment, or LINE-study behavior changes

Focused regression tests cover non-jumping modal opening and the full brand heading.