### PR TITLE
Fix public HP modal viewport positioning

### DIFF
--- a/site_marketing_hotfix.py
+++ b/site_marketing_hotfix.py
@@ -89,21 +89,21 @@ def _overlay_html(page_path: str) -> str:
         line_qr = ""
     close_href = escape(page_path, quote=True)
     return (
-        '<section id="faq-all-panel" class="marketing-modal-overlay" aria-label="よくある質問一覧">'
+        '<dialog id="faq-all-panel" class="marketing-modal-overlay" aria-label="よくある質問一覧">'
         '<div class="marketing-modal-card marketing-modal-faq-card">'
         f'<a class="marketing-modal-close" href="{close_href}#faq" aria-label="閉じる">×</a>'
         '<h2>よくある質問</h2><p class="marketing-modal-lead">10問すべての回答をまとめて確認できます。</p>'
         f'<div class="marketing-modal-faq-list">{faq_items}</div>'
         '<p class="marketing-modal-contact">解決しない場合は <a href="/site/legal/contact">お問い合わせください　›</a></p>'
-        '</div></section>'
-        '<section id="line-start-panel" class="marketing-modal-overlay" aria-label="LINEで無料ではじめる">'
+        '</div></dialog>'
+        '<dialog id="line-start-panel" class="marketing-modal-overlay" aria-label="LINEで無料ではじめる">'
         '<div class="marketing-modal-card marketing-modal-line-card">'
         f'<a class="marketing-modal-close" href="{close_href}#try" aria-label="閉じる">×</a>'
         '<h2>LINEで無料ではじめる</h2>'
         '<p>LicenseTownは現在、検証期間中のため無料で利用できます。</p>'
         f'{line_qr}{line_action}'
         '<p class="marketing-modal-help">PCの方はQRコードをスマホで読み取ってください。スマホの方は「LINEを開く」から進めます。</p>'
-        '</div></section>'
+        '</div></dialog>'
     )
 
 

--- a/site_marketing_viewport_fix.py
+++ b/site_marketing_viewport_fix.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 from flask import request
 
 
-_STYLE = """<style id="marketing-viewport-fix-v06">
-/* Real-browser fixes: open overlays independently of the page scroll position. */
+_STYLE = """<style id="marketing-viewport-fix-v07">
+/* Use the browser top layer so overlays are always relative to the live viewport. */
+dialog.marketing-modal-overlay{width:100vw!important;height:100dvh!important;max-width:none!important;max-height:none!important;margin:0!important;border:0!important}
+dialog.marketing-modal-overlay::backdrop{background:transparent!important}
 .marketing-modal-overlay.is-open{display:flex!important;align-items:flex-start!important;justify-content:center!important;overflow-y:auto!important;overscroll-behavior:contain!important}
 .marketing-modal-overlay.is-open>.marketing-modal-card{margin:0 auto!important;max-height:calc(100dvh - 32px)!important;scroll-margin-top:0!important}
 /* Keep hash-based :target as a no-JS fallback. */
