### PR TITLE
Add internal feedback email reply workflow

### DIFF
--- a/developer_ui.py
+++ b/developer_ui.py
@@ -1,4 +1,4 @@
-"""Internal developer-only diagnostics routes.
+"""Internal developer-only diagnostics and operator routes.
 
 The public app already registers ``site_ui``. To avoid touching the large Flask
 entrypoint, these routes are attached to that existing blueprint before it is
@@ -14,6 +14,16 @@ import os
 from flask import abort, redirect, render_template, request, url_for
 
 from developer_status import build_developer_system_status
+from email_delivery import EmailDeliveryError, send_feedback_reply
+from feedback_store import (
+    FeedbackStoreUnavailable,
+    FeedbackValidationError,
+    VALID_CATEGORIES,
+    get_feedback_for_operator,
+    list_feedback_for_operator,
+    mark_email_delivery,
+    set_operator_reply,
+)
 from goukaku_ui import build_dashboard
 from pilot_diagnostics import build_pilot_diagnostics
 from supporter_performance import begin_request, finish_request
@@ -41,6 +51,13 @@ def require_developer_authorization() -> str:
     if not developer_authorized(token):
         abort(403)
     return str(token)
+
+
+def _decorate_feedback(item):
+    if not item:
+        return item
+    item["category_label"] = VALID_CATEGORIES.get(str(item.get("category") or ""), "その他")
+    return item
 
 
 def register_developer_routes(blueprint) -> None:
@@ -93,6 +110,7 @@ def register_developer_routes(blueprint) -> None:
             internal_token=token,
             learner_id=learner_id,
             system_status=build_developer_system_status(),
