### PR TITLE
Add Google-independent public feedback inbox

### DIFF
--- a/feedback_store.py
+++ b/feedback_store.py
@@ -1,0 +1,237 @@
+"""Persistence helpers for LicenseTown public feedback.
+
+The public form intentionally stores the authoritative copy in Neon.  E-mail is
+an optional delivery channel for future replies, never the system of record.
+"""
+
+from __future__ import annotations
+
+import re
+import secrets
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+from database import database_is_available, get_db_connection
+
+
+VALID_CATEGORIES = {
+    "bug": "不具合",
+    "request": "ご要望",
+    "usage": "使い方について",
+    "other": "その他",
+}
+VALID_STATUSES = {"received", "reviewing", "planned", "responded", "closed"}
+
+_EMAIL_RE = re.compile(r"^[^\s@]+@[^\s@]+\.[^\s@]+$")
+
+
+class FeedbackError(RuntimeError):
+    """Base error for feedback operations."""
+
+
+class FeedbackValidationError(FeedbackError):
+    """Raised when submitted feedback is invalid."""
+
+
+class FeedbackStoreUnavailable(FeedbackError):
+    """Raised when the database is not configured."""
+
+
+@dataclass(frozen=True)
+class FeedbackReceipt:
+    public_id: str
+    tracking_token: str
+    created_at: datetime
+
+
+def _clean_optional(value: str | None, *, max_length: int) -> str | None:
+    cleaned = str(value or "").strip()
+    if not cleaned:
+        return None
+    if len(cleaned) > max_length:
+        raise FeedbackValidationError("入力が長すぎます。")
+    return cleaned
+
+
+def _clean_required(value: str | None, *, max_length: int, message: str) -> str:
+    cleaned = str(value or "").strip()
+    if not cleaned:
+        raise FeedbackValidationError(message)
+    if len(cleaned) > max_length:
+        raise FeedbackValidationError("入力が長すぎます。")
+    return cleaned
+
+
+def validate_feedback(*, name: str | None, email: str | None, category: str | None, message: str | None) -> dict[str, str | None]:
+    cleaned_name = _clean_optional(name, max_length=80)
+    cleaned_email = _clean_optional(email, max_length=254)
+    cleaned_category = _clean_required(category, max_length=32, message="お問い合わせ種類を選んでください。")
+    cleaned_message = _clean_required(message, max_length=4000, message="お問い合わせ内容を入力してください。")
+
+    if cleaned_category not in VALID_CATEGORIES:
+        raise FeedbackValidationError("お問い合わせ種類を選び直してください。")
+    if cleaned_email and not _EMAIL_RE.match(cleaned_email):
+        raise FeedbackValidationError("メールアドレスの形式を確認してください。")
+
+    return {
+        "name": cleaned_name,
+        "email": cleaned_email,
+        "category": cleaned_category,
+        "message": cleaned_message,
+    }
+
+
+def _new_public_id(now: datetime) -> str:
+    # Short enough to quote in conversation, random enough to avoid collisions.
+    return f"LT-{now:%Y%m%d}-{secrets.token_hex(4).upper()}"
+
+
+def create_feedback(
+    *,
+    name: str | None,
+    email: str | None,
+    category: str | None,
+    message: str | None,
+    source: str = "web",
+    page_path: str | None = None,
+    line_user_id: str | None = None,
+) -> FeedbackReceipt:
+    values = validate_feedback(name=name, email=email, category=category, message=message)
+    if not database_is_available():
+        raise FeedbackStoreUnavailable("お問い合わせの保存先に接続できません。")
+
+    now = datetime.now(timezone.utc)
+    tracking_token = secrets.token_urlsafe(32)
+    source_value = _clean_required(source, max_length=32, message="送信元が不明です。")
+    page_value = _clean_optional(page_path, max_length=240)
+    line_value = _clean_optional(line_user_id, max_length=160)
+
+    # Collision is extremely unlikely. Retry public_id only, keeping the private
+    # tracking token stable for this submission.
+    for _ in range(4):
+        public_id = _new_public_id(now)
+        try:
+            with get_db_connection() as conn:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        """
+                        INSERT INTO feedback_inbox (
+                            public_id, tracking_token, source, name, email,
+                            category, message, page_path, line_user_id
+                        )
+                        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+                        RETURNING created_at
+                        """,
+                        (
+                            public_id,
+                            tracking_token,
+                            source_value,
+                            values["name"],
+                            values["email"],
+                            values["category"],
+                            values["message"],
+                            page_value,
+                            line_value,
+                        ),
+                    )
+                    created_at = cur.fetchone()[0]
+                conn.commit()
+            return FeedbackReceipt(
+                public_id=public_id,
+                tracking_token=tracking_token,
+                created_at=created_at,
+            )
+        except Exception as exc:
+            # Retry only on public_id uniqueness collisions.  Avoid hiding real
+            # database failures behind repeated writes.
+            if getattr(exc, "sqlstate", None) == "23505" and "public_id" in str(exc):
+                continue
+            raise
+
+    raise FeedbackError("受付番号を発行できませんでした。")
+
+
+def get_feedback_for_public_status(tracking_token: str | None) -> dict[str, Any] | None:
+    token = str(tracking_token or "").strip()
+    if not token or len(token) > 128:
+        return None
+    if not database_is_available():
+        raise FeedbackStoreUnavailable("お問い合わせの保存先に接続できません。")
+
+    with get_db_connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT public_id, category, status, operator_reply,
+                       created_at, updated_at, replied_at
+                FROM feedback_inbox
+                WHERE tracking_token = %s
+                """,
+                (token,),
+            )
+            row = cur.fetchone()
+    if not row:
+        return None
+    return {
+        "public_id": row[0],
+        "category": row[1],
+        "status": row[2],
+        "operator_reply": row[3],
+        "created_at": row[4],
+        "updated_at": row[5],
+        "replied_at": row[6],
+    }
+
+
+def set_operator_reply(
+    *,
+    public_id: str,
+    reply: str,
+    status: str = "responded",
+) -> dict[str, Any] | None:
+    """Store an operator reply.
+
+    E-mail delivery is intentionally separate.  A future notifier can send the
+    same stored reply when a requester supplied an address without making e-mail
+    the authoritative record.
+    """
+
+    public_id_value = _clean_required(public_id, max_length=40, message="受付番号が必要です。")
+    reply_value = _clean_required(reply, max_length=8000, message="返信内容が必要です。")
+    if status not in VALID_STATUSES:
+        raise FeedbackValidationError("対応状況が不正です。")
+    if not database_is_available():
+        raise FeedbackStoreUnavailable("お問い合わせの保存先に接続できません。")
+
+    with get_db_connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                UPDATE feedback_inbox
+                SET operator_reply = %s,
+                    status = %s,
+                    replied_at = NOW(),
+                    updated_at = NOW(),
+                    email_delivery_status = CASE
+                        WHEN email IS NULL THEN 'not_requested'
+                        ELSE 'pending'
+                    END
+                WHERE public_id = %s
+                RETURNING public_id, email, operator_reply, status,
+                          tracking_token, email_delivery_status
+                """,
+                (reply_value, status, public_id_value),
+            )
+            row = cur.fetchone()
+        conn.commit()
+    if not row:
+        return None
+    return {
+        "public_id": row[0],
+        "email": row[1],
+        "operator_reply": row[2],
+        "status": row[3],
+        "tracking_token": row[4],
+        "email_delivery_status": row[5],
+    }