@@ -16,8 +18,10 @@ _STYLE = """<style id="marketing-viewport-fix-v06">
   .marketing-modal-overlay.is-open>.marketing-modal-card,.marketing-modal-overlay:target>.marketing-modal-card{max-height:calc(100dvh - 16px)!important}
 }
 </style>
-<script id="marketing-viewport-fix-script-v06">
+<script id="marketing-viewport-fix-script-v07">
 (function(){
+  var savedScrollX=0;
+  var savedScrollY=0;
   function resetPanel(panel){
     if(!panel) return;
     panel.scrollTop=0;
@@ -26,6 +30,10 @@ _STYLE = """<style id="marketing-viewport-fix-v06">
   }
   function openPanel(panel){
     if(!panel) return;
+    savedScrollX=window.scrollX;
+    savedScrollY=window.scrollY;
+    if(panel.parentElement!==document.body) document.body.appendChild(panel);
+    if(typeof panel.showModal==='function' && !panel.open) panel.showModal();
     panel.classList.add('is-open');
     document.documentElement.classList.add('marketing-modal-open');
     document.body.style.overflow='hidden';
@@ -34,9 +42,11 @@ _STYLE = """<style id="marketing-viewport-fix-v06">
   function closePanels(){
     document.querySelectorAll('.marketing-modal-overlay.is-open').forEach(function(panel){
       panel.classList.remove('is-open');
+      if(typeof panel.close==='function' && panel.open) panel.close();
     });
     document.documentElement.classList.remove('marketing-modal-open');
     document.body.style.overflow='';
+    window.scrollTo(savedScrollX,savedScrollY);
   }
   function bind(){
     var faqLink=document.querySelector('.marketing-contact-link');
@@ -89,7 +99,7 @@ def install_site_marketing_viewport_fix(app) -> None:
         if request.path not in {"/site/view/pc", "/site/view/mobile"}:
             return response
         html = response.get_data(as_text=True)
-        if 'id="marketing-viewport-fix-v06"' not in html:
+        if 'id="marketing-viewport-fix-v07"' not in html:
             html = html.replace("</head>", _STYLE + "</head>", 1)
             response.set_data(html)
             response.headers["Content-Length"] = str(len(response.get_data()))

--- a/tests/test_site_marketing_hotfix.py
+++ b/tests/test_site_marketing_hotfix.py
@@ -46,6 +46,8 @@ def test_hp_contains_all_ten_questions_in_same_page_overlay(monkeypatch):
     app = _app(monkeypatch)
     html = app.test_client().get("/site/view/pc").get_data(as_text=True)
     assert 'id="faq-all-panel"' in html
+    assert '<dialog id="faq-all-panel"' in html
+    assert '<dialog id="line-start-panel"' in html
     assert html.count('class="marketing-modal-faq-item"') == 10
     assert "会員登録やパスワードは必要ですか？" in html
     assert "「教えて源さん」では何ができますか？" in html

--- a/tests/test_site_marketing_viewport_fix.py
+++ b/tests/test_site_marketing_viewport_fix.py
@@ -29,6 +29,10 @@ def test_overlay_clicks_are_intercepted_without_hash_navigation():
     assert "panel.classList.add('is-open')" in html
     assert "panel.scrollTop=0" in html
     assert "card.scrollTop=0" in html
+    assert "panel.showModal()" in html
+    assert "panel.close()" in html
+    assert "window.scrollTo(savedScrollX,savedScrollY)" in html
+    assert "dialog.marketing-modal-overlay{width:100vw!important;height:100dvh!important" in html
 
 
 def test_brand_headline_is_shrunk_without_truncating_text():


### PR DESCRIPTION
## Summary
- Move the existing FAQ and LINE marketing modals into the browser's native `dialog` top layer.
- Preserve the current modal content and visual styling.
- Preserve and restore the background page scroll position, and reset modal content to its top on every open.
- Keep `preview-724/index.html` unchanged.

## Root cause and fix
The overlays were body children with `position: fixed`, but still remained in the normal document rendering layer and depended on hash/CSS/body-scroll behavior. This left a browser-specific path where a modal could be positioned relative to the scrolled document rather than reliably appearing in the current viewport. Native `showModal()` places the dialog in the browser top layer, removing that containing-block dependency.

## Verification
- Focused tests: 7 passed.
- Full suite: 1040 passed / 125 subtests passed / 1 known unmanaged UTF fixture deselected.
- `git diff --check`: PASS.
- Actual Chromium browser at 1280x800 from page bottom:
  - FAQ heading top: 59px; modal card top: 28px.
  - LINE heading top: 59px; QR fully inside viewport.
  - Closing either modal restored the exact original scroll position (delta 0px).
- Mobile route also verified with modal top at 0 and scroll restoration delta 0px.

No DB, LINE Bot, Question Bank, Dashboard, payment, Render, or other site-section changes.