### PR TITLE
Clarify Phase11 same-day load diagnostics

### DIFF
--- a/docs/phase11-natural-use-session-load-20260906-v02.md
+++ b/docs/phase11-natural-use-session-load-20260906-v02.md
@@ -5,7 +5,12 @@ Status: observational evidence only / Shadow promotion boundary unchanged
 
 ## Why v0.2 exists
 
-The first review correctly recorded 200 same-day answers and the fall in cumulative 50-question block accuracy, but later event-timing inspection shows that the 200 answers were not one uninterrupted sitting. This note tightens the interpretation boundary before any Phase11 policy uses same-day load evidence.
+The first review correctly recorded 200 same-day answers and the fall in cumulative 50-question block accuracy, but later event-timing and prior-answer-state inspection show two important interpretation limits:
+
+1. the 200 answers were not one uninterrupted sitting;
+2. the high overall repeat accuracy was mostly driven by questions that had already been answered correctly, so it cannot be used as a repair-effectiveness metric by itself.
+
+This note tightens those boundaries before any Phase11 policy uses same-day load evidence.
 
 ## Confirmed Production facts
 
@@ -33,7 +38,9 @@ The last full cumulative block was 10.0 percentage points below the first.
 
 ## Important timing correction
 
-Production event timestamps show a major break between the morning set and the next study period. The morning study activity ended around 08:16 JST and the next major study set began around 13:38 JST, a gap of more than five hours.
+Production timestamps show a major break between the morning set and the next study period. The morning activity ended at approximately 08:16 JST and the next study period began at approximately 13:38 JST.
+
+The measured gap is about 322 minutes (5 hours 22 minutes). Other large same-day gaps observed were about 21.9, 12.9, 11.1, and 10.2 minutes.
 
 Therefore the four 50-question blocks describe **same-day cumulative load**, not four consecutive blocks from one continuous 200-question sitting.
 
@@ -41,11 +48,38 @@ The late-day decline is compatible with fatigue or concentration decline, but it
 
 `phase11_session_load_facts.py` now exposes the study-day span and largest inter-attempt gaps so future review does not silently equate same-day volume with uninterrupted session duration.
 
-## Repair signal from this study day
+## Repeat-state correction
 
-Same-day repeats were substantially more accurate than first exposures (86.5% vs 70.3%). This supports the limited conclusion that repeated work was not obviously ineffective on this day. It does not prove long-term retention, because same-day success can still reflect short-term memory.
+The overall repeat accuracy of 86.5% looks strong, but chronological prior-answer-state inspection changes its interpretation.
 
-Long-term repair effectiveness must still be judged by later formal transitions:
+Among the 52 repeat attempts:
+
+- previous wrong -> current correct: 6
+- previous wrong -> current wrong: 5
+- previous correct -> current correct: 39
+- previous correct -> current wrong: 2
+
+So only 11 of the 52 repeats immediately followed a wrong answer. Of those 11, 6 became correct and 5 remained wrong: **54.5% immediate wrong-to-correct accuracy**.
+
+By contrast, 41 repeats followed a previously correct answer, and 39 of those remained correct.
+
+Therefore **generic repeat accuracy must not be treated as repair effectiveness**. The 86.5% figure is mostly a maintenance/repetition signal in this study day, not direct evidence that weak material was repaired.
+
+The Phase11 same-day helper now reports repeat transitions separately:
+
+- repeat-after-wrong count
+- wrong -> correct
+- wrong -> wrong
+- repeat-after-wrong accuracy
+- repeat-after-correct count
+- correct -> correct
+- correct -> wrong
+
+This makes future natural-use review less vulnerable to a misleading aggregate repeat percentage.
+
+## Repair effectiveness still requires formal evidence
+
+Immediate wrong-to-correct improvement is useful descriptive evidence, but it still does not prove durable repair. Long-term repair effectiveness must be judged by later formal transitions:
 
 - repairing -> repaired
 - repaired -> recheck_due

