### PR TITLE
Add Phase11 natural repair effectiveness diagnostics

### DIFF
--- a/developer_ui.py
+++ b/developer_ui.py
@@ -13,7 +13,7 @@ import os
 
 from flask import abort, redirect, render_template, request, url_for
 
-from database import get_question_attempts
+from database import get_learning_events, get_question_attempts
 from developer_status import build_developer_system_status
 from email_delivery import EmailDeliveryError, send_feedback_reply
 from feedback_store import (
@@ -26,6 +26,10 @@ from feedback_store import (
     set_operator_reply,
 )
 from goukaku_ui import build_dashboard
+from phase11_repair_effectiveness_facts import (
+    build_repair_effectiveness_evidence_line,
+    build_same_day_repair_effectiveness_facts,
+)
 from phase11_session_load_facts import (
     build_same_day_session_load_evidence_line,
     build_same_day_session_load_facts,
@@ -222,11 +226,17 @@ def register_developer_routes(blueprint) -> None:
         same_day_session_load = build_same_day_session_load_facts(
             get_question_attempts(learner_id)
         )
+        repair_effectiveness = build_same_day_repair_effectiveness_facts(
+            get_learning_events(learner_id)
+        )
         diagnostics["same_day_session_load"] = same_day_session_load
+        diagnostics["repair_effectiveness"] = repair_effectiveness
         diagnostics["promotion_evidence_text"] = (
             str(diagnostics.get("promotion_evidence_text") or "").rstrip()
             + "\n"
             + build_same_day_session_load_evidence_line(same_day_session_load)
+            + "\n"
+            + build_repair_effectiveness_evidence_line(repair_effectiveness)
         ).lstrip("\n")
         return render_template(
             "goukaku/supporter_pilot_diagnostics.html",

--- a/phase11_repair_effectiveness_facts.py
+++ b/phase11_repair_effectiveness_facts.py
@@ -1,0 +1,154 @@
+"""Read-only natural-use repair-effectiveness facts for Phase 11 QA.
+
+These helpers summarize persisted adaptive selection outcomes only.  They do not
+change Node state, selector behavior, repair ranking, Safety, or learner-facing
+recommendations.  A correct STRONG alternate with confidence=1 is reported as a
+formal-confirmation candidate, not independently promoted to a state change here.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import json
+from typing import Any, Iterable
+from zoneinfo import ZoneInfo
+
+
+TOKYO = ZoneInfo("Asia/Tokyo")
+
+
+def _parse_time(value: Any) -> datetime | None:
+    if isinstance(value, datetime):
+        parsed = value
+    elif value:
+        try:
+            parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+        except ValueError:
+            return None
+    else:
+        return None
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+
+
+def _results(event: dict[str, Any]) -> list[dict[str, Any]]:
+    source = event.get("question_results")
+    if isinstance(source, str):
+        try:
+            source = json.loads(source)
+        except (TypeError, ValueError):
+            return []
+    if not isinstance(source, list):
+        return []
+    return [dict(item) for item in source if isinstance(item, dict)]
+
+
+def build_same_day_repair_effectiveness_facts(
+    learning_events: Iterable[dict[str, Any]],
+    *,
+    as_of: datetime | None = None,
+) -> dict[str, Any]:
+    """Summarize today's persisted adaptive repair attempts in JST."""
+    as_of = as_of or datetime.now(timezone.utc)
+    if as_of.tzinfo is None:
+        as_of = as_of.replace(tzinfo=timezone.utc)
+    today = as_of.astimezone(TOKYO).date()
+
+    repair_results: list[dict[str, Any]] = []
+    for event in learning_events or ():
+        answered_at = _parse_time(event.get("answered_at"))
+        if not answered_at or answered_at.astimezone(TOKYO).date() != today:
+            continue
+        for result in _results(event):
+            if (
+                result.get("learning_source") == "adaptive_daily"
+                and result.get("selection_group") == "repair"
+            ):
+                repair_results.append(result)
+
+    strong = [
+        item for item in repair_results
+        if item.get("repair_evidence_quality") == "different_question_strong"
+    ]
+    weak = [
+        item for item in repair_results
+        if item.get("repair_evidence_quality") == "different_question_weak"
+    ]
+    same = [
+        item for item in repair_results
+        if item.get("repair_evidence_quality") == "same_question"
+    ]
+
+    def is_correct(item: dict[str, Any]) -> bool:
+        return item.get("is_correct") is True and item.get("answer_status") != "unknown"
+
+    def confident_correct(item: dict[str, Any]) -> bool:
+        return is_correct(item) and item.get("confidence") == 1
+
+    def is_wrong(item: dict[str, Any]) -> bool:
+        return item.get("is_correct") is False and item.get("answer_status") != "unknown"
+
+    def distinct(items: list[dict[str, Any]], key: str) -> int:
+        return len({str(item.get(key)) for item in items if item.get(key)})
+
+    strong_correct = sum(is_correct(item) for item in strong)
+    strong_confident_correct = sum(confident_correct(item) for item in strong)
+    strong_wrong = sum(is_wrong(item) for item in strong)
+    strong_confident_wrong = sum(
+        is_wrong(item) and item.get("confidence") == 1 for item in strong
+    )
+    recent_repeat = sum(item.get("recent_question_repeat") is True for item in strong)
+    cooldown_bypass = sum(item.get("recent_cooldown_bypassed") is True for item in strong)
+
+    return {
+        "date_jst": today.isoformat(),
+        "adaptive_repair_attempt_count": len(repair_results),
+        "strong_attempt_count": len(strong),
+        "strong_correct_count": int(strong_correct),
+        "strong_accuracy_percent": (
+            round(100.0 * strong_correct / len(strong), 1) if strong else None
+        ),
+        "strong_confident_correct_count": int(strong_confident_correct),
+        "strong_wrong_count": int(strong_wrong),
+        "strong_confident_wrong_count": int(strong_confident_wrong),
+        "strong_distinct_node_count": distinct(strong, "knowledge_node_id"),
+        "strong_distinct_question_count": distinct(strong, "question_id"),
+        "strong_recent_repeat_count": int(recent_repeat),
+        "strong_cooldown_bypass_count": int(cooldown_bypass),
+        "weak_attempt_count": len(weak),
+        "weak_correct_count": sum(is_correct(item) for item in weak),
+        "same_question_attempt_count": len(same),
+        "same_question_correct_count": sum(is_correct(item) for item in same),
+        "formal_confirmation_candidate_count": int(strong_confident_correct),
+        "diagnostic_only": True,
+        "policy_note": (
+            "STRONG alternate outcomes are natural-use evidence only. A confident "
+            "correct is a formal-confirmation candidate; durable repair still requires "
+            "the normal Node-state and spaced-retention rules."
+        ),
+    }
+
+
+def build_repair_effectiveness_evidence_line(facts: dict[str, Any] | None) -> str:
+    """Serialize compact, non-identifying repair outcome facts for internal QA."""
+    source = facts or {}
+
+    def value(name: str) -> Any:
+        result = source.get(name)
+        return "none" if result is None else result
+
+    return "repair_effectiveness=" + ",".join([
+        f"date:{value('date_jst')}",
+        f"adaptive_repair:{int(source.get('adaptive_repair_attempt_count') or 0)}",
+        f"strong:{int(source.get('strong_attempt_count') or 0)}",
+        f"strong_correct:{int(source.get('strong_correct_count') or 0)}",
+        f"strong_accuracy:{value('strong_accuracy_percent')}",
+        f"strong_confident_correct:{int(source.get('strong_confident_correct_count') or 0)}",
+        f"strong_wrong:{int(source.get('strong_wrong_count') or 0)}",
+        f"strong_nodes:{int(source.get('strong_distinct_node_count') or 0)}",
+        f"strong_questions:{int(source.get('strong_distinct_question_count') or 0)}",
+        f"recent_repeat:{int(source.get('strong_recent_repeat_count') or 0)}",
+        f"cooldown_bypass:{int(source.get('strong_cooldown_bypass_count') or 0)}",
+        f"weak:{int(source.get('weak_attempt_count') or 0)}",
+        f"same_q:{int(source.get('same_question_attempt_count') or 0)}",
+        f"formal_confirmation_candidates:{int(source.get('formal_confirmation_candidate_count') or 0)}",
+    ])

--- a/tests/test_phase11_repair_effectiveness_facts.py
+++ b/tests/test_phase11_repair_effectiveness_facts.py
@@ -1,0 +1,125 @@
+from datetime import datetime, timedelta, timezone
+
+from phase11_repair_effectiveness_facts import (
+    build_repair_effectiveness_evidence_line,
+    build_same_day_repair_effectiveness_facts,
+)
+
+
+NOW = datetime(2026, 9, 6, 12, 0, tzinfo=timezone.utc)
+
+
+def _event(minutes, results):
+    return {
+        "answered_at": NOW - timedelta(minutes=minutes),
+        "question_results": results,
+    }
+
+
+def _result(
+    q,
+    *,
+    correct,
+    confidence,
+    quality,
+    node="KN0001",
+    source="adaptive_daily",
+    group="repair",
+    recent=False,
+    bypass=False,
+):
+    return {
+        "question_id": q,
+        "knowledge_node_id": node,
+        "is_correct": correct,
+        "confidence": confidence,
+        "answer_status": "answered",
+        "learning_source": source,
+        "selection_group": group,
+        "repair_evidence_quality": quality,
+        "recent_question_repeat": recent,
+        "recent_cooldown_bypassed": bypass,
+    }
+
+
+def test_summarizes_strong_repair_outcomes_without_promoting_state():
+    events = [
+        _event(30, [
+            _result("Q1", correct=True, confidence=1, quality="different_question_strong", node="KN1"),
+            _result("Q2", correct=True, confidence=2, quality="different_question_strong", node="KN2"),
+            _result("Q3", correct=False, confidence=2, quality="different_question_strong", node="KN3"),
+            _result("Q4", correct=True, confidence=1, quality="different_question_weak", node="KN4"),
+            _result("Q5", correct=False, confidence=1, quality="same_question", node="KN5"),
+        ]),
+        _event(20, [
+            _result("Q1", correct=True, confidence=1, quality="different_question_strong", node="KN1"),
+            _result("Q6", correct=True, confidence=1, quality="different_question_strong", node="KN6", recent=True, bypass=True),
+            _result("Q7", correct=True, confidence=1, quality="different_question_strong", source="manual"),
+            _result("Q8", correct=True, confidence=1, quality="different_question_strong", group="checking"),
+        ]),
+    ]
+
+    facts = build_same_day_repair_effectiveness_facts(events, as_of=NOW)
+
+    assert facts["adaptive_repair_attempt_count"] == 7
+    assert facts["strong_attempt_count"] == 5
+    assert facts["strong_correct_count"] == 4
+    assert facts["strong_accuracy_percent"] == 80.0
+    assert facts["strong_confident_correct_count"] == 3
+    assert facts["formal_confirmation_candidate_count"] == 3
+    assert facts["strong_wrong_count"] == 1
+    assert facts["strong_distinct_node_count"] == 4
+    assert facts["strong_distinct_question_count"] == 4
+    assert facts["strong_recent_repeat_count"] == 1
+    assert facts["strong_cooldown_bypass_count"] == 1
+    assert facts["weak_attempt_count"] == 1
+    assert facts["same_question_attempt_count"] == 1
+    assert facts["diagnostic_only"] is True
+    assert "spaced-retention" in facts["policy_note"]
+
+
+def test_excludes_other_jst_day_and_handles_json_string_results():
+    previous_day = {
+        "answered_at": datetime(2026, 9, 5, 14, 59, tzinfo=timezone.utc),
+        "question_results": '[{"question_id":"Q1","knowledge_node_id":"KN1","is_correct":true,"confidence":1,"answer_status":"answered","learning_source":"adaptive_daily","selection_group":"repair","repair_evidence_quality":"different_question_strong"}]',
+    }
+    current_day = {
+        "answered_at": datetime(2026, 9, 5, 15, 1, tzinfo=timezone.utc),
+        "question_results": '[{"question_id":"Q2","knowledge_node_id":"KN2","is_correct":true,"confidence":1,"answer_status":"answered","learning_source":"adaptive_daily","selection_group":"repair","repair_evidence_quality":"different_question_strong"}]',
+    }
+    facts = build_same_day_repair_effectiveness_facts(
+        [previous_day, current_day],
+        as_of=datetime(2026, 9, 6, 1, 0, tzinfo=timezone.utc),
+    )
+    assert facts["strong_attempt_count"] == 1
+    assert facts["formal_confirmation_candidate_count"] == 1
+
+
+def test_evidence_line_is_compact_and_non_identifying():
+    line = build_repair_effectiveness_evidence_line({
+        "date_jst": "2026-09-06",
+        "adaptive_repair_attempt_count": 45,
+        "strong_attempt_count": 35,
+        "strong_correct_count": 26,
+        "strong_accuracy_percent": 74.3,
+        "strong_confident_correct_count": 13,
+        "strong_wrong_count": 9,
+        "strong_distinct_node_count": 29,
+        "strong_distinct_question_count": 29,
+        "strong_recent_repeat_count": 0,
+        "strong_cooldown_bypass_count": 0,
+        "weak_attempt_count": 8,
+        "same_question_attempt_count": 2,
+        "formal_confirmation_candidate_count": 13,
+        "user_id": "must-not-leak",
+        "token": "must-not-leak",
+    })
+    assert line.startswith("repair_effectiveness=date:2026-09-06,adaptive_repair:45,strong:35")
+    assert "strong_correct:26,strong_accuracy:74.3,strong_confident_correct:13" in line
+    assert "formal_confirmation_candidates:13" in line
+    assert "must-not-leak" not in line
+    assert "user_id" not in line
+    assert "token" not in line
+    assert build_repair_effectiveness_evidence_line(None).startswith(
+        "repair_effectiveness=date:none,adaptive_repair:0,strong:0"
+    )

--- a/tests/test_pilot_diagnostics.py
+++ b/tests/test_pilot_diagnostics.py
@@ -58,6 +58,7 @@ def test_diagnostics_route_requires_internal_admin_and_not_on_personal_dashboard
     assert "30問監査データをコピー" in html
     assert "same_day_load=" in html
     assert "block_scope:same_day_cumulative" in html
+    assert "repair_effectiveness=" in html
     assert html.count('class="adaptive-audit-item"') == 30
     assert "LT学習診断" not in client.get(f"/goukaku-no-michi?token=invalid").get_data(as_text=True)
 


### PR DESCRIPTION
## Summary
- summarize persisted same-day adaptive repair outcomes from natural use
- separate STRONG, weak, and same-question repair evidence
- count STRONG correct, confidence=1 correct confirmation candidates, wrong outcomes, unique Nodes/questions, and recent-repeat/bypass metadata
- append compact non-identifying repair-effectiveness evidence to the internal Phase11 bundle

## Safety boundary
- diagnostics only / Phase11 remains Shadow-only
- no Node-state mutation
- no J1-J7 or Phase10 selector change
- no Safety or Recent Cooldown change
- no Question Bank change
- no Production write or migration

## Tests
- natural-use-shaped outcome summary
- JST filtering and JSON-string event compatibility
- non-identifying evidence serialization
- internal diagnostics bundle wiring