### PR TITLE
Add Phase11 same-day session load diagnostics

### DIFF
--- a/docs/phase11-natural-use-session-load-20260906-v01.md
+++ b/docs/phase11-natural-use-session-load-20260906-v01.md
@@ -1,0 +1,60 @@
+# Phase 11 Natural-use Session Load Evidence v0.1
+
+Date: 2026-09-06
+Status: observational evidence only / Shadow promotion boundary unchanged
+
+## Scope
+
+This note records one natural Production study day for the learner used in current real-use validation. It does not change Phase 11 J1-J7 ordering, Phase 10 exact-question selection, Recent Cooldown, Safety priority, Node-state semantics, or learner-facing recommendations.
+
+## Observed same-day study
+
+- study answers: 200
+- correct: 149
+- accuracy: 74.5%
+- unique questions: 148
+- repeat attempts: 52
+- unique canonical Nodes observed: 143
+- first exposures: 148 answers / 104 correct / 70.3%
+- repeat attempts: 52 answers / 45 correct / 86.5%
+
+Chronological 50-question blocks:
+
+- attempts 1-50: 39/50 = 78.0%
+- attempts 51-100: 39/50 = 78.0%
+- attempts 101-150: 37/50 = 74.0%
+- attempts 151-200: 34/50 = 68.0%
+
+The final full block was 10.0 percentage points below the first full block.
+
+## Route evidence
+
+Observed route mix:
+
+- manual: 95 attempts / 70.5%
+- adaptive_daily: 90 attempts / 76.7%
+- dashboard_recommendation: 10 attempts / 90.0%
+- random: 5 attempts / 80.0%
+
+The 90 adaptive_daily attempts preserved the current Phase 10 soft composition across three 30-question sets:
+
+- repair: 45 total (40 repairing, 3 confident_wrong, 2 safety_wrong)
+- checking: 30
+- exploration: 15
+
+Observed adaptive accuracies were 72.5% for repairing, 90.0% for checking, 60.0% for exploration, 100.0% for confident_wrong, and 50.0% for safety_wrong. These are descriptive outcomes from one day, not ranking weights.
+
+## Interpretation boundary
+
+The evidence supports two observations:
+
+1. Same-day repeats were materially more accurate than first exposures in this session (86.5% vs 70.3%), so repair activity was not obviously ineffective.
+2. Accuracy declined across the latter half of a long study day, with 68.0% in the final 50. This is compatible with fatigue, concentration decline, changing question difficulty/mix, or other causes. The data alone does not identify the cause.
+
+Therefore this evidence must not be converted directly into a learner-facing stop rule or an automatic reduction in question count. Phase 11 already records `high_same_day_volume` from 60 answers onward as an observation-only signal. The added `phase11_session_load_facts.py` keeps volume, repeat structure, block accuracy, and leading-to-trailing accuracy delta as facts without deciding what action to take.
+
+## Promotion consequence
+
+The 2026-09-02 Phase 11 HOLD decision remains in force. This natural-use day strengthens the evidence base for long-session behavior but does not satisfy the still-missing promotion classes by itself, especially naturally occurring J4 `recheck_due` handling and subsequent stable retention evidence.
+
+No Production DB write or policy mutation is required by this evidence note.

