### PR TITLE
Apply bottom-sheet placement to all HP modal dialogs

### DIFF
--- a/site_marketing_viewport_fix.py
+++ b/site_marketing_viewport_fix.py
@@ -3,14 +3,14 @@ from __future__ import annotations
 from flask import request
 
 
-_STYLE = """<style id="marketing-viewport-fix-v08">
-/* Keep the marketing dialogs in the browser top layer and anchor their cards to the viewport bottom. */
+_STYLE = """<style id="marketing-viewport-fix-v09">
+/* All modal-like dialogs in the public HP use the browser top layer and open from the viewport bottom. */
 dialog.marketing-modal-overlay{width:100vw!important;height:100dvh!important;max-width:none!important;max-height:none!important;margin:0!important;border:0!important}
 dialog.marketing-modal-overlay::backdrop{background:transparent!important}
 .marketing-modal-overlay.is-open{display:flex!important;align-items:flex-end!important;justify-content:center!important;overflow-y:auto!important;overscroll-behavior:contain!important}
 .marketing-modal-overlay.is-open>.marketing-modal-card{margin:0 auto 16px!important;max-height:calc(100dvh - 32px)!important;scroll-margin-bottom:0!important}
-/* Keep hash-based :target as a no-JS fallback, also bottom-aligned. */
-.marketing-modal-overlay:target{align-items:flex-end!important;justify-content:center!important;overflow-y:auto!important;overscroll-behavior:contain!important}
+/* Hash fallback is also bottom-aligned. */
+.marketing-modal-overlay:target{display:flex!important;align-items:flex-end!important;justify-content:center!important;overflow-y:auto!important;overscroll-behavior:contain!important}
 .marketing-modal-overlay:target>.marketing-modal-card{margin:0 auto 16px!important;max-height:calc(100dvh - 32px)!important;scroll-margin-bottom:0!important}
 /* The left bottom card headline must stay complete at PC widths. */
 .brand-panel h2{font-size:15px!important;line-height:1.35!important;letter-spacing:-.035em!important;white-space:nowrap!important;overflow:visible!important}
@@ -18,16 +18,18 @@ dialog.marketing-modal-overlay::backdrop{background:transparent!important}
   .marketing-modal-overlay.is-open>.marketing-modal-card,.marketing-modal-overlay:target>.marketing-modal-card{margin-bottom:8px!important;max-height:calc(100dvh - 16px)!important}
 }
 </style>
