### PR TITLE
Wire retention horizon into internal Phase11 diagnostics

### DIFF
--- a/developer_ui.py
+++ b/developer_ui.py
@@ -26,9 +26,14 @@ from feedback_store import (
     set_operator_reply,
 )
 from goukaku_ui import build_dashboard
+from knowledge_node_state_transition import derive_all_user_node_states
 from phase11_repair_effectiveness_facts import (
     build_repair_effectiveness_evidence_line,
     build_same_day_repair_effectiveness_facts,
+)
+from phase11_retention_horizon_facts import (
+    build_retention_horizon_evidence_line,
+    build_retention_horizon_facts,
 )
 from phase11_session_load_facts import (
     build_same_day_session_load_evidence_line,
@@ -223,20 +228,25 @@ def register_developer_routes(blueprint) -> None:
         if period not in {"7", "30", "all"}:
             period = "7"
         diagnostics = build_pilot_diagnostics(learner_id, period)
-        same_day_session_load = build_same_day_session_load_facts(
-            get_question_attempts(learner_id)
-        )
+        attempts = get_question_attempts(learner_id)
+        same_day_session_load = build_same_day_session_load_facts(attempts)
         repair_effectiveness = build_same_day_repair_effectiveness_facts(
             get_learning_events(learner_id)
         )
+        retention_horizon = build_retention_horizon_facts(
+            derive_all_user_node_states(attempts)
+        )
         diagnostics["same_day_session_load"] = same_day_session_load
         diagnostics["repair_effectiveness"] = repair_effectiveness
+        diagnostics["retention_horizon"] = retention_horizon
         diagnostics["promotion_evidence_text"] = (
             str(diagnostics.get("promotion_evidence_text") or "").rstrip()
             + "\n"
             + build_same_day_session_load_evidence_line(same_day_session_load)
             + "\n"
             + build_repair_effectiveness_evidence_line(repair_effectiveness)
+            + "\n"
+            + build_retention_horizon_evidence_line(retention_horizon)
         ).lstrip("\n")
         return render_template(
             "goukaku/supporter_pilot_diagnostics.html",

--- a/phase11_retention_horizon_facts.py
+++ b/phase11_retention_horizon_facts.py
@@ -1,0 +1,90 @@
+"""Read-only upcoming-retention facts for Phase 11 diagnostics.
+
+This module consumes formal Node-state output and reports when naturally repaired
+Nodes are expected to become due. It never edits timestamps, promotes a Node,
+or changes J1-J7 ordering or Phase10 selection.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any, Iterable
+from zoneinfo import ZoneInfo
+
+
+TOKYO = ZoneInfo("Asia/Tokyo")
+
+
+def _as_datetime(value: Any) -> datetime | None:
+    if isinstance(value, datetime):
+        parsed = value
+    elif value:
+        try:
+            parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+        except ValueError:
+            return None
+    else:
+        return None
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+
+
+def build_retention_horizon_facts(
+    node_states: Iterable[dict[str, Any]],
+    *,
+    as_of: datetime | None = None,
+) -> dict[str, Any]:
+    """Summarize currently due and upcoming formal retention reviews."""
+    as_of = _as_datetime(as_of) or datetime.now(timezone.utc)
+    states = [dict(item) for item in node_states or ()]
+
+    due_now = [item for item in states if item.get("state") == "recheck_due"]
+    upcoming: list[tuple[datetime, dict[str, Any]]] = []
+    for item in states:
+        if item.get("state") not in {"repaired", "stable"}:
+            continue
+        next_review_at = _as_datetime(item.get("next_review_at"))
+        if next_review_at and next_review_at > as_of:
+            upcoming.append((next_review_at, item))
+    upcoming.sort(key=lambda pair: (pair[0], str(pair[1].get("canonical_node_id") or "")))
+
+    within_24h = sum(review_at <= as_of + timedelta(hours=24) for review_at, _ in upcoming)
+    within_3d = sum(review_at <= as_of + timedelta(days=3) for review_at, _ in upcoming)
+    within_7d = sum(review_at <= as_of + timedelta(days=7) for review_at, _ in upcoming)
+    earliest = upcoming[0][0] if upcoming else None
+
+    return {
+        "as_of_jst": as_of.astimezone(TOKYO).isoformat(),
+        "recheck_due_count": len(due_now),
+        "upcoming_review_count": len(upcoming),
+        "due_within_24h_count": int(within_24h),
+        "due_within_3d_count": int(within_3d),
+        "due_within_7d_count": int(within_7d),
+        "earliest_review_at_jst": earliest.astimezone(TOKYO).isoformat() if earliest else None,
+        "earliest_review_in_hours": (
+            round((earliest - as_of).total_seconds() / 3600.0, 1) if earliest else None
+        ),
+        "diagnostic_only": True,
+        "policy_note": (
+            "Retention horizon is a forecast from formal Node state only. Do not "
+            "alter learner timestamps or manufacture attempts to make a review due."
+        ),
+    }
+
+
+def build_retention_horizon_evidence_line(facts: dict[str, Any] | None) -> str:
+    """Serialize compact non-identifying retention timing facts."""
+    source = facts or {}
+
+    def value(name: str) -> Any:
+        result = source.get(name)
+        return "none" if result is None else result
+
+    return "retention_horizon=" + ",".join([
+        f"due_now:{int(source.get('recheck_due_count') or 0)}",
+        f"upcoming:{int(source.get('upcoming_review_count') or 0)}",
+        f"within_24h:{int(source.get('due_within_24h_count') or 0)}",
+        f"within_3d:{int(source.get('due_within_3d_count') or 0)}",
+        f"within_7d:{int(source.get('due_within_7d_count') or 0)}",
+        f"earliest_at_jst:{value('earliest_review_at_jst')}",
+        f"earliest_in_hours:{value('earliest_review_in_hours')}",
+    ])

--- a/tests/test_phase11_retention_horizon_facts.py
+++ b/tests/test_phase11_retention_horizon_facts.py
@@ -1,0 +1,68 @@
+from datetime import datetime, timedelta, timezone
+
+from phase11_retention_horizon_facts import (
+    build_retention_horizon_evidence_line,
+    build_retention_horizon_facts,
+)
+
+
+NOW = datetime(2026, 9, 6, 8, 0, tzinfo=timezone.utc)
+
+
+def test_summarizes_due_and_upcoming_reviews_without_mutation():
+    states = [
+        {"canonical_node_id": "KN1", "state": "recheck_due", "next_review_at": NOW - timedelta(hours=1)},
+        {"canonical_node_id": "KN2", "state": "repaired", "next_review_at": NOW + timedelta(hours=12)},
+        {"canonical_node_id": "KN3", "state": "repaired", "next_review_at": NOW + timedelta(days=2)},
+        {"canonical_node_id": "KN4", "state": "stable", "next_review_at": NOW + timedelta(days=5)},
+        {"canonical_node_id": "KN5", "state": "repairing", "next_review_at": NOW + timedelta(hours=2)},
+        {"canonical_node_id": "KN6", "state": "repaired", "next_review_at": NOW + timedelta(days=10)},
+    ]
+    original = [dict(item) for item in states]
+
+    facts = build_retention_horizon_facts(states, as_of=NOW)
+
+    assert states == original
+    assert facts["recheck_due_count"] == 1
+    assert facts["upcoming_review_count"] == 4
+    assert facts["due_within_24h_count"] == 1
+    assert facts["due_within_3d_count"] == 2
+    assert facts["due_within_7d_count"] == 3
+    assert facts["earliest_review_in_hours"] == 12.0
+    assert facts["earliest_review_at_jst"].startswith("2026-09-06T29") is False
+    assert facts["diagnostic_only"] is True
+    assert "manufacture attempts" in facts["policy_note"]
+
+
+def test_empty_and_invalid_review_times_fail_closed():
+    facts = build_retention_horizon_facts([
+        {"canonical_node_id": "KN1", "state": "repaired", "next_review_at": None},
+        {"canonical_node_id": "KN2", "state": "stable", "next_review_at": "not-a-time"},
+    ], as_of=NOW)
+    assert facts["recheck_due_count"] == 0
+    assert facts["upcoming_review_count"] == 0
+    assert facts["earliest_review_at_jst"] is None
+    assert facts["earliest_review_in_hours"] is None
+
+
+def test_evidence_line_is_non_identifying_and_has_safe_defaults():
+    line = build_retention_horizon_evidence_line({
+        "recheck_due_count": 0,
+        "upcoming_review_count": 13,
+        "due_within_24h_count": 0,
+        "due_within_3d_count": 4,
+        "due_within_7d_count": 13,
+        "earliest_review_at_jst": "2026-09-09T08:26:32+09:00",
+        "earliest_review_in_hours": 63.4,
+        "user_id": "must-not-leak",
+        "token": "must-not-leak",
+    })
+    assert line.startswith("retention_horizon=due_now:0,upcoming:13,within_24h:0,within_3d:4")
+    assert "earliest_at_jst:2026-09-09T08:26:32+09:00" in line
+    assert "must-not-leak" not in line
+    assert "user_id" not in line
+    assert "token" not in line
+    assert build_retention_horizon_evidence_line(None) == (
+        "retention_horizon=due_now:0,upcoming:0,within_24h:0,within_3d:0,within_7d:0,"
+        "earliest_at_jst:none,earliest_in_hours:none"
+    )


### PR DESCRIPTION
## Summary
- wire read-only retention horizon facts into the internal Phase11 diagnostics route
- derive formal Node states from existing attempt history
- append non-identifying due-now / 24h / 3d / 7d retention timing evidence to the promotion bundle
- preserve learner-facing behavior

## Safety boundary
- Phase11 remains Shadow-only
- no Node-state mutation
- no J1-J7 or Phase10 selector change
- no Safety or Recent Cooldown change
- no Question Bank change
- no Production write or migration

## Tests
- retention-horizon unit tests cover due/upcoming windows, fail-closed invalid timestamps, and non-identifying serialization
- full CI must remain green before merge