--- a/phase11_session_load_facts.py
+++ b/phase11_session_load_facts.py
@@ -1,0 +1,144 @@
+"""Read-only same-day session-load facts for Phase 11 diagnostics.
+
+This module deliberately reports evidence only.  It does not decide whether a
+learner should stop, change route, alter question counts, or override Safety,
+repair, retention, coverage, or the Phase 10 selector.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Iterable
+from zoneinfo import ZoneInfo
+
+
+TOKYO = ZoneInfo("Asia/Tokyo")
+DEFAULT_BLOCK_SIZE = 50
+
+
+def _parse_time(value: Any) -> datetime | None:
+    if isinstance(value, datetime):
+        parsed = value
+    elif value:
+        try:
+            parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+        except ValueError:
+            return None
+    else:
+        return None
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+
+
+def _accuracy(correct: int, answered: int) -> float | None:
+    return round(100.0 * correct / answered, 1) if answered else None
+
+
+def _ordered_today(
+    attempts: Iterable[dict[str, Any]], *, as_of: datetime
+) -> list[dict[str, Any]]:
+    today = as_of.astimezone(TOKYO).date()
+    rows: list[tuple[datetime, int, int, dict[str, Any]]] = []
+    for raw in attempts:
+        item = dict(raw)
+        answered_at = _parse_time(item.get("answered_at") or item.get("attempted_at"))
+        if not answered_at or answered_at.astimezone(TOKYO).date() != today:
+            continue
+        rows.append((
+            answered_at,
+            int(item.get("attempt_position") or 0),
+            int(item.get("id") or 0),
+            item,
+        ))
+    rows.sort(key=lambda value: (value[0], value[1], value[2]))
+    return [item for *_keys, item in rows]
+
+
+def build_same_day_session_load_facts(
+    attempts: Iterable[dict[str, Any]],
+    *,
+    as_of: datetime | None = None,
+    block_size: int = DEFAULT_BLOCK_SIZE,
+) -> dict[str, Any]:
+    """Return same-day volume, repeat structure, and chronological accuracy facts.
+
+    The result intentionally contains no learner-facing recommendation and no
+    fatigue/overpractice verdict.  A falling late-session accuracy is evidence to
+    review, not proof of its cause.
+    """
+    if block_size <= 0:
+        raise ValueError("block_size must be positive")
+    as_of = as_of or datetime.now(timezone.utc)
+    if as_of.tzinfo is None:
+        as_of = as_of.replace(tzinfo=timezone.utc)
+
+    today = _ordered_today(attempts, as_of=as_of)
+    seen_questions: set[str] = set()
+    first_attempt_count = first_correct = 0
+    repeat_attempt_count = repeat_correct = 0
+
+    for item in today:
+        question_id = str(item.get("question_id") or "").strip().upper()
+        is_repeat = bool(question_id and question_id in seen_questions)
+        is_correct = item.get("is_correct") is True and item.get("answer_status") != "unknown"
+        if is_repeat:
+            repeat_attempt_count += 1
+            repeat_correct += int(is_correct)
+        else:
+            first_attempt_count += 1
+            first_correct += int(is_correct)
+        if question_id:
+            seen_questions.add(question_id)
+
+    blocks: list[dict[str, Any]] = []
+    for start in range(0, len(today), block_size):
+        chunk = today[start : start + block_size]
+        correct = sum(
+            item.get("is_correct") is True and item.get("answer_status") != "unknown"
+            for item in chunk
+        )
+        blocks.append({
+            "block": start // block_size + 1,
+            "from_attempt": start + 1,
+            "to_attempt": start + len(chunk),
+            "answered_count": len(chunk),
+            "correct_count": int(correct),
+            "accuracy_percent": _accuracy(int(correct), len(chunk)),
+        })
+
+    first_full = blocks[0] if blocks and blocks[0]["answered_count"] == block_size else None
+    last_full = next(
+        (block for block in reversed(blocks) if block["answered_count"] == block_size),
+        None,
+    )
+    leading_to_trailing_delta = None
+    if first_full and last_full and first_full is not last_full:
+        leading_to_trailing_delta = round(
+            float(last_full["accuracy_percent"]) - float(first_full["accuracy_percent"]), 1
+        )
+
+    correct_count = sum(
+        item.get("is_correct") is True and item.get("answer_status") != "unknown"
+        for item in today
+    )
+    return {
+        "date_jst": as_of.astimezone(TOKYO).date().isoformat(),
+        "answered_count": len(today),
+        "correct_count": int(correct_count),
+        "accuracy_percent": _accuracy(int(correct_count), len(today)),
+        "unique_question_count": len(seen_questions),
+        "first_attempt_count": first_attempt_count,
+        "first_attempt_correct_count": first_correct,
+        "first_attempt_accuracy_percent": _accuracy(first_correct, first_attempt_count),
+        "repeat_attempt_count": repeat_attempt_count,
+        "repeat_correct_count": repeat_correct,
+        "repeat_accuracy_percent": _accuracy(repeat_correct, repeat_attempt_count),
+        "repeat_share_percent": _accuracy(repeat_attempt_count, len(today)),
+        "block_size": block_size,
+        "blocks": blocks,
+        "leading_to_trailing_full_block_accuracy_delta_pp": leading_to_trailing_delta,
+        "diagnostic_only": True,
+        "policy_note": (
+            "Same-day volume and late accuracy are observational evidence only; "
+            "they do not by themselves prove fatigue or justify blocking learning."
+        ),
+    }

--- a/tests/test_phase11_session_load_facts.py
+++ b/tests/test_phase11_session_load_facts.py
@@ -1,0 +1,88 @@
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from phase11_session_load_facts import build_same_day_session_load_facts
+
+
+def _attempt(index, *, correct, question_id=None, answered_at=None):
+    return {
+        "id": index,
+        "attempt_position": (index - 1) % 5 + 1,
+        "question_id": question_id or f"Q{index}",
+        "is_correct": correct,
+        "confidence": 1,
+        "answered_at": answered_at or datetime(2026, 9, 6, 0, 0, tzinfo=timezone.utc) + timedelta(minutes=index),
+    }
+
+
+def test_reconstructs_real_use_shape_without_making_fatigue_verdict():
+    # Four 50-question blocks: 78%, 78%, 74%, 68%.
+    block_correct = [39, 39, 37, 34]
+    rows = []
+    for block_index, correct_count in enumerate(block_correct):
+        for offset in range(50):
+            index = block_index * 50 + offset + 1
+            # 148 unique questions followed by 52 repeats.
+            question_id = f"Q{index}" if index <= 148 else f"Q{index - 148}"
+            rows.append(_attempt(index, correct=offset < correct_count, question_id=question_id))
+
+    facts = build_same_day_session_load_facts(
+        rows,
+        as_of=datetime(2026, 9, 6, 12, 0, tzinfo=timezone.utc),
+    )
+
+    assert facts["answered_count"] == 200
+    assert facts["correct_count"] == 149
+    assert facts["accuracy_percent"] == 74.5
+    assert facts["unique_question_count"] == 148
+    assert facts["repeat_attempt_count"] == 52
+    assert [block["accuracy_percent"] for block in facts["blocks"]] == [78.0, 78.0, 74.0, 68.0]
+    assert facts["leading_to_trailing_full_block_accuracy_delta_pp"] == -10.0
+    assert facts["diagnostic_only"] is True
+    assert "do not by themselves prove fatigue" in facts["policy_note"]
+
+
+def test_repeat_accuracy_is_derived_from_chronological_prior_exposure():
+    rows = [
+        _attempt(1, correct=False, question_id="Q1"),
+        _attempt(2, correct=True, question_id="Q2"),
+        _attempt(3, correct=True, question_id="Q1"),
+        _attempt(4, correct=False, question_id="Q2"),
+    ]
+
+    facts = build_same_day_session_load_facts(
+        rows,
+        as_of=datetime(2026, 9, 6, 12, 0, tzinfo=timezone.utc),
+        block_size=2,
+    )
+
+    assert facts["first_attempt_count"] == 2
+    assert facts["first_attempt_accuracy_percent"] == 50.0
+    assert facts["repeat_attempt_count"] == 2
+    assert facts["repeat_accuracy_percent"] == 50.0
+    assert facts["repeat_share_percent"] == 50.0
+
+
+def test_excludes_other_jst_days_and_keeps_partial_block_without_delta():
+    rows = [
+        _attempt(1, correct=True, answered_at=datetime(2026, 9, 5, 14, 59, tzinfo=timezone.utc)),
+        _attempt(2, correct=True, answered_at=datetime(2026, 9, 5, 15, 1, tzinfo=timezone.utc)),
+        _attempt(3, correct=False, answered_at=datetime(2026, 9, 5, 15, 2, tzinfo=timezone.utc)),
+    ]
+
+    facts = build_same_day_session_load_facts(
+        rows,
+        as_of=datetime(2026, 9, 6, 1, 0, tzinfo=timezone.utc),
+        block_size=50,
+    )
+
+    assert facts["answered_count"] == 2
+    assert facts["correct_count"] == 1
+    assert facts["blocks"][0]["answered_count"] == 2
+    assert facts["leading_to_trailing_full_block_accuracy_delta_pp"] is None
+
+
+def test_rejects_non_positive_block_size():
+    with pytest.raises(ValueError, match="block_size must be positive"):
+        build_same_day_session_load_facts([], block_size=0)


### PR DESCRIPTION
## Summary
- add read-only Phase11 same-day session-load facts
- capture volume, unique/repeat structure, chronological block accuracy, and leading-to-trailing accuracy delta
- keep all outputs diagnostic-only; no fatigue verdict, stop rule, selector change, Node-state mutation, DB write, or learner-facing behavior change
- record 2026-09-06 natural-use evidence from the 200-question Production study day

## Safety boundary
- Phase11 remains Shadow-only
- J1-J7 order unchanged
- Phase10 selector / Safety / Recent Cooldown unchanged
- no Question Bank changes
- no DB migration

## Tests
- real-use-shaped 200-attempt reconstruction
- chronological repeat classification
- JST day boundary
- invalid block-size guard