### PR TITLE
Wire same-day load facts into internal Phase11 evidence

### DIFF
--- a/developer_ui.py
+++ b/developer_ui.py
@@ -13,6 +13,7 @@ import os
 
 from flask import abort, redirect, render_template, request, url_for
 
+from database import get_question_attempts
 from developer_status import build_developer_system_status
 from email_delivery import EmailDeliveryError, send_feedback_reply
 from feedback_store import (
@@ -25,6 +26,10 @@ from feedback_store import (
     set_operator_reply,
 )
 from goukaku_ui import build_dashboard
+from phase11_session_load_facts import (
+    build_same_day_session_load_evidence_line,
+    build_same_day_session_load_facts,
+)
 from pilot_diagnostics import build_pilot_diagnostics
 from supporter_performance import begin_request, finish_request
 
@@ -213,9 +218,19 @@ def register_developer_routes(blueprint) -> None:
         period = request.args.get("period", "7")
         if period not in {"7", "30", "all"}:
             period = "7"
+        diagnostics = build_pilot_diagnostics(learner_id, period)
+        same_day_session_load = build_same_day_session_load_facts(
+            get_question_attempts(learner_id)
+        )
+        diagnostics["same_day_session_load"] = same_day_session_load
+        diagnostics["promotion_evidence_text"] = (
+            str(diagnostics.get("promotion_evidence_text") or "").rstrip()
+            + "\n"
+            + build_same_day_session_load_evidence_line(same_day_session_load)
+        ).lstrip("\n")
         return render_template(
             "goukaku/supporter_pilot_diagnostics.html",
-            diagnostics=build_pilot_diagnostics(learner_id, period),
+            diagnostics=diagnostics,
             learner_id=learner_id,
             supporter_token=token,
             internal_token=token,

--- a/phase11_session_load_facts.py
+++ b/phase11_session_load_facts.py
@@ -202,3 +202,30 @@ def build_same_day_session_load_facts(
             "checking the prior answer state."
         ),
     }
+
+
+def build_same_day_session_load_evidence_line(facts: dict[str, Any] | None) -> str:
+    """Serialize only non-identifying same-day facts for Supporter QA bundles."""
+    source = facts or {}
+
+    def value(name: str) -> Any:
+        result = source.get(name)
+        return "none" if result is None else result
+
+    return "same_day_load=" + ",".join([
+        f"date:{value('date_jst')}",
+        f"answers:{int(source.get('answered_count') or 0)}",
+        f"accuracy:{value('accuracy_percent')}",
+        f"unique_q:{int(source.get('unique_question_count') or 0)}",
+        f"first_accuracy:{value('first_attempt_accuracy_percent')}",
+        f"repeats:{int(source.get('repeat_attempt_count') or 0)}",
+        f"repeat_accuracy:{value('repeat_accuracy_percent')}",
+        f"repeat_after_wrong:{int(source.get('repeat_after_wrong_count') or 0)}",
+        f"wrong_to_correct:{int(source.get('wrong_to_correct_count') or 0)}",
+        f"wrong_to_wrong:{int(source.get('wrong_to_wrong_count') or 0)}",
+        f"repeat_after_wrong_accuracy:{value('repeat_after_wrong_accuracy_percent')}",
+        f"study_span_minutes:{value('study_span_minutes')}",
+        f"max_gap_minutes:{value('max_inter_attempt_gap_minutes')}",
+        f"late_delta_pp:{value('leading_to_trailing_full_block_accuracy_delta_pp')}",
+        f"block_scope:{source.get('block_scope') or 'none'}",
+    ])

--- a/tests/test_phase11_session_load_facts.py
+++ b/tests/test_phase11_session_load_facts.py
@@ -2,7 +2,10 @@ from datetime import datetime, timedelta, timezone
 
 import pytest
 
-from phase11_session_load_facts import build_same_day_session_load_facts
+from phase11_session_load_facts import (
+    build_same_day_session_load_evidence_line,
+    build_same_day_session_load_facts,
+)
 
 
 def _attempt(index, *, correct, question_id=None, answered_at=None):
@@ -98,6 +101,40 @@ def test_long_break_is_reported_without_turning_it_into_a_session_or_fatigue_rul
     assert facts["largest_inter_attempt_gaps_minutes"] == [322.0, 10.0, 3.0]
     assert facts["block_scope"] == "same_day_cumulative"
     assert "one continuous session" in facts["policy_note"]
+
+
+def test_supporter_evidence_line_contains_only_compact_non_identifying_facts():
+    line = build_same_day_session_load_evidence_line({
+        "date_jst": "2026-09-06",
+        "answered_count": 200,
+        "accuracy_percent": 74.5,
+        "unique_question_count": 148,
+        "first_attempt_accuracy_percent": 70.3,
+        "repeat_attempt_count": 52,
+        "repeat_accuracy_percent": 86.5,
+        "repeat_after_wrong_count": 11,
+        "wrong_to_correct_count": 6,
+        "wrong_to_wrong_count": 5,
+        "repeat_after_wrong_accuracy_percent": 54.5,
+        "study_span_minutes": 490.0,
+        "max_inter_attempt_gap_minutes": 322.0,
+        "leading_to_trailing_full_block_accuracy_delta_pp": -10.0,
+        "block_scope": "same_day_cumulative",
+        "user_id": "must-not-leak",
+        "supporter_token": "must-not-leak",
+    })
+
+    assert line.startswith("same_day_load=date:2026-09-06,answers:200,accuracy:74.5")
+    assert "repeat_after_wrong:11,wrong_to_correct:6,wrong_to_wrong:5" in line
+    assert "repeat_after_wrong_accuracy:54.5" in line
+    assert "max_gap_minutes:322.0" in line
+    assert "block_scope:same_day_cumulative" in line
+    assert "must-not-leak" not in line
+    assert "user_id" not in line
+    assert "supporter_token" not in line
+    assert build_same_day_session_load_evidence_line(None).startswith(
+        "same_day_load=date:none,answers:0,accuracy:none"
+    )
 
 
 def test_excludes_other_jst_days_and_keeps_partial_block_without_delta():

--- a/tests/test_pilot_diagnostics.py
+++ b/tests/test_pilot_diagnostics.py
@@ -56,6 +56,8 @@ def test_diagnostics_route_requires_internal_admin_and_not_on_personal_dashboard
         assert label in html
     assert "30問の選定理由を見る" in html
     assert "30問監査データをコピー" in html
+    assert "same_day_load=" in html
+    assert "block_scope:same_day_cumulative" in html
     assert html.count('class="adaptive-audit-item"') == 30
     assert "LT学習診断" not in client.get(f"/goukaku-no-michi?token=invalid").get_data(as_text=True)
 


### PR DESCRIPTION
## Summary
- serialize non-identifying same-day load facts for Phase11 QA
- append the line to the existing internal promotion evidence bundle
- expose same-day load facts on the internal diagnostics object
- preserve current learner-facing behavior

## Interpretation safeguards
- generic repeat accuracy is separated from repeat-after-wrong accuracy
- cumulative 50-question blocks remain explicitly same-day cumulative
- long gaps are facts only, not automatic session boundaries or fatigue rules

## Safety boundary
- Phase11 remains Shadow-only
- no J1-J7 change
- no Phase10 selector/Safety/Recent Cooldown change
- no Question Bank change
- no DB write or migration

## Tests
- evidence line excludes identity/token fields
- internal diagnostics route includes same_day_load evidence
- existing session-load, pilot, and full CI tests must remain green