### PR TITLE
Open LINE start outside preview iframe

### DIFF
--- a/site_marketing_viewport_fix.py
+++ b/site_marketing_viewport_fix.py
@@ -65,7 +65,16 @@ dialog.marketing-modal-overlay::backdrop{background:transparent!important}
     return panel;
   }
 
+  function wireStandaloneLineStart(){
+    document.querySelectorAll('a.marketing-line-button').forEach(function(link){
+      link.setAttribute('href','/site/line-start#top');
+      link.setAttribute('target','_top');
+    });
+  }
+
   function bind(){
+    wireStandaloneLineStart();
+
     document.addEventListener('click',function(event){
       var link=event.target.closest && event.target.closest('a[href*="#"]');
       var panel=panelFromLink(link);
@@ -110,36 +119,20 @@ dialog.marketing-modal-overlay::backdrop{background:transparent!important}
 
 
 def _open_info_pages_in_top_context(html: str) -> str:
-    """Open standalone public pages outside the preview iframe.
+    """Open standalone public information pages outside the preview iframe.
 
     The official site renders the PC/mobile public view inside an iframe. Without
-    ``target=_top``, standalone pages can inherit the outer page's scroll position
-    and appear blank until the user scrolls. Legal/support links and the LINE-start
-    action therefore escape the iframe and carry ``#top`` as an explicit start.
+    ``target=_top``, legal/support pages inherit the outer page's scroll position
+    and can appear blank until the user scrolls back to the top. These links also
+    carry ``#top`` so the destination page has an explicit initial anchor.
     """
 
-    line_pattern = re.compile(
-        r'<a(?P<attrs>[^>]*\bclass="[^"]*marketing-line-button[^"]*"[^>]*\bhref="[^"]*#line-start-panel"[^>]*)>',
-        flags=re.IGNORECASE,
-    )
-
-    def replace_line(match):
-        attrs = match.group("attrs")
-        attrs = re.sub(r'\bhref="[^"]+"', 'href="/site/line-start#top"', attrs, count=1)
-        if re.search(r'\btarget="[^"]*"', attrs, flags=re.IGNORECASE):
-            attrs = re.sub(r'\btarget="[^"]*"', 'target="_top"', attrs, count=1, flags=re.IGNORECASE)
-        else:
-            attrs += ' target="_top"'
-        return f"<a{attrs}>"
-
-    html = line_pattern.sub(replace_line, html)
-
-    info_pattern = re.compile(
+    pattern = re.compile(
         r'<a(?P<attrs>[^>]*\bhref="(?P<href>/site/(?:support|legal/[^"#?]+))(?:#top)?"[^>]*)>',
         flags=re.IGNORECASE,
     )
 
-    def replace_info(match):
+    def replace(match):
         attrs = match.group("attrs")
         href = match.group("href")
         attrs = re.sub(r'\bhref="[^"]+"', f'href="{href}#top"', attrs, count=1)
@@ -149,7 +142,7 @@ def _open_info_pages_in_top_context(html: str) -> str:
             attrs += ' target="_top"'
         return f"<a{attrs}>"
 
-    return info_pattern.sub(replace_info, html)
+    return pattern.sub(replace, html)
 
 
 def install_site_marketing_viewport_fix(app) -> None:

--- a/site_marketing_viewport_fix.py
+++ b/site_marketing_viewport_fix.py
@@ -5,8 +5,8 @@ import re
 from flask import request
 
 
-_STYLE = """<style id="marketing-viewport-fix-v10">
-/* All modal-like dialogs in the public HP use the browser top layer and open from the viewport bottom. */
+_STYLE = """<style id="marketing-viewport-fix-v11">
+/* Remaining modal-like dialogs in the public HP use the browser top layer and open from the viewport bottom. */
 dialog.marketing-modal-overlay{width:100vw!important;height:100dvh!important;max-width:none!important;max-height:none!important;margin:0!important;border:0!important}
 dialog.marketing-modal-overlay::backdrop{background:transparent!important}
 .marketing-modal-overlay.is-open{display:flex!important;align-items:flex-end!important;justify-content:center!important;overflow-y:auto!important;overscroll-behavior:contain!important}
@@ -20,7 +20,7 @@ dialog.marketing-modal-overlay::backdrop{background:transparent!important}
   .marketing-modal-overlay.is-open>.marketing-modal-card,.marketing-modal-overlay:target>.marketing-modal-card{margin-bottom:8px!important;max-height:calc(100dvh - 16px)!important}
 }
 </style>
-<script id="marketing-viewport-fix-script-v10">
+<script id="marketing-viewport-fix-script-v11">
 (function(){
   var savedScrollX=0;
   var savedScrollY=0;
@@ -110,20 +110,36 @@ dialog.marketing-modal-overlay::backdrop{background:transparent!important}
 
 
 def _open_info_pages_in_top_context(html: str) -> str:
-    """Open standalone public information pages outside the preview iframe.
+    """Open standalone public pages outside the preview iframe.
 
     The official site renders the PC/mobile public view inside an iframe. Without
-    ``target=_top``, legal/support pages inherit the outer page's scroll position
-    and can appear blank until the user scrolls back to the top. These links also
-    carry ``#top`` so the destination page has an explicit initial anchor.
+    ``target=_top``, standalone pages can inherit the outer page's scroll position
+    and appear blank until the user scrolls. Legal/support links and the LINE-start
+    action therefore escape the iframe and carry ``#top`` as an explicit start.
     """
 
-    pattern = re.compile(
+    line_pattern = re.compile(
+        r'<a(?P<attrs>[^>]*\bclass="[^"]*marketing-line-button[^"]*"[^>]*\bhref="[^"]*#line-start-panel"[^>]*)>',
+        flags=re.IGNORECASE,
+    )
+
+    def replace_line(match):
+        attrs = match.group("attrs")
+        attrs = re.sub(r'\bhref="[^"]+"', 'href="/site/line-start#top"', attrs, count=1)
+        if re.search(r'\btarget="[^"]*"', attrs, flags=re.IGNORECASE):
+            attrs = re.sub(r'\btarget="[^"]*"', 'target="_top"', attrs, count=1, flags=re.IGNORECASE)
+        else:
+            attrs += ' target="_top"'
+        return f"<a{attrs}>"
+
+    html = line_pattern.sub(replace_line, html)
+
+    info_pattern = re.compile(
         r'<a(?P<attrs>[^>]*\bhref="(?P<href>/site/(?:support|legal/[^"#?]+))(?:#top)?"[^>]*)>',
         flags=re.IGNORECASE,
     )
 
-    def replace(match):
+    def replace_info(match):
         attrs = match.group("attrs")
         href = match.group("href")
         attrs = re.sub(r'\bhref="[^"]+"', f'href="{href}#top"', attrs, count=1)
@@ -133,7 +149,7 @@ def _open_info_pages_in_top_context(html: str) -> str:
             attrs += ' target="_top"'
         return f"<a{attrs}>"
 
-    return pattern.sub(replace, html)
+    return info_pattern.sub(replace_info, html)
 
 
 def install_site_marketing_viewport_fix(app) -> None:
@@ -145,7 +161,8 @@ def install_site_marketing_viewport_fix(app) -> None:
             return response
         html = response.get_data(as_text=True)
         html = _open_info_pages_in_top_context(html)
-        if 'id="marketing-viewport-fix-v10"' not in html:
+        if 'id="marketing-viewport-fix-v11"' not in html:
+            html = re.sub(r'<style id="marketing-viewport-fix-v10">.*?<script id="marketing-viewport-fix-script-v10">.*?</script>', "", html, count=1, flags=re.DOTALL)
             html = html.replace("</head>", _STYLE + "</head>", 1)
         response.set_data(html)
         response.headers["Content-Length"] = str(len(response.get_data()))

--- a/tests/test_site_marketing_viewport_fix.py
+++ b/tests/test_site_marketing_viewport_fix.py
@@ -55,10 +55,12 @@ def test_standalone_info_links_escape_preview_iframe_and_start_at_top():
     assert 'href="/site/legal/terms#top" target="_top"' in html
 
 
-def test_line_start_escapes_preview_iframe_and_starts_at_top():
+def test_line_start_is_rewired_to_top_context_after_render():
     html = _app().test_client().get("/site/view/pc").get_data(as_text=True)
-    assert 'class="marketing-line-button" href="/site/line-start#top" target="_top"' in html
-    assert 'href="/site/view/pc#line-start-panel">LINEで無料ではじめる' not in html
+    assert "document.querySelectorAll('a.marketing-line-button')" in html
+    assert "link.setAttribute('href','/site/line-start#top')" in html
+    assert "link.setAttribute('target','_top')" in html
+    assert "wireStandaloneLineStart();" in html
 
 
 def test_brand_headline_is_shrunk_without_truncating_text():

--- a/tests/test_site_marketing_viewport_fix.py
+++ b/tests/test_site_marketing_viewport_fix.py
@@ -24,7 +24,7 @@ def _app():
     return app
 
 
-def test_all_modal_links_are_intercepted_without_hash_navigation():
+def test_remaining_modal_links_are_intercepted_without_hash_navigation():
     html = _app().test_client().get("/site/view/pc").get_data(as_text=True)
     assert '.marketing-modal-overlay.is-open{display:flex!important' in html
     assert "event.target.closest('a[href*=\"#\"]')" in html
@@ -40,7 +40,7 @@ def test_all_modal_links_are_intercepted_without_hash_navigation():
     assert "dialog.marketing-modal-overlay{width:100vw!important;height:100dvh!important" in html
 
 
-def test_all_overlays_are_anchored_to_viewport_bottom():
+def test_remaining_overlays_are_anchored_to_viewport_bottom():
     html = _app().test_client().get("/site/view/pc").get_data(as_text=True)
     assert '.marketing-modal-overlay.is-open{display:flex!important;align-items:flex-end!important' in html
     assert '.marketing-modal-overlay:target{display:flex!important;align-items:flex-end!important' in html
@@ -53,6 +53,12 @@ def test_standalone_info_links_escape_preview_iframe_and_start_at_top():
     html = _app().test_client().get("/site/view/pc").get_data(as_text=True)
     assert 'href="/site/support#top" target="_top"' in html
     assert 'href="/site/legal/terms#top" target="_top"' in html
+
+
+def test_line_start_escapes_preview_iframe_and_starts_at_top():
+    html = _app().test_client().get("/site/view/pc").get_data(as_text=True)
+    assert 'class="marketing-line-button" href="/site/line-start#top" target="_top"' in html
+    assert 'href="/site/view/pc#line-start-panel">LINEで無料ではじめる' not in html
 
 
 def test_brand_headline_is_shrunk_without_truncating_text():

--- a/tests/test_site_public_interactions.py
+++ b/tests/test_site_public_interactions.py
@@ -26,10 +26,10 @@ def test_mobile_footer_operator_and_legal_links_are_public_routes():
     client = app.test_client()
     html = client.get("/site/view/mobile").get_data(as_text=True)
 
-    assert '<a href="/site/legal/terms">利用規約</a>' in html
-    assert '<a href="/site/legal/privacy">プライバシーポリシー</a>' in html
-    assert '<a href="/site/legal/contact">お問い合わせ</a>' in html
-    assert '<a href="/site/legal/operator">運営情報</a>' in html
+    assert '<a href="/site/legal/terms#top" target="_top">利用規約</a>' in html
+    assert '<a href="/site/legal/privacy#top" target="_top">プライバシーポリシー</a>' in html
+    assert '<a href="/site/legal/contact#top" target="_top">お問い合わせ</a>' in html
+    assert '<a href="/site/legal/operator#top" target="_top">運営情報</a>' in html
 
     for path in (
         "/site/legal/terms",
@@ -58,6 +58,14 @@ def test_mobile_faq_has_compact_answer_preview_and_single_open_accordion_behavio
     assert '.faq-list details[open] summary:after{content:"−"}' in css
     assert ".faq-answer{" in css
     assert ".story-faq{height:286px!important" in css
+
+
+def test_line_start_leaves_preview_iframe_on_pc_and_mobile():
+    client = app.test_client()
+    for path in ("/site/view/pc", "/site/view/mobile"):
+        html = client.get(path).get_data(as_text=True)
+        assert 'class="marketing-line-button" href="/site/line-start#top" target="_top"' in html
+    assert client.get("/site/line-start").status_code == 200
 
 
 def test_pc_public_document_has_no_href_less_anchor_affordances():

--- a/tests/test_site_public_interactions.py
+++ b/tests/test_site_public_interactions.py
@@ -60,11 +60,13 @@ def test_mobile_faq_has_compact_answer_preview_and_single_open_accordion_behavio
     assert ".story-faq{height:286px!important" in css
 
 
-def test_line_start_leaves_preview_iframe_on_pc_and_mobile():
+def test_line_start_is_rewired_to_leave_preview_iframe_on_pc_and_mobile():
     client = app.test_client()
     for path in ("/site/view/pc", "/site/view/mobile"):
         html = client.get(path).get_data(as_text=True)
-        assert 'class="marketing-line-button" href="/site/line-start#top" target="_top"' in html
+        assert "document.querySelectorAll('a.marketing-line-button')" in html
+        assert "link.setAttribute('href','/site/line-start#top')" in html
+        assert "link.setAttribute('target','_top')" in html
     assert client.get("/site/line-start").status_code == 200
 
 


### PR DESCRIPTION
Use the same proven top-level navigation approach as the standalone support/legal pages for the public HP LINE start action.

- rewrites the HP `LINEで無料ではじめる` action from the in-iframe modal hash to `/site/line-start#top`
- forces `target="_top"` so the standalone LINE start page replaces the iframe context
- leaves FAQ modal behavior and other public HP content unchanged
- keeps existing LINE QR/action page intact
- adds regression coverage for the top-level LINE navigation

No learner, Question Bank, dashboard, DB, payment, LINE Bot, or Render config changes.