### PR TITLE
Align HP FAQ and LINE dialogs to viewport bottom

### DIFF
--- a/site_marketing_viewport_fix.py
+++ b/site_marketing_viewport_fix.py
@@ -3,22 +3,22 @@ from __future__ import annotations
 from flask import request
 
 
-_STYLE = """<style id="marketing-viewport-fix-v07">
-/* Use the browser top layer so overlays are always relative to the live viewport. */
+_STYLE = """<style id="marketing-viewport-fix-v08">
+/* Keep the marketing dialogs in the browser top layer and anchor their cards to the viewport bottom. */
 dialog.marketing-modal-overlay{width:100vw!important;height:100dvh!important;max-width:none!important;max-height:none!important;margin:0!important;border:0!important}
 dialog.marketing-modal-overlay::backdrop{background:transparent!important}
-.marketing-modal-overlay.is-open{display:flex!important;align-items:flex-start!important;justify-content:center!important;overflow-y:auto!important;overscroll-behavior:contain!important}
-.marketing-modal-overlay.is-open>.marketing-modal-card{margin:0 auto!important;max-height:calc(100dvh - 32px)!important;scroll-margin-top:0!important}
-/* Keep hash-based :target as a no-JS fallback. */
-.marketing-modal-overlay:target{align-items:flex-start!important;justify-content:center!important;overflow-y:auto!important;overscroll-behavior:contain!important}
-.marketing-modal-overlay:target>.marketing-modal-card{margin:0 auto!important;max-height:calc(100dvh - 32px)!important;scroll-margin-top:0!important}
+.marketing-modal-overlay.is-open{display:flex!important;align-items:flex-end!important;justify-content:center!important;overflow-y:auto!important;overscroll-behavior:contain!important}
+.marketing-modal-overlay.is-open>.marketing-modal-card{margin:0 auto 16px!important;max-height:calc(100dvh - 32px)!important;scroll-margin-bottom:0!important}
+/* Keep hash-based :target as a no-JS fallback, also bottom-aligned. */
+.marketing-modal-overlay:target{align-items:flex-end!important;justify-content:center!important;overflow-y:auto!important;overscroll-behavior:contain!important}
+.marketing-modal-overlay:target>.marketing-modal-card{margin:0 auto 16px!important;max-height:calc(100dvh - 32px)!important;scroll-margin-bottom:0!important}
 /* The left bottom card headline must stay complete at PC widths. */
 .brand-panel h2{font-size:15px!important;line-height:1.35!important;letter-spacing:-.035em!important;white-space:nowrap!important;overflow:visible!important}
 @media(max-width:760px){
-  .marketing-modal-overlay.is-open>.marketing-modal-card,.marketing-modal-overlay:target>.marketing-modal-card{max-height:calc(100dvh - 16px)!important}
+  .marketing-modal-overlay.is-open>.marketing-modal-card,.marketing-modal-overlay:target>.marketing-modal-card{margin-bottom:8px!important;max-height:calc(100dvh - 16px)!important}
 }
 </style>
-<script id="marketing-viewport-fix-script-v07">
+<script id="marketing-viewport-fix-script-v08">
 (function(){
   var savedScrollX=0;
   var savedScrollY=0;
@@ -99,7 +99,7 @@ def install_site_marketing_viewport_fix(app) -> None:
         if request.path not in {"/site/view/pc", "/site/view/mobile"}:
             return response
         html = response.get_data(as_text=True)
-        if 'id="marketing-viewport-fix-v07"' not in html:
+        if 'id="marketing-viewport-fix-v08"' not in html:
             html = html.replace("</head>", _STYLE + "</head>", 1)
             response.set_data(html)
             response.headers["Content-Length"] = str(len(response.get_data()))

--- a/tests/test_site_marketing_viewport_fix.py
+++ b/tests/test_site_marketing_viewport_fix.py
@@ -35,6 +35,14 @@ def test_overlay_clicks_are_intercepted_without_hash_navigation():
     assert "dialog.marketing-modal-overlay{width:100vw!important;height:100dvh!important" in html
 
 
+def test_overlays_are_anchored_to_viewport_bottom():
+    html = _app().test_client().get("/site/view/pc").get_data(as_text=True)
+    assert '.marketing-modal-overlay.is-open{display:flex!important;align-items:flex-end!important' in html
+    assert '.marketing-modal-overlay:target{align-items:flex-end!important' in html
+    assert 'margin:0 auto 16px!important' in html
+    assert 'scroll-margin-bottom:0!important' in html
+
+
 def test_brand_headline_is_shrunk_without_truncating_text():
     html = _app().test_client().get("/site/view/pc").get_data(as_text=True)
     assert 'ライセンスタウンは、あなたの「合格したい」を応援します。' in html


### PR DESCRIPTION
Adjust only the public HP modal placement requested by the user.

- keep FAQ and LINE dialogs in the native dialog/top layer
- anchor both dialog cards to the bottom of the current viewport
- keep dialog content, QR, links, FAQ text, learner logic, dashboard, DB, payment, and LINE Bot unchanged
- preserve scroll restoration and internal scroll reset
- add a focused regression assertion for bottom alignment