### PR TITLE
Clarify inquiry email replies and spam guidance

### DIFF
--- a/site_legal_ui.py
+++ b/site_legal_ui.py
@@ -130,7 +130,7 @@ def _contact_form(*, values: dict[str, str] | None = None, error: str = "") -> s
   <div class="field">
     <label for="email">返信先メールアドレス <span class="hint">任意</span></label>
     <input id="email" name="email" type="email" maxlength="254" autocomplete="email" value="{escape(values.get('email', ''))}">
-    <span class="hint">未入力でも送信できます。メール返信機能は現在準備中のため、当面は送信後に表示される確認ページをご利用ください。</span>
+    <span class="hint">未入力でも送信できます。入力した場合は、このアドレス宛てにも返信します。返信が見当たらない場合は迷惑メールフォルダをご確認ください。</span>
   </div>
   <div class="field">
     <label for="category">お問い合わせ種類</label>
@@ -287,10 +287,17 @@ def contact():
 
     token = escape(receipt.tracking_token, quote=True)
     public_id = escape(receipt.public_id)
+    email_notice = ""
+    if values["email"].strip():
+        email_notice = """
+<p><strong>返信先メールアドレスにも返信します。</strong></p>
+<p class="privacy-note">返信メールが見当たらない場合は、迷惑メールフォルダをご確認ください。迷惑メールに入っていた場合は、そのメールを「迷惑メールではない」に設定してください。</p>
+"""
     body = f"""
 <div class="success"><strong>お問い合わせを受け付けました。</strong></div>
 <p>受付番号</p><p class="receipt">{public_id}</p>
 <p>こちらで内容を確認します。お問い合わせ状況と運営からの返信は、下の専用ページから確認できます。</p>
+{email_notice}
 <p><a class="button" href="/site/legal/contact/status?token={token}#top">お問い合わせ状況を確認する</a></p>
 <p class="privacy-note">この確認ページのURLは、他の人に共有しないでください。受付番号だけでは内容を表示できません。</p>
 """

--- a/tests/test_site_contact_feedback.py
+++ b/tests/test_site_contact_feedback.py
@@ -21,6 +21,8 @@ def test_contact_get_has_low_friction_fields():
     assert "ニックネームでも可・任意" in html
     assert "返信先メールアドレス" in html
     assert "未入力でも送信できます" in html
+    assert "入力した場合は、このアドレス宛てにも返信します" in html
+    assert "迷惑メールフォルダをご確認ください" in html
     assert "不具合" in html
     assert "ご要望" in html
     assert "使い方について" in html
@@ -56,8 +58,33 @@ def test_contact_post_success_shows_receipt_and_private_status_link(monkeypatch)
     assert "LT-20260906-ABCDEF12" in html
     assert "private-token-123" in html
     assert "受付番号だけでは内容を表示できません" in html
+    assert "返信先メールアドレスにも返信します" in html
+    assert "迷惑メールではない" in html
     assert calls[0]["name"] == "源さんファン"
     assert calls[0]["source"] == "web"
+
+
+def test_contact_post_without_email_does_not_show_email_delivery_notice(monkeypatch):
+    receipt = FeedbackReceipt(
+        public_id="LT-20260906-NOEMAIL01",
+        tracking_token="private-token-no-email",
+        created_at=datetime.now(timezone.utc),
+    )
+    monkeypatch.setattr(site_legal_ui, "create_feedback", lambda **kwargs: receipt)
+    response = _app().test_client().post(
+        "/site/legal/contact",
+        data={
+            "name": "",
+            "email": "",
+            "category": "other",
+            "message": "確認です。",
+            "website": "",
+        },
+    )
+    assert response.status_code == 201
+    html = response.get_data(as_text=True)
+    assert "返信先メールアドレスにも返信します" not in html
+    assert "迷惑メールではない" not in html
 
 
 def test_contact_validation_error_preserves_input(monkeypatch):


### PR DESCRIPTION
問い合わせフォームのメール案内を、現在の0円運用方針に合わせて更新します。

- メールアドレス入力時は、そのアドレス宛てにも返信することを明記
- 返信が見当たらない場合の迷惑メール確認・「迷惑メールではない」設定を案内
- メール未入力時は送信完了画面にメール案内を出さない
- 既存のNeon保存・専用確認ページは維持
- テスト追加

本PRはまずCI確認用のdraftです。Productionへの反映は安全確認後に判断します。