--- a/docs/phase11-natural-use-session-load-20260906-v02.md
+++ b/docs/phase11-natural-use-session-load-20260906-v02.md
@@ -1,0 +1,68 @@
+# Phase 11 Natural-use Session Load Evidence v0.2
+
+Date: 2026-09-06
+Status: observational evidence only / Shadow promotion boundary unchanged
+
+## Why v0.2 exists
+
+The first review correctly recorded 200 same-day answers and the fall in cumulative 50-question block accuracy, but later event-timing inspection shows that the 200 answers were not one uninterrupted sitting. This note tightens the interpretation boundary before any Phase11 policy uses same-day load evidence.
+
+## Confirmed Production facts
+
+- same-day answers: 200
+- correct: 149
+- accuracy: 74.5%
+- unique questions: 148
+- same-day repeat attempts: 52
+- unique canonical Nodes observed: 143
+- first exposures: 148 / 104 correct = 70.3%
+- repeat attempts: 52 / 45 correct = 86.5%
+- confidence 1: 112
+- confidence 2: 87
+- confidence 3: 1
+- confident-wrong answers: 12
+
+Cumulative same-day 50-question blocks:
+
+- attempts 1-50: 39/50 = 78.0%
+- attempts 51-100: 39/50 = 78.0%
+- attempts 101-150: 37/50 = 74.0%
+- attempts 151-200: 34/50 = 68.0%
+
+The last full cumulative block was 10.0 percentage points below the first.
+
+## Important timing correction
+
+Production event timestamps show a major break between the morning set and the next study period. The morning study activity ended around 08:16 JST and the next major study set began around 13:38 JST, a gap of more than five hours.
+
+Therefore the four 50-question blocks describe **same-day cumulative load**, not four consecutive blocks from one continuous 200-question sitting.
+
+The late-day decline is compatible with fatigue or concentration decline, but it is also compatible with differences in question mix, target difficulty, route composition, time of day, and other session effects. Current evidence cannot identify the cause.
+
+`phase11_session_load_facts.py` now exposes the study-day span and largest inter-attempt gaps so future review does not silently equate same-day volume with uninterrupted session duration.
+
+## Repair signal from this study day
+
+Same-day repeats were substantially more accurate than first exposures (86.5% vs 70.3%). This supports the limited conclusion that repeated work was not obviously ineffective on this day. It does not prove long-term retention, because same-day success can still reflect short-term memory.
+
+Long-term repair effectiveness must still be judged by later formal transitions:
+
+- repairing -> repaired
+- repaired -> recheck_due
+- recheck_due -> stable or back to repairing
+
+## Natural J4 timing
+
+A read-only check of the currently reviewed STRONG different-question pairs found one confirmed repair sequence for KN0394:
+
+- wrong answer on Q1572: 2026-09-01
+- confidence=1 correct STRONG alternate Q399: 2026-09-02 18:32 JST
+- corresponding seven-day retention review time: approximately 2026-09-09 18:32 JST
+
+This is a **candidate timing marker from the reviewed-pair subset**, not a claim that it is the earliest possible recheck_due Node across the entire current repair-supply catalog. No timestamps or learner data were modified to create this evidence.
+
+## Policy consequence
+
+No learner-facing stop rule, fatigue rule, question-count reduction, J1-J7 ordering change, Phase10 selector change, Safety change, Recent Cooldown change, Node-state mutation, or Production DB write is justified by this review.
+
+Phase11 remains Shadow-only. The next decisive evidence remains naturally occurring retention behavior and additional natural Baseline-vs-Shadow comparison diversity.

--- a/docs/phase11-session-load-bundle-wiring-plan-v01.md
+++ b/docs/phase11-session-load-bundle-wiring-plan-v01.md
@@ -1,0 +1,41 @@
+# Phase 11 Session-load Bundle Wiring Plan v0.1
+
+Date: 2026-09-06
+Status: implementation boundary recorded; no learner-facing policy change
+
+## Purpose
+
+The same-day session-load helper is now production-safe as a read-only fact builder, including explicit long-gap evidence. The next integration step is to expose these facts through the existing Supporter-only Phase11 promotion evidence bundle without changing learner-facing behavior.
+
+## Required wiring
+
+`pilot_diagnostics.build_pilot_diagnostics` should:
+
+1. call `build_same_day_session_load_facts(all_attempts, as_of=now)`;
+2. include the returned dict in the Supporter diagnostic result as `same_day_session_load`;
+3. pass it into `build_phase11_promotion_evidence_text` through a new optional argument;
+4. serialize only non-identifying facts such as date, answer count, accuracy, unique-question count, first/repeat accuracy, repeat share, study-day span, maximum inter-attempt gap, and cumulative-block accuracy delta.
+
+The promotion bundle change must remain backward-compatible when session-load facts are absent.
+
+## Non-negotiable boundary
+
+The integration must not:
+
+- change J1-J7 decision ordering;
+- select exact questions;
+- change Phase10 weights, Safety, repair evidence, or Recent Cooldown;
+- infer fatigue from the same-day block decline;
+- convert a long gap into an automatic session boundary policy;
+- expose user IDs, tokens, consultation content, or private identifiers;
+- write to Production learner data.
+
+## Acceptance tests
+
+- bundle contains deterministic same-day-load facts when supplied;
+- bundle has safe `none`/zero defaults when absent;
+- no identity/token/consultation fields are added;
+- `build_pilot_diagnostics` returns same-day facts for the requested learner using all same-day attempt history;
+- existing promotion-bundle and pilot-diagnostic tests remain green.
+
+This plan exists so the integration can be implemented as a narrow change to the existing diagnostics surface rather than introducing a second recommendation path.

