### PR TITLE
Add conservative Phase11 promotion gate status

### DIFF
--- a/developer_ui.py
+++ b/developer_ui.py
@@ -27,6 +27,10 @@ from feedback_store import (
 )
 from goukaku_ui import build_dashboard
 from knowledge_node_state_transition import derive_all_user_node_states
+from phase11_promotion_gate_status import (
+    build_phase11_promotion_gate_evidence_line,
+    build_phase11_promotion_gate_status,
+)
 from phase11_repair_effectiveness_facts import (
     build_repair_effectiveness_evidence_line,
     build_same_day_repair_effectiveness_facts,
@@ -236,9 +240,21 @@ def register_developer_routes(blueprint) -> None:
         retention_horizon = build_retention_horizon_facts(
             derive_all_user_node_states(attempts)
         )
+        promotion_gate_status = build_phase11_promotion_gate_status(
+            retrospective_shadow_audit=diagnostics.get("retrospective_shadow_audit"),
+            repeat_structure_audit=diagnostics.get("repeat_structure_audit"),
+            retention_horizon=retention_horizon,
+            state_counts=diagnostics.get("state_counts"),
+            transitions={
+                "recheck_due_to_stable": diagnostics.get("due_to_stable", 0),
+                "recheck_due_to_repairing": diagnostics.get("due_to_repairing", 0),
+            },
+            shadow_judgment=diagnostics.get("shadow_judgment"),
+        )
         diagnostics["same_day_session_load"] = same_day_session_load
         diagnostics["repair_effectiveness"] = repair_effectiveness
         diagnostics["retention_horizon"] = retention_horizon
+        diagnostics["promotion_gate_status"] = promotion_gate_status
         diagnostics["promotion_evidence_text"] = (
             str(diagnostics.get("promotion_evidence_text") or "").rstrip()
             + "\n"
@@ -247,6 +263,8 @@ def register_developer_routes(blueprint) -> None:
             + build_repair_effectiveness_evidence_line(repair_effectiveness)
             + "\n"
             + build_retention_horizon_evidence_line(retention_horizon)
+            + "\n"
+            + build_phase11_promotion_gate_evidence_line(promotion_gate_status)
         ).lstrip("\n")
         return render_template(
             "goukaku/supporter_pilot_diagnostics.html",

--- a/phase11_promotion_gate_status.py
+++ b/phase11_promotion_gate_status.py
@@ -1,0 +1,154 @@
+"""Read-only Phase 11 promotion gate status from existing diagnostic evidence.
+
+This module is intentionally conservative.  It can report PASS / OPEN / BLOCKED
+for evidence classes, but it never authorizes learner-facing promotion.  A human
+promotion review remains required even when every automatically checkable gate
+is clear.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+PASS = "pass"
+OPEN = "open"
+BLOCKED = "blocked"
+
+
+def _int(source: dict[str, Any] | None, key: str) -> int:
+    return int((source or {}).get(key) or 0)
+
+
+def build_phase11_promotion_gate_status(
+    *,
+    retrospective_shadow_audit: dict[str, Any] | None,
+    repeat_structure_audit: dict[str, Any] | None,
+    retention_horizon: dict[str, Any] | None,
+    state_counts: dict[str, Any] | None,
+    transitions: dict[str, Any] | None,
+    shadow_judgment: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Return deterministic gate states without inventing promotion thresholds."""
+    replay = retrospective_shadow_audit or {}
+    repeat = repeat_structure_audit or {}
+    repeat_counts = repeat.get("category_counts") or {}
+    retention = retention_horizon or {}
+    states = state_counts or {}
+    transition_counts = transitions or {}
+    shadow = shadow_judgment or {}
+    comparison = shadow.get("comparison") or {}
+
+    safety_misses = _int(replay, "phase11_critical_safety_miss_candidate_count")
+    safety_status = BLOCKED if safety_misses else PASS
+
+    unexplained_repeat = _int(repeat_counts, "adaptive_unexplained_repeat")
+    metadata_inconsistent = _int(repeat_counts, "adaptive_metadata_inconsistent")
+    repeat_status = BLOCKED if unexplained_repeat or metadata_inconsistent else PASS
+
+    trigger_mismatch = _int(replay, "ordinary_single_wrong_takeover_candidate_count")
+    trigger_status = BLOCKED if trigger_mismatch else PASS
+
+    due_now = _int(retention, "recheck_due_count")
+    stable_now = _int(states, "stable")
+    due_to_stable = _int(transition_counts, "recheck_due_to_stable")
+    due_to_repairing = _int(transition_counts, "recheck_due_to_repairing")
+    retention_observed = bool(due_now or stable_now or due_to_stable or due_to_repairing)
+    retention_status = PASS if (due_to_stable or due_to_repairing or stable_now) else OPEN
+
+    eligible = _int(replay, "eligible_snapshot_count")
+    shadow_stronger = _int(replay, "shadow_stronger_disagreement_count")
+    current_stronger = _int(replay, "current_stronger_disagreement_count")
+    agreement = _int(replay, "agreement_count")
+    inconclusive = _int(replay, "inconclusive_disagreement_count")
+    observed_directions = sum(
+        value > 0 for value in (shadow_stronger, current_stronger, agreement, inconclusive)
+    )
+    # No fixed sample threshold is encoded.  Diversity is OPEN until at least two
+    # naturally observed result directions exist, then PASS as a collection gate.
+    prospective_status = PASS if observed_directions >= 2 else OPEN
+
+    profile_consistent = bool(comparison.get("shadow_reason_profile_consistent", True))
+    comparison_status = PASS if profile_consistent else BLOCKED
+
+    gates = {
+        "safety": {
+            "status": safety_status,
+            "critical_miss_count": safety_misses,
+        },
+        "repeat_audit": {
+            "status": repeat_status,
+            "unexplained_recent_repeat_count": unexplained_repeat,
+            "metadata_inconsistent_count": metadata_inconsistent,
+        },
+        "formal_trigger_consistency": {
+            "status": trigger_status,
+            "single_wrong_takeover_candidate_count": trigger_mismatch,
+        },
+        "retention": {
+            "status": retention_status,
+            "natural_retention_observed": retention_observed,
+            "recheck_due_count": due_now,
+            "stable_count": stable_now,
+            "recheck_due_to_stable": due_to_stable,
+            "recheck_due_to_repairing": due_to_repairing,
+            "upcoming_review_count": _int(retention, "upcoming_review_count"),
+            "earliest_review_at_jst": retention.get("earliest_review_at_jst"),
+        },
+        "comparison_diversity": {
+            "status": prospective_status,
+            "eligible_snapshot_count": eligible,
+            "shadow_stronger": shadow_stronger,
+            "current_stronger": current_stronger,
+            "agreement": agreement,
+            "inconclusive": inconclusive,
+            "observed_direction_count": observed_directions,
+        },
+        "profile_consistency": {
+            "status": comparison_status,
+            "shadow_reason_profile_consistent": profile_consistent,
+        },
+    }
+
+    blocked = [name for name, item in gates.items() if item["status"] == BLOCKED]
+    open_gates = [name for name, item in gates.items() if item["status"] == OPEN]
+    automatically_clear = not blocked and not open_gates
+
+    return {
+        "decision": "blocked" if blocked else "hold",
+        "learner_facing_promotion_allowed": False,
+        "manual_review_required": True,
+        "automatically_clear": automatically_clear,
+        "blocked_gates": blocked,
+        "open_gates": open_gates,
+        "gates": gates,
+        "policy_note": (
+            "Automatic diagnostics never promote Phase11. Even when every checkable "
+            "gate is clear, learner-facing promotion requires an explicit human review."
+        ),
+    }
+
+
+def build_phase11_promotion_gate_evidence_line(status: dict[str, Any] | None) -> str:
+    """Serialize a compact non-identifying status line for the evidence bundle."""
+    source = status or {}
+    gates = source.get("gates") or {}
+
+    def gate(name: str) -> str:
+        return str((gates.get(name) or {}).get("status") or OPEN)
+
+    blocked = "|".join(source.get("blocked_gates") or []) or "none"
+    open_gates = "|".join(source.get("open_gates") or []) or "none"
+    return "phase11_gate_status=" + ",".join([
+        f"decision:{source.get('decision') or 'hold'}",
+        f"safety:{gate('safety')}",
+        f"repeat:{gate('repeat_audit')}",
+        f"trigger:{gate('formal_trigger_consistency')}",
+        f"retention:{gate('retention')}",
+        f"diversity:{gate('comparison_diversity')}",
+        f"profile:{gate('profile_consistency')}",
+        f"blocked:{blocked}",
+        f"open:{open_gates}",
+        "promotion_allowed:false",
+        "manual_review_required:true",
+    ])

--- a/tests/test_phase11_promotion_gate_status.py
+++ b/tests/test_phase11_promotion_gate_status.py
@@ -1,0 +1,119 @@
+from phase11_promotion_gate_status import (
+    BLOCKED,
+    OPEN,
+    PASS,
+    build_phase11_promotion_gate_evidence_line,
+    build_phase11_promotion_gate_status,
+)
+
+
+def _status(**overrides):
+    kwargs = dict(
+        retrospective_shadow_audit={
+            "eligible_snapshot_count": 2,
+            "shadow_stronger_disagreement_count": 2,
+            "current_stronger_disagreement_count": 0,
+            "agreement_count": 0,
+            "inconclusive_disagreement_count": 0,
+            "phase11_critical_safety_miss_candidate_count": 0,
+            "ordinary_single_wrong_takeover_candidate_count": 0,
+        },
+        repeat_structure_audit={
+            "category_counts": {
+                "adaptive_unexplained_repeat": 0,
+                "adaptive_metadata_inconsistent": 0,
+            }
+        },
+        retention_horizon={
+            "recheck_due_count": 0,
+            "upcoming_review_count": 13,
+            "earliest_review_at_jst": "2026-09-09T08:26:32+09:00",
+        },
+        state_counts={"stable": 0},
+        transitions={
+            "recheck_due_to_stable": 0,
+            "recheck_due_to_repairing": 0,
+        },
+        shadow_judgment={
+            "comparison": {"shadow_reason_profile_consistent": True}
+        },
+    )
+    kwargs.update(overrides)
+    return build_phase11_promotion_gate_status(**kwargs)
+
+
+def test_current_natural_shape_stays_hold_with_retention_and_diversity_open():
+    result = _status()
+    assert result["decision"] == "hold"
+    assert result["learner_facing_promotion_allowed"] is False
+    assert result["manual_review_required"] is True
+    assert result["gates"]["safety"]["status"] == PASS
+    assert result["gates"]["repeat_audit"]["status"] == PASS
+    assert result["gates"]["formal_trigger_consistency"]["status"] == PASS
+    assert result["gates"]["retention"]["status"] == OPEN
+    assert result["gates"]["comparison_diversity"]["status"] == OPEN
+    assert set(result["open_gates"]) == {"retention", "comparison_diversity"}
+
+
+def test_safety_repeat_or_trigger_regression_blocks_without_enabling_promotion():
+    result = _status(
+        retrospective_shadow_audit={
+            "eligible_snapshot_count": 3,
+            "shadow_stronger_disagreement_count": 1,
+            "current_stronger_disagreement_count": 1,
+            "phase11_critical_safety_miss_candidate_count": 1,
+            "ordinary_single_wrong_takeover_candidate_count": 1,
+        },
+        repeat_structure_audit={
+            "category_counts": {
+                "adaptive_unexplained_repeat": 2,
+                "adaptive_metadata_inconsistent": 1,
+            }
+        },
+    )
+    assert result["decision"] == "blocked"
+    assert result["gates"]["safety"]["status"] == BLOCKED
+    assert result["gates"]["repeat_audit"]["status"] == BLOCKED
+    assert result["gates"]["formal_trigger_consistency"]["status"] == BLOCKED
+    assert result["learner_facing_promotion_allowed"] is False
+
+
+def test_retention_outcome_and_direction_diversity_can_clear_checkable_gates_only():
+    result = _status(
+        retrospective_shadow_audit={
+            "eligible_snapshot_count": 4,
+            "shadow_stronger_disagreement_count": 2,
+            "current_stronger_disagreement_count": 1,
+            "agreement_count": 1,
+            "inconclusive_disagreement_count": 0,
+            "phase11_critical_safety_miss_candidate_count": 0,
+            "ordinary_single_wrong_takeover_candidate_count": 0,
+        },
+        retention_horizon={"recheck_due_count": 0, "upcoming_review_count": 8},
+        state_counts={"stable": 1},
+        transitions={
+            "recheck_due_to_stable": 1,
+            "recheck_due_to_repairing": 0,
+        },
+    )
+    assert result["gates"]["retention"]["status"] == PASS
+    assert result["gates"]["comparison_diversity"]["status"] == PASS
+    assert result["automatically_clear"] is True
+    assert result["decision"] == "hold"
+    assert result["learner_facing_promotion_allowed"] is False
+    assert result["manual_review_required"] is True
+
+
+def test_evidence_line_is_non_identifying_and_never_says_promotion_allowed_true():
+    result = _status()
+    result["user_id"] = "must-not-leak"
+    result["token"] = "must-not-leak"
+    line = build_phase11_promotion_gate_evidence_line(result)
+    assert line.startswith("phase11_gate_status=decision:hold")
+    assert "retention:open" in line
+    assert "diversity:open" in line
+    assert "promotion_allowed:false" in line
+    assert "manual_review_required:true" in line
+    assert "must-not-leak" not in line
+    assert "user_id" not in line
+    assert "token" not in line


### PR DESCRIPTION
## Summary
- add a read-only Phase11 promotion gate status derived from existing diagnostics
- classify Safety, repeat-audit, formal-trigger consistency, retention, comparison diversity, and profile consistency as pass/open/blocked
- never authorize learner-facing promotion automatically; even fully clear diagnostics remain HOLD pending explicit human review
- append a compact non-identifying gate-status line to the internal promotion evidence bundle

## Safety boundary
- Phase11 remains Shadow-only
- no J1-J7 change
- no Phase10 selector/Safety/Recent Cooldown change
- no Question Bank change
- no Production DB write or migration
- no automatic promotion threshold or learner-facing behavior change

## Tests
- current natural-use shape remains HOLD with retention/diversity open
- Safety/repeat/trigger regressions block
- later retention/diversity evidence can clear checkable gates without enabling promotion
- evidence serialization excludes identity/token fields