+            feedback_url=url_for("site_ui.internal_feedback", token=token),
             pilot_url=(
                 url_for(
                     "site_ui.internal_pilot_diagnostics",
@@ -111,6 +129,77 @@ def register_developer_routes(blueprint) -> None:
                 if learner_id
                 else None
             ),
+        )
+
+    @blueprint.route("/internal/feedback", methods=["GET", "POST"], endpoint="internal_feedback")
+    def _internal_feedback():
+        token = require_developer_authorization()
+        public_id = str(request.values.get("public_id") or "").strip()
+        notice = ""
+        error = ""
+
+        if request.method == "POST":
+            action = str(request.form.get("action") or "").strip()
+            selected = get_feedback_for_operator(public_id)
+            if not selected:
+                abort(404)
+
+            try:
+                if action == "reply":
+                    stored = set_operator_reply(
+                        public_id=public_id,
+                        reply=str(request.form.get("reply") or ""),
+                        status="responded",
+                    )
+                    if not stored:
+                        abort(404)
+                    selected = get_feedback_for_operator(public_id)
+                elif action == "retry":
+                    if not str(selected.get("operator_reply") or "").strip():
+                        raise FeedbackValidationError("再送できる保存済み返信がありません。")
+                else:
+                    abort(400)
+
+                if selected and selected.get("email"):
+                    try:
+                        delivery = send_feedback_reply(
+                            public_id=public_id,
+                            to_email=str(selected["email"]),
+                            reply=str(selected.get("operator_reply") or ""),
+                        )
+                    except EmailDeliveryError as exc:
+                        mark_email_delivery(public_id=public_id, delivery_status="failed")
+                        error = f"返信はNeonに保存しましたが、メール送信に失敗しました: {exc}"
+                    else:
+                        mark_email_delivery(
+                            public_id=public_id,
+                            delivery_status=delivery.delivery_state,
+                        )
+                        notice = (
+                            "返信を保存し、メール配送を確認しました。"
+                            if delivery.delivery_state == "sent"
+                            else "返信を保存し、メール送信を受け付けました。配送確認待ちです。"
+                        )
+                else:
+                    notice = "返信をNeonに保存しました。メールアドレス未入力のためメール送信はありません。"
+            except FeedbackValidationError as exc:
+                error = str(exc)
+
+        try:
+            items = [_decorate_feedback(item) for item in list_feedback_for_operator(limit=100)]
+            selected = _decorate_feedback(get_feedback_for_operator(public_id)) if public_id else None
+        except FeedbackStoreUnavailable:
+            items = []
+            selected = None
+            error = "お問い合わせの保存先に接続できません。"
+
+        return render_template(
+            "internal/feedback.html",
+            internal_token=token,
+            items=items,
+            selected=selected,
+            notice=notice,
+            error=error,
         )
 
     @blueprint.route(

--- a/email_delivery.py
+++ b/email_delivery.py
@@ -1,0 +1,113 @@
+"""Transactional email delivery for LicenseTown feedback replies.
+
+Neon remains the source of truth. When a requester supplied an email address,
+LicenseTown also delivers the stored operator reply to that address.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from dataclasses import dataclass
+from typing import Any
+
+import requests
+
+
+_PRIMITIVE_SEND_URL = "https://api.primitive.dev/v1/send-mail"
+_DEFAULT_FROM = "LicenseTown <agent@thin-snail.primitive.email>"
+_SUCCESS_STATUSES = {"delivered"}
+_PENDING_STATUSES = {"queued", "submitted_to_agent", "deferred", "wait_timeout", "unknown"}
+
+
+class EmailDeliveryError(RuntimeError):
+    """Raised when the provider cannot accept or deliver a feedback reply."""
+
+
+@dataclass(frozen=True)
+class EmailDeliveryResult:
+    delivery_state: str
+    provider_status: str
+    provider_message_id: str | None = None
+
+
+def email_delivery_configured() -> bool:
+    return bool(str(os.getenv("PRIMITIVE_API_KEY") or "").strip())
+
+
+def _idempotency_key(public_id: str, reply: str) -> str:
+    digest = hashlib.sha256(reply.encode("utf-8")).hexdigest()[:20]
+    return f"lt-feedback-{public_id}-{digest}"
+
+
+def send_feedback_reply(
+    *,
+    public_id: str,
+    to_email: str,
+    reply: str,
+    timeout_seconds: float = 20.0,
+) -> EmailDeliveryResult:
+    """Send the exact stored operator reply through Primitive.
+
+    The request uses Primitive's idempotency support so a retry with the same
+    receipt number and reply body does not create a duplicate message.
+    """
+
+    api_key = str(os.getenv("PRIMITIVE_API_KEY") or "").strip()
+    if not api_key:
+        raise EmailDeliveryError("PRIMITIVE_API_KEY が設定されていません。")
+
+    from_address = str(os.getenv("LT_FEEDBACK_EMAIL_FROM") or _DEFAULT_FROM).strip()
+    subject = f"【LicenseTown】お問い合わせへの返信 {public_id}"
+    body_text = (
+        "お問い合わせありがとうございます。\n\n"
+        f"{reply.strip()}\n\n"
+        f"受付番号: {public_id}\n\n"
+        "※このメールが迷惑メールフォルダに入っていた場合は、"
+        "「迷惑メールではない」に設定してください。\n"
+        "LicenseTown"
+    )
+    payload: dict[str, Any] = {
+        "from": from_address,
+        "to": to_email,
+        "subject": subject,
+        "body_text": body_text,
+        "wait": True,
+    }
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+        "Idempotency-Key": _idempotency_key(public_id, reply),
+    }
+
+    try:
+        response = requests.post(
+            _PRIMITIVE_SEND_URL,
+            json=payload,
+            headers=headers,
+            timeout=timeout_seconds,
+        )
+    except requests.RequestException as exc:
+        raise EmailDeliveryError("メール送信サービスに接続できませんでした。") from exc
+
+    try:
+        data = response.json()
+    except ValueError:
+        data = {}
+
+    if response.status_code >= 400:
+        message = str(data.get("message") or data.get("error_message") or "").strip()
+        suffix = f" ({message})" if message else ""
+        raise EmailDeliveryError(f"メール送信サービスが送信を受け付けませんでした{suffix}")
+
+    inner = data.get("data") if isinstance(data.get("data"), dict) else data
+    provider_status = str(
+        inner.get("delivery_status") or inner.get("status") or "unknown"
+    ).strip()
+    message_id = str(inner.get("id") or "").strip() or None
+
+    if provider_status in _SUCCESS_STATUSES:
+        return EmailDeliveryResult("sent", provider_status, message_id)
+    if provider_status in _PENDING_STATUSES:
+        return EmailDeliveryResult("pending", provider_status, message_id)
+    raise EmailDeliveryError(f"メール配送に失敗しました ({provider_status or 'unknown'})")

--- a/feedback_store.py
+++ b/feedback_store.py
@@ -1,7 +1,8 @@
 """Persistence helpers for LicenseTown public feedback.
 
-The public form intentionally stores the authoritative copy in Neon.  E-mail is
-an optional delivery channel for future replies, never the system of record.
+Neon is the authoritative copy of every inquiry and operator reply. When a
+requester supplied an email address, email delivery is also required and its
+state is recorded alongside the stored reply.
 """
 
 from __future__ import annotations
@@ -22,6 +23,7 @@ VALID_CATEGORIES = {
     "other": "その他",
 }
 VALID_STATUSES = {"received", "reviewing", "planned", "responded", "closed"}
+VALID_EMAIL_DELIVERY_STATUSES = {"not_requested", "pending", "sent", "failed"}
 
 _EMAIL_RE = re.compile(r"^[^\s@]+@[^\s@]+\.[^\s@]+$")
 
@@ -83,7 +85,6 @@ def validate_feedback(*, name: str | None, email: str | None, category: str | No
 
 
 def _new_public_id(now: datetime) -> str:
-    # Short enough to quote in conversation, random enough to avoid collisions.
     return f"LT-{now:%Y%m%d}-{secrets.token_hex(4).upper()}"
 
 
@@ -107,8 +108,6 @@ def create_feedback(
     page_value = _clean_optional(page_path, max_length=240)
     line_value = _clean_optional(line_user_id, max_length=160)
 
-    # Collision is extremely unlikely. Retry public_id only, keeping the private
-    # tracking token stable for this submission.
     for _ in range(4):
         public_id = _new_public_id(now)
         try:
@@ -143,8 +142,6 @@ def create_feedback(
                 created_at=created_at,
             )
         except Exception as exc:
-            # Retry only on public_id uniqueness collisions.  Avoid hiding real
-            # database failures behind repeated writes.
             if getattr(exc, "sqlstate", None) == "23505" and "public_id" in str(exc):
                 continue
             raise
@@ -184,18 +181,59 @@ def get_feedback_for_public_status(tracking_token: str | None) -> dict[str, Any]
     }
 
 
+def list_feedback_for_operator(*, limit: int = 100) -> list[dict[str, Any]]:
+    if not database_is_available():
+        raise FeedbackStoreUnavailable("お問い合わせの保存先に接続できません。")
+    safe_limit = min(max(int(limit), 1), 200)
+    with get_db_connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT public_id, name, email, category, message, status,
+                       operator_reply, email_delivery_status, email_sent_at,
+                       created_at, updated_at, replied_at, tracking_token
+                FROM feedback_inbox
+                ORDER BY created_at DESC
+                LIMIT %s
+                """,
+                (safe_limit,),
+            )
+            rows = cur.fetchall()
+    return [
+        {
+            "public_id": row[0],
+            "name": row[1],
+            "email": row[2],
+            "category": row[3],
+            "message": row[4],
+            "status": row[5],
+            "operator_reply": row[6],
+            "email_delivery_status": row[7],
+            "email_sent_at": row[8],
+            "created_at": row[9],
+            "updated_at": row[10],
+            "replied_at": row[11],
+            "tracking_token": row[12],
+        }
+        for row in rows
+    ]
+
+
+def get_feedback_for_operator(public_id: str | None) -> dict[str, Any] | None:
+    public_id_value = str(public_id or "").strip()
+    if not public_id_value or len(public_id_value) > 40:
+        return None
+    items = list_feedback_for_operator(limit=200)
+    return next((item for item in items if item["public_id"] == public_id_value), None)
+
+
 def set_operator_reply(
     *,
     public_id: str,
     reply: str,
     status: str = "responded",
 ) -> dict[str, Any] | None:
