### PR TITLE
Open public info pages from the top with normal scrolling

### DIFF
--- a/site_legal_ui.py
+++ b/site_legal_ui.py
@@ -66,13 +66,26 @@ def _layout(title: str, body_html: str):
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>{{ title }} | LicenseTown</title>
 <style>
-html,body{height:100%;margin:0}
-body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;background:#f7faf7;color:#18331f;overflow:hidden}
-main{width:min(860px,100%);height:100dvh;margin:0 auto;padding:16px 20px;box-sizing:border-box;display:flex;align-items:center;justify-content:center}
-.card{width:100%;max-height:calc(100dvh - 32px);box-sizing:border-box;overflow-y:auto;overscroll-behavior:contain;scrollbar-gutter:stable;background:#fff;border:1px solid #dce8de;border-radius:18px;padding:28px}
+html{scroll-behavior:auto}
+body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;margin:0;background:#f7faf7;color:#18331f;overflow-y:auto}
+main{max-width:820px;margin:24px auto;padding:0 20px 40px}
+.card{width:100%;box-sizing:border-box;background:#fff;border:1px solid #dce8de;border-radius:18px;padding:28px}
 a{color:#087d2c}.notice{padding:14px 16px;background:#eef8ef;border-radius:12px;margin-bottom:24px}h1{font-size:28px}h2{margin-top:28px;font-size:20px}dt{font-weight:700;margin-top:14px}dd{margin:4px 0 0}footer{margin-top:32px;font-size:13px;color:#66756a}.support-note{padding:16px;background:#f3f8f3;border-radius:12px}.muted{color:#66756a}.support-amounts{display:flex;gap:10px;flex-wrap:wrap;padding:0;list-style:none}.support-amounts li{padding:8px 12px;border:1px solid #cfe0d2;border-radius:999px;background:#fff;font-weight:700}
-@media(max-width:640px){main{padding:8px}.card{max-height:calc(100dvh - 16px);padding:20px;border-radius:14px}h1{font-size:24px}}
-</style></head><body><main><div class="card"><div class="notice">{{ status }}</div>
+@media(max-width:640px){main{margin:8px auto;padding:0 8px 24px}.card{padding:20px;border-radius:14px}h1{font-size:24px}}
+</style>
+<script>
+(function(){
+  if('scrollRestoration' in history) history.scrollRestoration='manual';
+  function showFromTop(){
+    window.scrollTo(0,0);
+    document.documentElement.scrollTop=0;
+    document.body.scrollTop=0;
+  }
+  if(document.readyState==='loading') document.addEventListener('DOMContentLoaded',showFromTop); else showFromTop();
+  window.addEventListener('pageshow',showFromTop);
+  window.addEventListener('load',showFromTop);
+})();
+</script></head><body><main><div class="card"><div class="notice">{{ status }}</div>
 <h1>{{ title }}</h1>{{ body|safe }}<footer><a href="/site">LicenseTown公式サイトへ戻る</a></footer>
 </div></main></body></html>
         """,

--- a/tests/test_site_legal_ui.py
+++ b/tests/test_site_legal_ui.py
@@ -45,7 +45,7 @@ def test_support_page_is_optional_and_sale_safe():
     assert "決済機能はまだ公開していません" in html
 
 
-def test_all_public_info_pages_are_viewport_contained_and_scrollable():
+def test_all_public_info_pages_open_from_top_and_use_normal_page_scroll():
     app = Flask(__name__)
     app.register_blueprint(site_legal_ui.site_legal_ui)
     client = app.test_client()
@@ -61,11 +61,12 @@ def test_all_public_info_pages_are_viewport_contained_and_scrollable():
         response = client.get(path)
         assert response.status_code == 200, path
         html = response.get_data(as_text=True)
-        assert "height:100dvh" in html
-        assert "align-items:center" in html
-        assert "max-height:calc(100dvh - 32px)" in html
+        assert "body{font-family" in html
         assert "overflow-y:auto" in html
-        assert "overscroll-behavior:contain" in html
+        assert "max-height:calc(100dvh" not in html
+        assert "history.scrollRestoration='manual'" in html
+        assert "window.scrollTo(0,0)" in html
+        assert "window.addEventListener('pageshow',showFromTop)" in html
         assert "LicenseTown公式サイトへ戻る" in html
 
 


### PR DESCRIPTION
Fix the actual remaining usability issue on standalone HP information pages.

Changes:
- remove viewport-internal card scrolling
- return to normal document scrolling so the complete text is always reachable
- force each page to open from the document top on DOMContentLoaded/load/pageshow
- disable browser scroll restoration on these pages to prevent reopening in the middle
- applies to commercial-transactions, privacy, terms, operator, contact, and support pages
- no copy changes and no learner, Question Bank, dashboard, DB, payment, LINE Bot, or Render config changes