--- a/phase11_session_load_facts.py
+++ b/phase11_session_load_facts.py
@@ -62,8 +62,8 @@ def build_same_day_session_load_facts(
     """Return same-day volume, repeat structure, and chronological accuracy facts.
 
     The result intentionally contains no learner-facing recommendation and no
-    fatigue/overpractice verdict.  A falling late-session accuracy is evidence to
-    review, not proof of its cause.
+    fatigue/overpractice verdict.  The chronological blocks are cumulative
+    same-day blocks, not proof of one uninterrupted study session.
     """
     if block_size <= 0:
         raise ValueError("block_size must be positive")
@@ -72,6 +72,21 @@ def build_same_day_session_load_facts(
         as_of = as_of.replace(tzinfo=timezone.utc)
 
     today = _ordered_today(attempts, as_of=as_of)
+    answered_times = [
+        _parse_time(item.get("answered_at") or item.get("attempted_at"))
+        for item in today
+    ]
+    answered_times = [value for value in answered_times if value is not None]
+    inter_attempt_gaps = [
+        round((current - previous).total_seconds() / 60.0, 1)
+        for previous, current in zip(answered_times, answered_times[1:])
+    ]
+    largest_gaps = sorted(inter_attempt_gaps, reverse=True)[:3]
+    study_span_minutes = (
+        round((answered_times[-1] - answered_times[0]).total_seconds() / 60.0, 1)
+        if len(answered_times) >= 2 else 0.0 if answered_times else None
+    )
+
     seen_questions: set[str] = set()
     first_attempt_count = first_correct = 0
     repeat_attempt_count = repeat_correct = 0
@@ -133,12 +148,23 @@ def build_same_day_session_load_facts(
         "repeat_correct_count": repeat_correct,
         "repeat_accuracy_percent": _accuracy(repeat_correct, repeat_attempt_count),
         "repeat_share_percent": _accuracy(repeat_attempt_count, len(today)),
+        "first_answered_at_jst": (
+            answered_times[0].astimezone(TOKYO).isoformat() if answered_times else None
+        ),
+        "last_answered_at_jst": (
+            answered_times[-1].astimezone(TOKYO).isoformat() if answered_times else None
+        ),
+        "study_span_minutes": study_span_minutes,
+        "largest_inter_attempt_gaps_minutes": largest_gaps,
+        "max_inter_attempt_gap_minutes": largest_gaps[0] if largest_gaps else None,
         "block_size": block_size,
+        "block_scope": "same_day_cumulative",
         "blocks": blocks,
         "leading_to_trailing_full_block_accuracy_delta_pp": leading_to_trailing_delta,
         "diagnostic_only": True,
         "policy_note": (
             "Same-day volume and late accuracy are observational evidence only; "
-            "they do not by themselves prove fatigue or justify blocking learning."
+            "cumulative blocks may span long breaks and do not by themselves prove "
+            "fatigue, one continuous session, or a reason to block learning."
         ),
     }

--- a/phase11_session_load_facts.py
+++ b/phase11_session_load_facts.py
@@ -63,7 +63,9 @@ def build_same_day_session_load_facts(
 
     The result intentionally contains no learner-facing recommendation and no
     fatigue/overpractice verdict.  The chronological blocks are cumulative
-    same-day blocks, not proof of one uninterrupted study session.
+    same-day blocks, not proof of one uninterrupted study session.  Generic
+    repeat accuracy is also kept separate from repeats that follow a wrong
+    answer so it cannot be mistaken for repair effectiveness.
     """
     if block_size <= 0:
         raise ValueError("block_size must be positive")
@@ -88,21 +90,39 @@ def build_same_day_session_load_facts(
     )
 
     seen_questions: set[str] = set()
+    previous_result_by_question: dict[str, bool | None] = {}
     first_attempt_count = first_correct = 0
     repeat_attempt_count = repeat_correct = 0
+    wrong_to_correct = wrong_to_wrong = 0
+    correct_to_correct = correct_to_wrong = 0
 
     for item in today:
         question_id = str(item.get("question_id") or "").strip().upper()
         is_repeat = bool(question_id and question_id in seen_questions)
-        is_correct = item.get("is_correct") is True and item.get("answer_status") != "unknown"
+        is_evaluable = item.get("answer_status") != "unknown"
+        current_result = item.get("is_correct") if is_evaluable else None
+        is_correct = current_result is True
         if is_repeat:
             repeat_attempt_count += 1
             repeat_correct += int(is_correct)
+            previous_result = previous_result_by_question.get(question_id)
+            if previous_result is False and current_result is True:
+                wrong_to_correct += 1
+            elif previous_result is False and current_result is False:
+                wrong_to_wrong += 1
+            elif previous_result is True and current_result is True:
+                correct_to_correct += 1
+            elif previous_result is True and current_result is False:
+                correct_to_wrong += 1
         else:
             first_attempt_count += 1
             first_correct += int(is_correct)
         if question_id:
             seen_questions.add(question_id)
+            previous_result_by_question[question_id] = current_result
+
+    repeat_after_wrong_count = wrong_to_correct + wrong_to_wrong
+    repeat_after_correct_count = correct_to_correct + correct_to_wrong
 
     blocks: list[dict[str, Any]] = []
     for start in range(0, len(today), block_size):
@@ -148,6 +168,18 @@ def build_same_day_session_load_facts(
         "repeat_correct_count": repeat_correct,
         "repeat_accuracy_percent": _accuracy(repeat_correct, repeat_attempt_count),
         "repeat_share_percent": _accuracy(repeat_attempt_count, len(today)),
+        "repeat_after_wrong_count": repeat_after_wrong_count,
+        "wrong_to_correct_count": wrong_to_correct,
+        "wrong_to_wrong_count": wrong_to_wrong,
+        "repeat_after_wrong_accuracy_percent": _accuracy(
+            wrong_to_correct, repeat_after_wrong_count
+        ),
+        "repeat_after_correct_count": repeat_after_correct_count,
+        "correct_to_correct_count": correct_to_correct,
+        "correct_to_wrong_count": correct_to_wrong,
+        "repeat_after_correct_accuracy_percent": _accuracy(
+            correct_to_correct, repeat_after_correct_count
+        ),
         "first_answered_at_jst": (
             answered_times[0].astimezone(TOKYO).isoformat() if answered_times else None
         ),
@@ -165,6 +197,8 @@ def build_same_day_session_load_facts(
         "policy_note": (
             "Same-day volume and late accuracy are observational evidence only; "
             "cumulative blocks may span long breaks and do not by themselves prove "
-            "fatigue, one continuous session, or a reason to block learning."
+            "fatigue, one continuous session, or a reason to block learning. Generic "
+            "repeat accuracy must not be treated as repair effectiveness without "
+            "checking the prior answer state."
         ),
     }

--- a/tests/test_phase11_session_load_facts.py
+++ b/tests/test_phase11_session_load_facts.py
@@ -43,28 +43,39 @@ def test_reconstructs_real_use_shape_without_making_fatigue_verdict():
     assert facts["max_inter_attempt_gap_minutes"] == 1.0
     assert facts["diagnostic_only"] is True
     assert "may span long breaks" in facts["policy_note"]
-    assert "do not by themselves prove" in facts["policy_note"]
+    assert "prior answer state" in facts["policy_note"]
 
 
-def test_repeat_accuracy_is_derived_from_chronological_prior_exposure():
+def test_repeat_accuracy_is_split_by_previous_answer_state():
     rows = [
         _attempt(1, correct=False, question_id="Q1"),
         _attempt(2, correct=True, question_id="Q2"),
         _attempt(3, correct=True, question_id="Q1"),
         _attempt(4, correct=False, question_id="Q2"),
+        _attempt(5, correct=False, question_id="Q3"),
+        _attempt(6, correct=False, question_id="Q3"),
+        _attempt(7, correct=True, question_id="Q4"),
+        _attempt(8, correct=True, question_id="Q4"),
     ]
 
     facts = build_same_day_session_load_facts(
         rows,
         as_of=datetime(2026, 9, 6, 12, 0, tzinfo=timezone.utc),
-        block_size=2,
+        block_size=4,
     )
 
-    assert facts["first_attempt_count"] == 2
+    assert facts["first_attempt_count"] == 4
     assert facts["first_attempt_accuracy_percent"] == 50.0
-    assert facts["repeat_attempt_count"] == 2
+    assert facts["repeat_attempt_count"] == 4
     assert facts["repeat_accuracy_percent"] == 50.0
-    assert facts["repeat_share_percent"] == 50.0
+    assert facts["repeat_after_wrong_count"] == 2
+    assert facts["wrong_to_correct_count"] == 1
+    assert facts["wrong_to_wrong_count"] == 1
+    assert facts["repeat_after_wrong_accuracy_percent"] == 50.0
+    assert facts["repeat_after_correct_count"] == 2
+    assert facts["correct_to_correct_count"] == 1
+    assert facts["correct_to_wrong_count"] == 1
+    assert facts["repeat_after_correct_accuracy_percent"] == 50.0
 
 
 def test_long_break_is_reported_without_turning_it_into_a_session_or_fatigue_rule():

--- a/tests/test_phase11_session_load_facts.py
+++ b/tests/test_phase11_session_load_facts.py
@@ -17,7 +17,7 @@ def _attempt(index, *, correct, question_id=None, answered_at=None):
 
 
 def test_reconstructs_real_use_shape_without_making_fatigue_verdict():
-    # Four 50-question blocks: 78%, 78%, 74%, 68%.
+    # Four 50-question cumulative same-day blocks: 78%, 78%, 74%, 68%.
     block_correct = [39, 39, 37, 34]
     rows = []
     for block_index, correct_count in enumerate(block_correct):
@@ -39,8 +39,11 @@ def test_reconstructs_real_use_shape_without_making_fatigue_verdict():
     assert facts["repeat_attempt_count"] == 52
     assert [block["accuracy_percent"] for block in facts["blocks"]] == [78.0, 78.0, 74.0, 68.0]
     assert facts["leading_to_trailing_full_block_accuracy_delta_pp"] == -10.0
+    assert facts["block_scope"] == "same_day_cumulative"
+    assert facts["max_inter_attempt_gap_minutes"] == 1.0
     assert facts["diagnostic_only"] is True
-    assert "do not by themselves prove fatigue" in facts["policy_note"]
+    assert "may span long breaks" in facts["policy_note"]
+    assert "do not by themselves prove" in facts["policy_note"]
 
 
 def test_repeat_accuracy_is_derived_from_chronological_prior_exposure():
@@ -62,6 +65,28 @@ def test_repeat_accuracy_is_derived_from_chronological_prior_exposure():
     assert facts["repeat_attempt_count"] == 2
     assert facts["repeat_accuracy_percent"] == 50.0
     assert facts["repeat_share_percent"] == 50.0
+
+
+def test_long_break_is_reported_without_turning_it_into_a_session_or_fatigue_rule():
+    rows = [
+        _attempt(1, correct=True, answered_at=datetime(2026, 9, 5, 23, 6, tzinfo=timezone.utc)),
+        _attempt(2, correct=True, answered_at=datetime(2026, 9, 5, 23, 16, tzinfo=timezone.utc)),
+        _attempt(3, correct=False, answered_at=datetime(2026, 9, 6, 4, 38, tzinfo=timezone.utc)),
+        _attempt(4, correct=True, answered_at=datetime(2026, 9, 6, 4, 41, tzinfo=timezone.utc)),
+    ]
+
+    facts = build_same_day_session_load_facts(
+        rows,
+        as_of=datetime(2026, 9, 6, 8, 0, tzinfo=timezone.utc),
+        block_size=2,
+    )
+
+    assert facts["answered_count"] == 4
+    assert facts["study_span_minutes"] == 335.0
+    assert facts["max_inter_attempt_gap_minutes"] == 322.0
+    assert facts["largest_inter_attempt_gaps_minutes"] == [322.0, 10.0, 3.0]
+    assert facts["block_scope"] == "same_day_cumulative"
+    assert "one continuous session" in facts["policy_note"]
 
 
 def test_excludes_other_jst_days_and_keeps_partial_block_without_delta():


### PR DESCRIPTION
## Summary
- clarify that 50-question blocks are same-day cumulative, not one continuous session
- add first/last answer time, total study-day span, and largest inter-attempt gaps to the read-only Phase11 load facts
- record the 2026-09-06 multi-session interpretation and one reviewed-pair J4 timing marker
- document the narrow Supporter bundle wiring boundary for the next integration step

## Safety boundary
- Phase11 remains Shadow-only
- no J1-J7 change
- no selector/Safety/Recent Cooldown change
- no Question Bank change
- no DB write or migration
- no learner-facing fatigue/stop rule

## Tests
- preserve 200-answer cumulative block reconstruction
- verify long break reporting without converting it into a policy rule
- preserve JST filtering and repeat classification