-    """Store an operator reply.
-
-    E-mail delivery is intentionally separate.  A future notifier can send the
-    same stored reply when a requester supplied an address without making e-mail
-    the authoritative record.
-    """
+    """Store the reply first; email delivery follows from this stored text."""
 
     public_id_value = _clean_required(public_id, max_length=40, message="受付番号が必要です。")
     reply_value = _clean_required(reply, max_length=8000, message="返信内容が必要です。")
@@ -216,7 +254,8 @@ def set_operator_reply(
                     email_delivery_status = CASE
                         WHEN email IS NULL THEN 'not_requested'
                         ELSE 'pending'
-                    END
+                    END,
+                    email_sent_at = NULL
                 WHERE public_id = %s
                 RETURNING public_id, email, operator_reply, status,
                           tracking_token, email_delivery_status
@@ -235,3 +274,31 @@ def set_operator_reply(
         "tracking_token": row[4],
         "email_delivery_status": row[5],
     }
+
+
+def mark_email_delivery(*, public_id: str, delivery_status: str) -> bool:
+    public_id_value = _clean_required(public_id, max_length=40, message="受付番号が必要です。")
+    if delivery_status not in VALID_EMAIL_DELIVERY_STATUSES:
+        raise FeedbackValidationError("メール配送状況が不正です。")
+    if not database_is_available():
+        raise FeedbackStoreUnavailable("お問い合わせの保存先に接続できません。")
+
+    with get_db_connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                UPDATE feedback_inbox
+                SET email_delivery_status = %s,
+                    email_sent_at = CASE
+                        WHEN %s = 'sent' THEN NOW()
+                        WHEN %s IN ('failed', 'not_requested') THEN NULL
+                        ELSE email_sent_at
+                    END,
+                    updated_at = NOW()
+                WHERE public_id = %s
+                """,
+                (delivery_status, delivery_status, delivery_status, public_id_value),
+            )
+            updated = cur.rowcount > 0
+        conn.commit()
+    return updated

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ gunicorn==21.2.0
 line-bot-sdk==3.18.1
 openai>=1.0.0
 stripe>=12.0.0
+requests>=2.32.3
 setuptools>=65.0.0
 wheel>=0.40.0
 build>=1.0.3

--- a/templates/internal/feedback.html
+++ b/templates/internal/feedback.html
@@ -93,7 +93,7 @@
         </form>
         {% endif %}
 
-        <p class="muted" style="margin-top:18px;">公開確認ページ: <a href="{{ url_for('site_legal_ui.contact_status', token=selected.tracking_token) }}" target="_blank" rel="noopener">確認する</a></p>
+        <p class="muted" style="margin-top:18px;">公開確認ページ: <a href="{{ url_for('site_ui.site_legal_ui.contact_status', token=selected.tracking_token) }}" target="_blank" rel="noopener">確認する</a></p>
       {% else %}
         <h2>問い合わせを選択</h2>
         <p class="muted">左の一覧から対応する問い合わせを選んでください。</p>

--- a/templates/internal/feedback.html
+++ b/templates/internal/feedback.html
@@ -1,0 +1,105 @@
+<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>お問い合わせ | LicenseTown Internal</title>
+  <style>
+    :root { color-scheme: light; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    body { margin: 0; background: #f5f7f6; color: #16231b; }
+    main { width: min(1180px, calc(100% - 28px)); margin: 28px auto 60px; }
+    a { color: #176b42; }
+    h1 { margin-bottom: 6px; }
+    .muted { color: #5f6d64; }
+    .grid { display: grid; grid-template-columns: minmax(300px, 0.9fr) minmax(380px, 1.4fr); gap: 16px; align-items: start; }
+    .card { background: #fff; border: 1px solid #dbe4de; border-radius: 12px; padding: 16px; box-shadow: 0 1px 3px rgba(0,0,0,.04); }
+    .item { display:block; padding: 11px 10px; margin: 0 -4px 6px; border: 1px solid #edf1ee; border-radius: 9px; text-decoration:none; color:inherit; }
+    .item:hover { background:#f8fbf9; }
+    .item strong { display:block; margin-bottom:3px; }
+    .meta { font-size:.86rem; color:#5f6d64; }
+    .badge { display:inline-block; border-radius:999px; padding:3px 8px; background:#e8f3eb; font-size:.78rem; font-weight:700; margin-right:5px; }
+    .badge.failed { background:#fff0ed; color:#8a2d22; }
+    .badge.pending { background:#fff7df; color:#795600; }
+    .message, .reply { white-space:pre-wrap; line-height:1.7; padding:13px; border-radius:9px; background:#f7faf8; border:1px solid #e1e9e4; }
+    textarea { width:100%; box-sizing:border-box; min-height:170px; resize:vertical; padding:11px; border:1px solid #aebbb2; border-radius:8px; font:inherit; }
+    button, .action { display:inline-block; border:0; border-radius:8px; padding:10px 14px; background:#176b42; color:#fff; text-decoration:none; font-weight:700; cursor:pointer; }
+    button.secondary { background:#566b5e; }
+    .notice { padding:11px 13px; border-radius:9px; background:#eaf6ed; margin:12px 0; }
+    .error { padding:11px 13px; border-radius:9px; background:#fff0ed; color:#7d271d; margin:12px 0; }
+    dl { display:grid; grid-template-columns:130px 1fr; gap:7px 12px; }
+    dt { font-weight:700; }
+    dd { margin:0; overflow-wrap:anywhere; }
+    .buttons { display:flex; flex-wrap:wrap; gap:8px; margin-top:10px; }
+    @media(max-width:800px){ .grid{grid-template-columns:1fr} dl{grid-template-columns:1fr} dt{margin-top:7px} }
+  </style>
+</head>
+<body>
+<main>
+  <p><a href="{{ url_for('site_ui.internal_index', token=internal_token) }}">← Internalへ戻る</a></p>
+  <h1>お問い合わせ対応</h1>
+  <p class="muted">Neonに保存された問い合わせを確認し、返信を保存して、メールアドレスがある場合は同じ内容をメールでも送ります。</p>
+  {% if notice %}<div class="notice">{{ notice }}</div>{% endif %}
+  {% if error %}<div class="error">{{ error }}</div>{% endif %}
+
+  <div class="grid">
+    <section class="card">
+      <h2>受信一覧</h2>
+      {% if items %}
+        {% for item in items %}
+          <a class="item" href="{{ url_for('site_ui.internal_feedback', token=internal_token, public_id=item.public_id) }}">
+            <strong>{{ item.public_id }}</strong>
+            <div>{{ item.category_label }} / {{ item.name or '名前なし' }}</div>
+            <div class="meta">{{ item.created_at }} · {{ item.email or 'メールなし' }}</div>
+            <div style="margin-top:6px;">
+              <span class="badge">{{ item.status }}</span>
+              <span class="badge {{ item.email_delivery_status }}">mail: {{ item.email_delivery_status }}</span>
+            </div>
+          </a>
+        {% endfor %}
+      {% else %}
+        <p class="muted">お問い合わせはありません。</p>
+      {% endif %}
+    </section>
+
+    <section class="card">
+      {% if selected %}
+        <h2>{{ selected.public_id }}</h2>
+        <dl>
+          <dt>名前</dt><dd>{{ selected.name or '—' }}</dd>
+          <dt>返信先</dt><dd>{{ selected.email or '—' }}</dd>
+          <dt>種類</dt><dd>{{ selected.category_label }}</dd>
+          <dt>状態</dt><dd>{{ selected.status }}</dd>
+          <dt>メール配送</dt><dd>{{ selected.email_delivery_status }}{% if selected.email_sent_at %} / {{ selected.email_sent_at }}{% endif %}</dd>
+        </dl>
+        <h3>送信内容</h3>
+        <div class="message">{{ selected.message }}</div>
+
+        {% if selected.operator_reply %}
+          <h3>保存済み返信</h3>
+          <div class="reply">{{ selected.operator_reply }}</div>
+        {% endif %}
+
+        <h3>{{ '返信を修正して送信' if selected.operator_reply else '返信する' }}</h3>
+        <form method="post" action="{{ url_for('site_ui.internal_feedback', token=internal_token, public_id=selected.public_id) }}">
+          <input type="hidden" name="action" value="reply">
+          <textarea name="reply" required maxlength="8000">{{ selected.operator_reply or '' }}</textarea>
+          <div class="buttons"><button type="submit">返信を保存して送信</button></div>
+        </form>
+
+        {% if selected.email and selected.operator_reply and selected.email_delivery_status in ['failed', 'pending'] %}
+        <form method="post" action="{{ url_for('site_ui.internal_feedback', token=internal_token, public_id=selected.public_id) }}">
+          <input type="hidden" name="action" value="retry">
+          <div class="buttons"><button class="secondary" type="submit">保存済み返信をメール再送</button></div>
+        </form>
+        {% endif %}
+
+        <p class="muted" style="margin-top:18px;">公開確認ページ: <a href="{{ url_for('site_legal_ui.contact_status', token=selected.tracking_token) }}" target="_blank" rel="noopener">確認する</a></p>
+      {% else %}
+        <h2>問い合わせを選択</h2>
+        <p class="muted">左の一覧から対応する問い合わせを選んでください。</p>
+      {% endif %}
+    </section>
+  </div>
+</main>
+</body>
+</html>

--- a/templates/internal/index.html
+++ b/templates/internal/index.html
@@ -37,6 +37,14 @@
     <p class="muted">開発・診断専用。学習者・親向け「学習見守り」とは、URL・認証・処理・表示を分離しています。</p>
 
     <section>
+      <div class="card">
+        <h2>お問い合わせ対応</h2>
+        <p class="muted">公開フォームから届いた問い合わせの確認・返信・メール配送状況を管理します。</p>
+        <a class="action" href="{{ feedback_url }}">お問い合わせを開く</a>
+      </div>
+    </section>
+
+    <section>
       <h2>システム概要</h2>
       <div class="grid">
         <div class="card">

--- a/tests/test_email_delivery.py
+++ b/tests/test_email_delivery.py
@@ -1,0 +1,102 @@
+import pytest
+
+import email_delivery
+
+
+def test_send_feedback_reply_requires_api_key(monkeypatch):
+    monkeypatch.delenv("PRIMITIVE_API_KEY", raising=False)
+    with pytest.raises(email_delivery.EmailDeliveryError, match="PRIMITIVE_API_KEY"):
+        email_delivery.send_feedback_reply(
+            public_id="LT-20260906-ABCDEF12",
+            to_email="user@example.com",
+            reply="返信です。",
+        )
+
+
+def test_send_feedback_reply_uses_idempotency_and_maps_delivered(monkeypatch):
+    monkeypatch.setenv("PRIMITIVE_API_KEY", "prim_test_secret")
+    captured = {}
+
+    class Response:
+        status_code = 200
+
+        @staticmethod
+        def json():
+            return {
+                "data": {
+                    "id": "mail-123",
+                    "status": "delivered",
+                    "delivery_status": "delivered",
+                }
+            }
+
+    def fake_post(url, *, json, headers, timeout):
+        captured.update(url=url, json=json, headers=headers, timeout=timeout)
+        return Response()
+
+    monkeypatch.setattr(email_delivery.requests, "post", fake_post)
+    result = email_delivery.send_feedback_reply(
+        public_id="LT-20260906-ABCDEF12",
+        to_email="user@example.com",
+        reply="確認しました。",
+    )
+
+    assert result.delivery_state == "sent"
+    assert result.provider_status == "delivered"
+    assert result.provider_message_id == "mail-123"
+    assert captured["url"].endswith("/v1/send-mail")
+    assert captured["json"]["to"] == "user@example.com"
+    assert captured["json"]["wait"] is True
+    assert "確認しました。" in captured["json"]["body_text"]
+    assert "迷惑メールではない" in captured["json"]["body_text"]
+    assert captured["headers"]["Authorization"] == "Bearer prim_test_secret"
+    assert captured["headers"]["Idempotency-Key"].startswith(
+        "lt-feedback-LT-20260906-ABCDEF12-"
+    )
+
+
+def test_send_feedback_reply_maps_wait_timeout_to_pending(monkeypatch):
+    monkeypatch.setenv("PRIMITIVE_API_KEY", "prim_test_secret")
+
+    class Response:
+        status_code = 200
+
+        @staticmethod
+        def json():
+            return {"data": {"id": "mail-456", "status": "wait_timeout"}}
+
+    monkeypatch.setattr(
+        email_delivery.requests,
+        "post",
+        lambda *args, **kwargs: Response(),
+    )
+    result = email_delivery.send_feedback_reply(
+        public_id="LT-20260906-ABCDEF12",
+        to_email="user@example.com",
+        reply="返信です。",
+    )
+    assert result.delivery_state == "pending"
+    assert result.provider_status == "wait_timeout"
+
+
+def test_send_feedback_reply_raises_on_provider_rejection(monkeypatch):
+    monkeypatch.setenv("PRIMITIVE_API_KEY", "prim_test_secret")
+
+    class Response:
+        status_code = 422
+
+        @staticmethod
+        def json():
+            return {"message": "recipient denied"}
+
+    monkeypatch.setattr(
+        email_delivery.requests,
+        "post",
+        lambda *args, **kwargs: Response(),
+    )
+    with pytest.raises(email_delivery.EmailDeliveryError, match="recipient denied"):
+        email_delivery.send_feedback_reply(
+            public_id="LT-20260906-ABCDEF12",
+            to_email="user@example.com",
+            reply="返信です。",
+        )

--- a/tests/test_internal_feedback.py
+++ b/tests/test_internal_feedback.py
@@ -1,0 +1,128 @@
+import os
+from datetime import datetime, timezone
+
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
+os.environ.setdefault("CHANNEL_ACCESS_TOKEN", "test-token")
+os.environ.setdefault("CHANNEL_SECRET", "test-secret")
+
+from app import app
+import developer_ui
+from email_delivery import EmailDeliveryResult
+
+
+def _item(**overrides):
+    now = datetime.now(timezone.utc)
+    item = {
+        "public_id": "LT-20260906-ABCDEF12",
+        "name": "テスト利用者",
+        "email": "user@example.com",
+        "category": "bug",
+        "message": "不具合があります。",
+        "status": "received",
+        "operator_reply": None,
+        "email_delivery_status": "not_requested",
+        "email_sent_at": None,
+        "created_at": now,
+        "updated_at": now,
+        "replied_at": None,
+        "tracking_token": "private-status-token",
+    }
+    item.update(overrides)
+    return item
+
+
+def test_internal_feedback_requires_admin_secret(monkeypatch):
+    monkeypatch.setenv("LT_INTERNAL_ADMIN_TOKEN", "admin-secret")
+    client = app.test_client()
+    assert client.get("/internal/feedback").status_code == 403
+    assert client.get("/internal/feedback?token=wrong").status_code == 403
+
+
+def test_internal_feedback_lists_inquiries(monkeypatch):
+    monkeypatch.setenv("LT_INTERNAL_ADMIN_TOKEN", "admin-secret")
+    monkeypatch.setattr(developer_ui, "list_feedback_for_operator", lambda limit=100: [_item()])
+    monkeypatch.setattr(
+        developer_ui,
+        "get_feedback_for_operator",
+        lambda public_id: _item() if public_id else None,
+    )
+
+    response = app.test_client().get(
+        "/internal/feedback?token=admin-secret&public_id=LT-20260906-ABCDEF12"
+    )
+    assert response.status_code == 200
+    html = response.get_data(as_text=True)
+    assert "お問い合わせ対応" in html
+    assert "LT-20260906-ABCDEF12" in html
+    assert "不具合があります。" in html
+    assert "user@example.com" in html
+
+
+def test_internal_feedback_reply_saves_then_sends_email(monkeypatch):
+    monkeypatch.setenv("LT_INTERNAL_ADMIN_TOKEN", "admin-secret")
+    current = _item()
+    events = []
+
+    def fake_get(public_id):
+        return dict(current) if public_id else None
+
+    def fake_set_operator_reply(*, public_id, reply, status):
+        events.append(("save", public_id, reply, status))
+        current.update(
+            operator_reply=reply,
+            status=status,
+            email_delivery_status="pending",
+        )
+        return dict(current)
+
+    def fake_send_feedback_reply(*, public_id, to_email, reply):
+        events.append(("send", public_id, to_email, reply))
+        return EmailDeliveryResult("sent", "delivered", "mail-123")
+
+    def fake_mark_email_delivery(*, public_id, delivery_status):
+        events.append(("mark", public_id, delivery_status))
+        current["email_delivery_status"] = delivery_status
+        return True
+
+    monkeypatch.setattr(developer_ui, "list_feedback_for_operator", lambda limit=100: [dict(current)])
+    monkeypatch.setattr(developer_ui, "get_feedback_for_operator", fake_get)
+    monkeypatch.setattr(developer_ui, "set_operator_reply", fake_set_operator_reply)
+    monkeypatch.setattr(developer_ui, "send_feedback_reply", fake_send_feedback_reply)
+    monkeypatch.setattr(developer_ui, "mark_email_delivery", fake_mark_email_delivery)
+
+    response = app.test_client().post(
+        "/internal/feedback?token=admin-secret&public_id=LT-20260906-ABCDEF12",
+        data={"action": "reply", "reply": "確認して修正しました。"},
+    )
+    assert response.status_code == 200
+    assert events[0][0] == "save"
+    assert events[1][0] == "send"
+    assert events[2] == ("mark", "LT-20260906-ABCDEF12", "sent")
+    html = response.get_data(as_text=True)
+    assert "メール配送を確認しました" in html
+
+
+def test_internal_feedback_without_email_never_calls_provider(monkeypatch):
+    monkeypatch.setenv("LT_INTERNAL_ADMIN_TOKEN", "admin-secret")
+    current = _item(email=None)
+
+    monkeypatch.setattr(developer_ui, "get_feedback_for_operator", lambda public_id: dict(current))
+    monkeypatch.setattr(developer_ui, "list_feedback_for_operator", lambda limit=100: [dict(current)])
+
+    def fake_set_operator_reply(*, public_id, reply, status):
+        current.update(operator_reply=reply, status=status, email_delivery_status="not_requested")
+        return dict(current)
+
+    monkeypatch.setattr(developer_ui, "set_operator_reply", fake_set_operator_reply)
+    monkeypatch.setattr(
+        developer_ui,
+        "send_feedback_reply",
+        lambda **kwargs: (_ for _ in ()).throw(AssertionError("provider must not be called")),
+    )
+
+    response = app.test_client().post(
+        "/internal/feedback?token=admin-secret&public_id=LT-20260906-ABCDEF12",
+        data={"action": "reply", "reply": "確認しました。"},
+    )
+    assert response.status_code == 200
+    assert "メールアドレス未入力" in response.get_data(as_text=True)


### PR DESCRIPTION
問い合わせ返信をNeon保存＋Primitiveメール配送の二経路で運用できるようにする。

- Internalに問い合わせ一覧・返信画面を追加
- 返信は先にNeonへ保存し、メールアドレスがある場合は同じ本文をPrimitiveで送信
- Primitive送信はIdempotency-Keyを使用し、同一返信の重複送信を防止
- email_delivery_status / email_sent_atを既存カラムで更新
- 迷惑メール案内をメール本文にも明記
- APIキー未設定や送信失敗時はNeon返信を保持し、failedとして再送可能
- 新規DB migrationなし
- 学習機能・Question Bank変更なし