--- a/migrations/20260906_feedback_inbox.sql
+++ b/migrations/20260906_feedback_inbox.sql
@@ -1,0 +1,31 @@
+CREATE TABLE IF NOT EXISTS feedback_inbox (
+    id BIGSERIAL PRIMARY KEY,
+    public_id TEXT NOT NULL UNIQUE,
+    tracking_token TEXT NOT NULL UNIQUE,
+    source TEXT NOT NULL DEFAULT 'web',
+    name TEXT,
+    email TEXT,
+    category TEXT NOT NULL,
+    message TEXT NOT NULL,
+    page_path TEXT,
+    line_user_id TEXT,
+    status TEXT NOT NULL DEFAULT 'received',
+    operator_reply TEXT,
+    email_delivery_status TEXT NOT NULL DEFAULT 'not_requested',
+    email_sent_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    replied_at TIMESTAMPTZ,
+    CONSTRAINT feedback_inbox_category_check
+        CHECK (category IN ('bug', 'request', 'usage', 'other')),
+    CONSTRAINT feedback_inbox_status_check
+        CHECK (status IN ('received', 'reviewing', 'planned', 'responded', 'closed')),
+    CONSTRAINT feedback_inbox_email_delivery_check
+        CHECK (email_delivery_status IN ('not_requested', 'pending', 'sent', 'failed'))
+);
+
+CREATE INDEX IF NOT EXISTS feedback_inbox_status_created_idx
+    ON feedback_inbox (status, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS feedback_inbox_created_idx
+    ON feedback_inbox (created_at DESC);

--- a/site_legal_ui.py
+++ b/site_legal_ui.py
@@ -10,7 +10,15 @@ from __future__ import annotations
 import os
 from html import escape
 
-from flask import Blueprint, render_template_string
+from flask import Blueprint, render_template_string, request
+
+from feedback_store import (
+    FeedbackStoreUnavailable,
+    FeedbackValidationError,
+    VALID_CATEGORIES,
+    create_feedback,
+    get_feedback_for_public_status,
+)
 
 
 site_legal_ui = Blueprint("site_legal_ui", __name__)
@@ -23,6 +31,14 @@ _REQUIRED_OPERATOR_ENV = {
 }
 
 _OPERATOR_BRAND_ENV = "SITE_OPERATOR_BRAND"
+
+_STATUS_LABELS = {
+    "received": "受付済み",
+    "reviewing": "確認中",
+    "planned": "対応予定",
+    "responded": "返信済み",
+    "closed": "対応完了",
+}
 
 
 def _env(name: str) -> str:
@@ -53,7 +69,7 @@ def sale_legal_ready() -> bool:
     return all(operator_details().values())
 
 
-def _layout(title: str, body_html: str):
+def _layout(title: str, body_html: str, *, show_sale_notice: bool = True):
     ready = sale_legal_ready()
     status = (
         "販売に必要な事業者情報を設定済みです。公開前に最終確認が必要です。"
@@ -71,7 +87,8 @@ body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;backgrou
 main{position:fixed;inset:0;box-sizing:border-box;padding:16px 20px;display:flex;align-items:center;justify-content:center}
 .card{width:min(820px,100%);max-height:calc(100dvh - 32px);box-sizing:border-box;overflow-y:auto;overscroll-behavior:contain;scrollbar-gutter:stable;background:#fff;border:1px solid #dce8de;border-radius:18px;padding:28px}
 a{color:#087d2c}.notice{padding:14px 16px;background:#eef8ef;border-radius:12px;margin-bottom:24px}h1{font-size:28px}h2{margin-top:28px;font-size:20px}dt{font-weight:700;margin-top:14px}dd{margin:4px 0 0}footer{margin-top:32px;font-size:13px;color:#66756a}.support-note{padding:16px;background:#f3f8f3;border-radius:12px}.muted{color:#66756a}.support-amounts{display:flex;gap:10px;flex-wrap:wrap;padding:0;list-style:none}.support-amounts li{padding:8px 12px;border:1px solid #cfe0d2;border-radius:999px;background:#fff;font-weight:700}
-@media(max-width:640px){main{padding:8px}.card{max-height:calc(100dvh - 16px);padding:20px;border-radius:14px}h1{font-size:24px}}
+.contact-lead{line-height:1.75;margin:0 0 22px}.field{margin-top:18px}.field label{display:block;font-weight:700;margin-bottom:7px}.field .hint{display:block;font-weight:400;color:#66756a;font-size:13px;margin-top:3px}.field input,.field select,.field textarea{width:100%;box-sizing:border-box;border:1px solid #c8d8cb;border-radius:10px;background:#fff;color:#18331f;font:inherit;padding:12px 13px}.field textarea{min-height:160px;resize:vertical}.field input:focus,.field select:focus,.field textarea:focus{outline:2px solid #bfe3c7;outline-offset:1px;border-color:#4aa963}.button{display:inline-block;margin-top:22px;border:0;border-radius:999px;padding:12px 22px;background:#11843a;color:#fff;font:inherit;font-weight:700;cursor:pointer}.button:hover{filter:brightness(.96)}.error{padding:12px 14px;background:#fff4f2;border:1px solid #f0c8c0;border-radius:10px;color:#84251d;margin-bottom:18px}.success{padding:14px 16px;background:#eef8ef;border-radius:12px;margin:16px 0}.receipt{font-size:20px;font-weight:800;letter-spacing:.02em}.status-box{padding:16px;background:#f3f8f3;border-radius:12px;margin:16px 0}.status-label{display:inline-block;padding:5px 10px;border-radius:999px;background:#e2f2e5;font-weight:700}.reply-box{white-space:pre-wrap;padding:14px 16px;background:#f7faf7;border:1px solid #dce8de;border-radius:10px;line-height:1.7}.privacy-note{font-size:13px;color:#66756a;line-height:1.6;margin-top:16px}.hp-field{position:absolute;left:-10000px;width:1px;height:1px;overflow:hidden}
+@media(max-width:640px){main{padding:8px}.card{max-height:calc(100dvh - 16px);padding:20px;border-radius:14px}h1{font-size:24px}.button{width:100%}}
 </style>
 <script>
 (function(){
@@ -83,14 +100,53 @@ a{color:#087d2c}.notice{padding:14px 16px;background:#eef8ef;border-radius:12px;
   window.addEventListener('pageshow',resetCard);
   window.addEventListener('load',resetCard);
 })();
-</script></head><body><main><div class="card"><div class="notice">{{ status }}</div>
+</script></head><body><main><div class="card">{% if show_sale_notice %}<div class="notice">{{ status }}</div>{% endif %}
 <h1>{{ title }}</h1>{{ body|safe }}<footer><a href="/site">LicenseTown公式サイトへ戻る</a></footer>
 </div></main></body></html>
         """,
         title=title,
         status=status,
         body=body_html,
+        show_sale_notice=show_sale_notice,
     )
+
+
+def _contact_form(*, values: dict[str, str] | None = None, error: str = "") -> str:
+    values = values or {}
+    category = values.get("category", "")
+    options = ['<option value="">選択してください</option>']
+    for value, label in VALID_CATEGORIES.items():
+        selected = " selected" if category == value else ""
+        options.append(f'<option value="{escape(value)}"{selected}>{escape(label)}</option>')
+    error_html = f'<div class="error" role="alert">{escape(error)}</div>' if error else ""
+    return f"""
+<p class="contact-lead">不具合や使いにくいところ、「こうしてほしい」というご要望、使い方についての質問などをお送りください。小さなことでも大歓迎です。</p>
+{error_html}
+<form method="post" action="/site/legal/contact#top" novalidate>
+  <div class="field">
+    <label for="name">お名前 <span class="hint">ニックネームでも可・任意</span></label>
+    <input id="name" name="name" type="text" maxlength="80" autocomplete="name" value="{escape(values.get('name', ''))}">
+  </div>
+  <div class="field">
+    <label for="email">返信先メールアドレス <span class="hint">任意</span></label>
+    <input id="email" name="email" type="email" maxlength="254" autocomplete="email" value="{escape(values.get('email', ''))}">
+    <span class="hint">未入力でも送信できます。メール返信機能は現在準備中のため、当面は送信後に表示される確認ページをご利用ください。</span>
+  </div>
+  <div class="field">
+    <label for="category">お問い合わせ種類</label>
+    <select id="category" name="category" required>{''.join(options)}</select>
+  </div>
+  <div class="field">
+    <label for="message">お問い合わせ内容</label>
+    <textarea id="message" name="message" maxlength="4000" required>{escape(values.get('message', ''))}</textarea>
+  </div>
+  <div class="hp-field" aria-hidden="true">
+    <label for="website">Web site</label><input id="website" name="website" type="text" tabindex="-1" autocomplete="off">
+  </div>
+  <p class="privacy-note">送信内容は、お問い合わせへの対応とLicenseTownの改善のために利用します。返信先メールアドレスを入力した場合は、返信のためにも利用します。</p>
+  <button class="button" type="submit">送信する</button>
+</form>
+"""
 
 
 @site_legal_ui.get("/site/legal/commercial-transactions")
@@ -115,6 +171,8 @@ def privacy():
 <p>LicenseTownは、学習サービスの提供に必要な範囲で利用者情報を取り扱います。</p>
 <h2>取り扱う主な情報</h2>
 <p>LINE等のアカウント識別情報、学習履歴、回答結果、学習進捗、サービス利用状況、契約・利用権限に関する情報など。</p>
+<h2>お問い合わせ情報</h2>
+<p>お問い合わせフォームから送信された内容、入力されたお名前またはニックネーム、返信先メールアドレス（任意）を、お問い合わせ対応とサービス改善のために取り扱います。返信先メールアドレスは、入力された場合に返信のためにも利用します。</p>
 <h2>利用目的</h2>
 <p>本人確認、学習機能・弱点分析・見守り機能の提供、サポート、不正利用防止、サービス改善、契約状態の管理のために利用します。</p>
 <h2>決済情報</h2>
@@ -122,7 +180,7 @@ def privacy():
 <h2>見守り機能</h2>
 <p>見守り相手には学習状況を共有します。個別の相談内容そのものを見守り画面へ共有しない方針です。</p>
 <h2>最終確認</h2>
-<p>本ページは販売開始前に、保存期間・第三者提供・委託先・開示等請求・問い合わせ窓口を含めて最終確認します。</p>
+<p>本ページは販売開始前に、保存期間・第三者提供・委託先・開示等請求を含めて最終確認します。</p>
 """
     return _layout("プライバシーポリシー", body)
 
@@ -173,11 +231,109 @@ def support():
     return _layout("LicenseTownを応援する", body)
 
 
-@site_legal_ui.get("/site/legal/contact")
+@site_legal_ui.route("/site/legal/contact", methods=["GET", "POST"])
 def contact():
-    email = _env("SITE_SUPPORT_EMAIL")
-    if email:
-        body = f'<p>お問い合わせ：<a href="mailto:{escape(email)}">{escape(email)}</a></p>'
-    else:
-        body = "<p>お問い合わせ窓口は販売開始前に掲載します。</p>"
-    return _layout("お問い合わせ", body)
+    if request.method == "GET":
+        return _layout("お問い合わせ", _contact_form(), show_sale_notice=False)
+
+    values = {
+        "name": str(request.form.get("name") or ""),
+        "email": str(request.form.get("email") or ""),
+        "category": str(request.form.get("category") or ""),
+        "message": str(request.form.get("message") or ""),
+    }
+
+    # Quietly absorb simple bot submissions without writing them to the inbox.
+    if str(request.form.get("website") or "").strip():
+        body = """
+<div class="success"><strong>お問い合わせを受け付けました。</strong></div>
+<p>ご連絡ありがとうございました。</p>
+"""
+        return _layout("お問い合わせ", body, show_sale_notice=False)
+
+    try:
+        receipt = create_feedback(
+            name=values["name"],
+            email=values["email"],
+            category=values["category"],
+            message=values["message"],
+            source="web",
+            page_path=request.path,
+        )
+    except FeedbackValidationError as exc:
+        return _layout(
+            "お問い合わせ",
+            _contact_form(values=values, error=str(exc)),
+            show_sale_notice=False,
+        ), 400
+    except FeedbackStoreUnavailable:
+        return _layout(
+            "お問い合わせ",
+            _contact_form(
+                values=values,
+                error="現在お問い合わせを保存できません。時間をおいて、もう一度お試しください。",
+            ),
+            show_sale_notice=False,
+        ), 503
+    except Exception:
+        return _layout(
+            "お問い合わせ",
+            _contact_form(
+                values=values,
+                error="送信中に問題が発生しました。時間をおいて、もう一度お試しください。",
+            ),
+            show_sale_notice=False,
+        ), 503
+
+    token = escape(receipt.tracking_token, quote=True)
+    public_id = escape(receipt.public_id)
+    body = f"""
+<div class="success"><strong>お問い合わせを受け付けました。</strong></div>
+<p>受付番号</p><p class="receipt">{public_id}</p>
+<p>こちらで内容を確認します。お問い合わせ状況と運営からの返信は、下の専用ページから確認できます。</p>
+<p><a class="button" href="/site/legal/contact/status?token={token}#top">お問い合わせ状況を確認する</a></p>
+<p class="privacy-note">この確認ページのURLは、他の人に共有しないでください。受付番号だけでは内容を表示できません。</p>
+"""
+    return _layout("お問い合わせ", body, show_sale_notice=False), 201
+
+
+@site_legal_ui.get("/site/legal/contact/status")
+def contact_status():
+    token = str(request.args.get("token") or "").strip()
+    if not token:
+        body = """
+<p>お問い合わせ送信後に表示された専用の確認URLから開いてください。</p>
+<p><a href="/site/legal/contact#top">お問い合わせフォームへ</a></p>
+"""
+        return _layout("お問い合わせ状況", body, show_sale_notice=False), 400
+
+    try:
+        item = get_feedback_for_public_status(token)
+    except FeedbackStoreUnavailable:
+        item = None
+
+    if not item:
+        body = """
+<p>このお問い合わせを確認できませんでした。URLが途中で切れていないか確認してください。</p>
+<p><a href="/site/legal/contact#top">お問い合わせフォームへ</a></p>
+"""
+        return _layout("お問い合わせ状況", body, show_sale_notice=False), 404
+
+    status_label = _STATUS_LABELS.get(str(item.get("status") or ""), "確認中")
+    category_label = VALID_CATEGORIES.get(str(item.get("category") or ""), "その他")
+    reply = str(item.get("operator_reply") or "").strip()
+    reply_html = (
+        f'<h2>運営からの返信</h2><div class="reply-box">{escape(reply)}</div>'
+        if reply
+        else '<p class="muted">運営からの返信はまだありません。</p>'
+    )
+    body = f"""
+<div class="status-box">
+<p><strong>受付番号：</strong>{escape(str(item['public_id']))}</p>
+<p><strong>種類：</strong>{escape(category_label)}</p>
+<p><strong>状況：</strong> <span class="status-label">{escape(status_label)}</span></p>
+</div>
+{reply_html}
+<p class="privacy-note">このページには、お名前・メールアドレス・送信本文は表示しません。</p>
+"""
+    return _layout("お問い合わせ状況", body, show_sale_notice=False)

--- a/tests/test_feedback_store.py
+++ b/tests/test_feedback_store.py
@@ -1,0 +1,71 @@
+from datetime import datetime, timezone
+
+import pytest
+
+import feedback_store
+
+
+def test_validate_feedback_allows_nickname_and_optional_email():
+    values = feedback_store.validate_feedback(
+        name="げん好き",
+        email="",
+        category="request",
+        message="ここをもう少し分かりやすくしてほしいです。",
+    )
+    assert values["name"] == "げん好き"
+    assert values["email"] is None
+    assert values["category"] == "request"
+
+
+def test_validate_feedback_rejects_bad_email():
+    with pytest.raises(feedback_store.FeedbackValidationError):
+        feedback_store.validate_feedback(
+            name="test",
+            email="not-an-email",
+            category="bug",
+            message="動きません",
+        )
+
+
+def test_validate_feedback_requires_category_and_message():
+    with pytest.raises(feedback_store.FeedbackValidationError):
+        feedback_store.validate_feedback(name="", email="", category="", message="text")
+    with pytest.raises(feedback_store.FeedbackValidationError):
+        feedback_store.validate_feedback(name="", email="", category="other", message="")
+
+
+def test_get_public_status_does_not_return_private_fields(monkeypatch):
+    class Cursor:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def execute(self, sql, params):
+            assert "name" not in sql.lower()
+            assert "email" not in sql.lower()
+            assert "message" not in sql.lower()
+
+        def fetchone(self):
+            now = datetime.now(timezone.utc)
+            return ("LT-20260906-ABCDEF12", "bug", "received", None, now, now, None)
+
+    class Connection:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def cursor(self):
+            return Cursor()
+
+    monkeypatch.setattr(feedback_store, "database_is_available", lambda: True)
+    monkeypatch.setattr(feedback_store, "get_db_connection", lambda: Connection())
+
+    item = feedback_store.get_feedback_for_public_status("private-token")
+    assert item["public_id"] == "LT-20260906-ABCDEF12"
+    assert "email" not in item
+    assert "name" not in item
+    assert "message" not in item

--- a/tests/test_site_contact_feedback.py
+++ b/tests/test_site_contact_feedback.py
@@ -1,0 +1,127 @@
+from datetime import datetime, timezone
+
+from flask import Flask
+
+import site_legal_ui
+from feedback_store import FeedbackReceipt, FeedbackValidationError
+
+
+def _app():
+    app = Flask(__name__)
+    app.register_blueprint(site_legal_ui.site_legal_ui)
+    app.config.update(TESTING=True)
+    return app
+
+
+def test_contact_get_has_low_friction_fields():
+    response = _app().test_client().get("/site/legal/contact")
+    assert response.status_code == 200
+    html = response.get_data(as_text=True)
+    assert "お名前" in html
+    assert "ニックネームでも可・任意" in html
+    assert "返信先メールアドレス" in html
+    assert "未入力でも送信できます" in html
+    assert "不具合" in html
+    assert "ご要望" in html
+    assert "使い方について" in html
+    assert "お問い合わせ内容" in html
+    assert "販売開始前の準備ページ" not in html
+
+
+def test_contact_post_success_shows_receipt_and_private_status_link(monkeypatch):
+    receipt = FeedbackReceipt(
+        public_id="LT-20260906-ABCDEF12",
+        tracking_token="private-token-123",
+        created_at=datetime.now(timezone.utc),
+    )
+    calls = []
+
+    def fake_create_feedback(**kwargs):
+        calls.append(kwargs)
+        return receipt
+
+    monkeypatch.setattr(site_legal_ui, "create_feedback", fake_create_feedback)
+    response = _app().test_client().post(
+        "/site/legal/contact",
+        data={
+            "name": "源さんファン",
+            "email": "user@example.test",
+            "category": "request",
+            "message": "この機能がほしいです。",
+            "website": "",
+        },
+    )
+    assert response.status_code == 201
+    html = response.get_data(as_text=True)
+    assert "LT-20260906-ABCDEF12" in html
+    assert "private-token-123" in html
+    assert "受付番号だけでは内容を表示できません" in html
+    assert calls[0]["name"] == "源さんファン"
+    assert calls[0]["source"] == "web"
+
+
+def test_contact_validation_error_preserves_input(monkeypatch):
+    def fake_create_feedback(**kwargs):
+        raise FeedbackValidationError("メールアドレスの形式を確認してください。")
+
+    monkeypatch.setattr(site_legal_ui, "create_feedback", fake_create_feedback)
+    response = _app().test_client().post(
+        "/site/legal/contact",
+        data={
+            "name": "ニック",
+            "email": "bad",
+            "category": "bug",
+            "message": "困っています",
+        },
+    )
+    assert response.status_code == 400
+    html = response.get_data(as_text=True)
+    assert "メールアドレスの形式を確認してください" in html
+    assert "ニック" in html
+    assert "困っています" in html
+
+
+def test_honeypot_submission_does_not_write(monkeypatch):
+    def should_not_run(**kwargs):
+        raise AssertionError("honeypot submission must not be stored")
+
+    monkeypatch.setattr(site_legal_ui, "create_feedback", should_not_run)
+    response = _app().test_client().post(
+        "/site/legal/contact",
+        data={
+            "website": "https://spam.example",
+            "category": "other",
+            "message": "spam",
+        },
+    )
+    assert response.status_code == 200
+    assert "お問い合わせを受け付けました" in response.get_data(as_text=True)
+
+
+def test_status_page_shows_reply_but_not_private_submission(monkeypatch):
+    monkeypatch.setattr(
+        site_legal_ui,
+        "get_feedback_for_public_status",
+        lambda token: {
+            "public_id": "LT-20260906-ABCDEF12",
+            "category": "bug",
+            "status": "responded",
+            "operator_reply": "ご報告ありがとうございます。修正しました。",
+            "created_at": datetime.now(timezone.utc),
+            "updated_at": datetime.now(timezone.utc),
+            "replied_at": datetime.now(timezone.utc),
+        },
+    )
+    response = _app().test_client().get("/site/legal/contact/status?token=secret")
+    assert response.status_code == 200
+    html = response.get_data(as_text=True)
+    assert "返信済み" in html
+    assert "ご報告ありがとうございます。修正しました。" in html
+    assert "お名前・メールアドレス・送信本文は表示しません" in html
+
+
+def test_status_page_without_private_token_does_not_enumerate_by_receipt():
+    response = _app().test_client().get("/site/legal/contact/status")
+    assert response.status_code == 400
+    html = response.get_data(as_text=True)
+    assert "専用の確認URL" in html

--- a/tests/test_weekly_question_history.py
+++ b/tests/test_weekly_question_history.py
@@ -1,5 +1,6 @@
 import os
 from datetime import datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
 
 os.environ.setdefault("OPENAI_API_KEY", "test-key")
 os.environ.setdefault("CHANNEL_ACCESS_TOKEN", "test-token")
@@ -11,7 +12,10 @@ from database import get_weekly_question_history, set_supporter_link, deactivate
 from goukaku_ui import create_supporter_token
 
 
-NOW = datetime(2026, 8, 30, 3, 0, tzinfo=timezone.utc)  # 2026/08/30 JST
+# Keep fixtures in the actual current week so route-level tests do not expire as
+# calendar time advances.  The previous fixed 2026-08-30 value became stale on
+# the following week and made an unrelated PR fail.
+NOW = datetime.now(timezone.utc)
 
 
 def row(q, days, correct, confidence=2, selected=None, user="learner"):
@@ -34,8 +38,11 @@ def test_weekly_summary_boundaries_duplicates_unknown_and_natural_sort():
         row("Q1", 0, False, 1, user="other"),
     ])
     result = get_weekly_question_history("learner", NOW)
-    assert result["start_date"].isoformat() == "2026-08-24"
-    assert result["end_date"].isoformat() == "2026-08-30"
+    today_jst = NOW.astimezone(ZoneInfo("Asia/Tokyo")).date()
+    expected_start = today_jst - timedelta(days=today_jst.weekday())
+    expected_end = expected_start + timedelta(days=6)
+    assert result["start_date"] == expected_start
+    assert result["end_date"] == expected_end
     assert result["total_attempts"] == 4
     assert result["unique_questions"] == 3
     assert result["attempted_question_ids"] == ["Q2", "Q3", "Q10"]


### PR DESCRIPTION
## Purpose
Create a low-friction public feedback/inquiry path that does not depend on Google/Gmail.

## Scope
- Replace the existing `/site/legal/contact` destination with a public feedback form while preserving the proven top-level standalone URL.
- Store submissions in Neon as the authoritative record.
- Allow nickname/anonymous-ish use; reply email is optional.
- Issue a receipt number plus a private status URL.
- Show operator replies on the private status page without exposing name, email, or submitted message.
- Add a honeypot for basic bot filtering.
- Extend privacy copy for inquiry data.
- Add migration and tests.

## Test maintenance
- The full suite exposed an existing date-expiry defect in `tests/test_weekly_question_history.py`: its route-level fixture was fixed to 2026-08-30 and stopped being in the current week on 2026-09-06. The test fixture is now current-week-relative; product weekly-history behavior is unchanged.

## Safety
- No change to LINE learning logic, Question Bank, adaptive selector, payment behavior, or current production database.
- Email delivery is not enabled yet; the UI says it is preparing and status page remains the authoritative reply channel.
- Production migration remains unapplied pending final approval.