-<script id="marketing-viewport-fix-script-v08">
+<script id="marketing-viewport-fix-script-v09">
 (function(){
   var savedScrollX=0;
   var savedScrollY=0;
+
   function resetPanel(panel){
     if(!panel) return;
     panel.scrollTop=0;
     var card=panel.querySelector('.marketing-modal-card');
     if(card) card.scrollTop=0;
   }
+
   function openPanel(panel){
     if(!panel) return;
     savedScrollX=window.scrollX;
@@ -39,6 +41,7 @@ dialog.marketing-modal-overlay::backdrop{background:transparent!important}
     document.body.style.overflow='hidden';
     requestAnimationFrame(function(){ resetPanel(panel); });
   }
+
   function closePanels(){
     document.querySelectorAll('.marketing-modal-overlay.is-open').forEach(function(panel){
       panel.classList.remove('is-open');
@@ -48,42 +51,55 @@ dialog.marketing-modal-overlay::backdrop{background:transparent!important}
     document.body.style.overflow='';
     window.scrollTo(savedScrollX,savedScrollY);
   }
+
+  function panelFromLink(link){
+    if(!link || !link.getAttribute) return null;
+    var rawHref=link.getAttribute('href') || '';
+    if(rawHref.indexOf('#')===-1) return null;
+    var hash=rawHref.slice(rawHref.indexOf('#'));
+    if(!hash || hash==='#') return null;
+    var panel=document.querySelector(hash);
+    if(!panel || !panel.matches('dialog.marketing-modal-overlay')) return null;
+    return panel;
+  }
+
   function bind(){
-    var faqLink=document.querySelector('.marketing-contact-link');
-    var lineLink=document.querySelector('.marketing-line-button');
-    var faqPanel=document.getElementById('faq-all-panel');
-    var linePanel=document.getElementById('line-start-panel');
-    if(faqLink && faqPanel){
-      faqLink.addEventListener('click',function(event){
+    document.addEventListener('click',function(event){
+      var link=event.target.closest && event.target.closest('a[href*="#"]');
+      var panel=panelFromLink(link);
+      if(panel){
         event.preventDefault();
-        openPanel(faqPanel);
-      });
-    }
-    if(lineLink && linePanel){
-      lineLink.addEventListener('click',function(event){
-        event.preventDefault();
-        openPanel(linePanel);
-      });
-    }
+        openPanel(panel);
+      }
+    });
+
     document.querySelectorAll('.marketing-modal-close').forEach(function(link){
       link.addEventListener('click',function(event){
         event.preventDefault();
+        event.stopPropagation();
         closePanels();
       });
     });
+
     document.querySelectorAll('.marketing-modal-overlay').forEach(function(panel){
       panel.addEventListener('click',function(event){
         if(event.target===panel) closePanels();
       });
     });
+
     document.addEventListener('keydown',function(event){
       if(event.key==='Escape') closePanels();
     });
   }
+
   function resetHashFallback(){
-    if(location.hash!=="#faq-all-panel" && location.hash!=="#line-start-panel") return;
-    requestAnimationFrame(function(){ resetPanel(document.querySelector(location.hash)); });
+    if(!location.hash) return;
+    var panel=document.querySelector(location.hash);
+    if(panel && panel.matches('dialog.marketing-modal-overlay')){
+      requestAnimationFrame(function(){ resetPanel(panel); });
+    }
   }
+
   if(document.readyState==='loading') document.addEventListener('DOMContentLoaded',bind); else bind();
   window.addEventListener('hashchange', resetHashFallback);
   window.addEventListener('load', resetHashFallback);
@@ -99,7 +115,7 @@ def install_site_marketing_viewport_fix(app) -> None:
         if request.path not in {"/site/view/pc", "/site/view/mobile"}:
             return response
         html = response.get_data(as_text=True)
-        if 'id="marketing-viewport-fix-v08"' not in html:
+        if 'id="marketing-viewport-fix-v09"' not in html:
             html = html.replace("</head>", _STYLE + "</head>", 1)
             response.set_data(html)
             response.headers["Content-Length"] = str(len(response.get_data()))

--- a/tests/test_site_marketing_viewport_fix.py
+++ b/tests/test_site_marketing_viewport_fix.py
@@ -11,8 +11,10 @@ def _app():
         lambda: '''<html><head></head><body>
         <a class="marketing-contact-link" href="/site/view/pc#faq-all-panel">その他の質問はこちら</a>
         <a class="marketing-line-button" href="/site/view/pc#line-start-panel">LINEで無料ではじめる</a>
-        <section id="faq-all-panel" class="marketing-modal-overlay"><div class="marketing-modal-card"><a class="marketing-modal-close" href="/site/view/pc#faq">×</a>FAQ</div></section>
-        <section id="line-start-panel" class="marketing-modal-overlay"><div class="marketing-modal-card"><a class="marketing-modal-close" href="/site/view/pc#try">×</a>LINE</div></section>
+        <a class="future-modal-link" href="/site/view/pc#future-panel">将来の別画面</a>
+        <dialog id="faq-all-panel" class="marketing-modal-overlay"><div class="marketing-modal-card"><a class="marketing-modal-close" href="/site/view/pc#faq">×</a>FAQ</div></dialog>
+        <dialog id="line-start-panel" class="marketing-modal-overlay"><div class="marketing-modal-card"><a class="marketing-modal-close" href="/site/view/pc#try">×</a>LINE</div></dialog>
+        <dialog id="future-panel" class="marketing-modal-overlay"><div class="marketing-modal-card"><a class="marketing-modal-close" href="/site/view/pc#top">×</a>FUTURE</div></dialog>
         <section class="brand-panel"><h2>ライセンスタウンは、あなたの「合格したい」を応援します。</h2></section>
         </body></html>''',
     )
@@ -20,11 +22,12 @@ def _app():
     return app
 
 
-def test_overlay_clicks_are_intercepted_without_hash_navigation():
+def test_all_modal_links_are_intercepted_without_hash_navigation():
     html = _app().test_client().get("/site/view/pc").get_data(as_text=True)
     assert '.marketing-modal-overlay.is-open{display:flex!important' in html
-    assert "faqLink.addEventListener('click'" in html
-    assert "lineLink.addEventListener('click'" in html
+    assert "event.target.closest('a[href*=\"#\"]')" in html
+    assert "panelFromLink(link)" in html
+    assert "panel.matches('dialog.marketing-modal-overlay')" in html
     assert "event.preventDefault();" in html
     assert "panel.classList.add('is-open')" in html
     assert "panel.scrollTop=0" in html
@@ -35,12 +38,13 @@ def test_overlay_clicks_are_intercepted_without_hash_navigation():
     assert "dialog.marketing-modal-overlay{width:100vw!important;height:100dvh!important" in html
 
 
-def test_overlays_are_anchored_to_viewport_bottom():
+def test_all_overlays_are_anchored_to_viewport_bottom():
     html = _app().test_client().get("/site/view/pc").get_data(as_text=True)
     assert '.marketing-modal-overlay.is-open{display:flex!important;align-items:flex-end!important' in html
-    assert '.marketing-modal-overlay:target{align-items:flex-end!important' in html
+    assert '.marketing-modal-overlay:target{display:flex!important;align-items:flex-end!important' in html
     assert 'margin:0 auto 16px!important' in html
     assert 'scroll-margin-bottom:0!important' in html
+    assert 'future-panel' in html
 
 
 def test_brand_headline_is_shrunk_without_truncating_text():


### PR DESCRIPTION
Generalize the already user-verified bottom-aligned modal behavior across all public HP dialog overlays.

- preserve the current FAQ/LINE bottom-sheet styling exactly
- replace hardcoded FAQ/LINE click binding with generic handling for any link whose hash target is `dialog.marketing-modal-overlay`
- keep background scroll restoration and modal-internal scroll reset
- add regression coverage with a third/future modal target to prove the behavior is generic
- do not change full-page navigation links such as legal/support routes
- no learner, Question Bank, dashboard, DB, payment, Render config, or LINE Bot changes