### PR TITLE
Add internal Phase11 gate dashboard

### DIFF
--- a/phase11_gate_ui.py
+++ b/phase11_gate_ui.py
@@ -1,0 +1,77 @@
+"""Internal-only Phase11 gate dashboard.
+
+This view exposes already-computed diagnostic evidence without changing learner
+recommendations, selector behavior, Node state, or Production data.
+"""
+
+from __future__ import annotations
+
+from flask import abort, render_template, request
+
+from database import get_learning_events, get_question_attempts
+from developer_ui import require_developer_authorization
+from knowledge_node_state_transition import derive_all_user_node_states
+from phase11_promotion_gate_status import build_phase11_promotion_gate_status
+from phase11_repair_effectiveness_facts import build_same_day_repair_effectiveness_facts
+from phase11_retention_horizon_facts import build_retention_horizon_facts
+from phase11_session_load_facts import build_same_day_session_load_facts
+from pilot_diagnostics import build_pilot_diagnostics
+
+
+ROUTE = "/internal/phase11-gates"
+ENDPOINT = "internal_phase11_gates"
+
+
+def build_phase11_gate_dashboard(learner_id: str, period: str = "7") -> dict:
+    """Build one read-only snapshot from formal history and existing diagnostics."""
+    if period not in {"7", "30", "all"}:
+        period = "7"
+
+    diagnostics = build_pilot_diagnostics(learner_id, period)
+    attempts = get_question_attempts(learner_id)
+    retention_horizon = build_retention_horizon_facts(
+        derive_all_user_node_states(attempts)
+    )
+    gate_status = build_phase11_promotion_gate_status(
+        retrospective_shadow_audit=diagnostics.get("retrospective_shadow_audit"),
+        repeat_structure_audit=diagnostics.get("repeat_structure_audit"),
+        retention_horizon=retention_horizon,
+        state_counts=diagnostics.get("state_counts"),
+        transitions={
+            "recheck_due_to_stable": diagnostics.get("due_to_stable", 0),
+            "recheck_due_to_repairing": diagnostics.get("due_to_repairing", 0),
+        },
+        shadow_judgment=diagnostics.get("shadow_judgment"),
+    )
+    return {
+        "period": period,
+        "diagnostics": diagnostics,
+        "session_load": build_same_day_session_load_facts(attempts),
+        "repair_effectiveness": build_same_day_repair_effectiveness_facts(
+            get_learning_events(learner_id)
+        ),
+        "retention_horizon": retention_horizon,
+        "gate_status": gate_status,
+    }
+
+
+def install_phase11_gate_ui(flask_app) -> None:
+    """Register the internal dashboard exactly once."""
+    if ENDPOINT in flask_app.view_functions:
+        return
+
+    def internal_phase11_gates():
+        token = require_developer_authorization()
+        learner_id = request.args.get("learner_user_id", "").strip()
+        if not learner_id:
+            abort(400)
+        period = request.args.get("period", "7")
+        snapshot = build_phase11_gate_dashboard(learner_id, period)
+        return render_template(
+            "internal/phase11_gates.html",
+            internal_token=token,
+            learner_id=learner_id,
+            **snapshot,
+        )
+
+    flask_app.add_url_rule(ROUTE, ENDPOINT, internal_phase11_gates, methods=["GET"])

--- a/templates/internal/phase11_gates.html
+++ b/templates/internal/phase11_gates.html
@@ -21,13 +21,12 @@
     .gate-row { display: flex; justify-content: space-between; gap: 14px; padding: 8px 0; border-bottom: 1px solid #edf1ee; }
     .gate-row:last-child { border-bottom: 0; }
     .notice { border-left: 4px solid #a67b00; padding-left: 12px; }
-    a { color: #176b42; font-weight: 700; }
-    code { overflow-wrap: anywhere; }
+    button { border: 0; background: transparent; padding: 0; color: #176b42; font: inherit; font-weight: 700; cursor: pointer; }
   </style>
 </head>
 <body>
 <main>
-  <p><a href="{{ url_for('site_ui.internal_index', token=internal_token, learner_user_id=learner_id) }}">← Internal console</a></p>
+  <p><button type="button" onclick="history.back()">← 戻る</button></p>
   <h1>Phase11 Gate Status</h1>
   <p class="muted">診断専用。学習者向け推薦・Selector・Node状態を変更しません。</p>
 

--- a/templates/internal/phase11_gates.html
+++ b/templates/internal/phase11_gates.html
@@ -1,0 +1,92 @@
+<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Phase11 Gate Status</title>
+  <style>
+    :root { color-scheme: light; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+    body { margin: 0; background: #f5f7f6; color: #16231b; }
+    main { width: min(1040px, calc(100% - 32px)); margin: 28px auto 60px; }
+    h1 { margin-bottom: 6px; }
+    h2 { margin: 0 0 12px; font-size: 1.08rem; }
+    .muted { color: #5f6d64; }
+    .grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(210px, 1fr)); gap: 12px; }
+    .card { background: #fff; border: 1px solid #dbe4de; border-radius: 12px; padding: 16px; margin-top: 14px; }
+    .metric { font-size: 1.4rem; font-weight: 750; margin: 4px 0; }
+    .pass { color: #116530; font-weight: 750; }
+    .open { color: #9b5d00; font-weight: 750; }
+    .blocked { color: #a22121; font-weight: 750; }
+    .hold { color: #795500; font-weight: 800; }
+    .gate-row { display: flex; justify-content: space-between; gap: 14px; padding: 8px 0; border-bottom: 1px solid #edf1ee; }
+    .gate-row:last-child { border-bottom: 0; }
+    .notice { border-left: 4px solid #a67b00; padding-left: 12px; }
+    a { color: #176b42; font-weight: 700; }
+    code { overflow-wrap: anywhere; }
+  </style>
+</head>
+<body>
+<main>
+  <p><a href="{{ url_for('site_ui.internal_index', token=internal_token, learner_user_id=learner_id) }}">← Internal console</a></p>
+  <h1>Phase11 Gate Status</h1>
+  <p class="muted">診断専用。学習者向け推薦・Selector・Node状態を変更しません。</p>
+
+  {% set gate = gate_status %}
+  <section class="card">
+    <h2>Promotion decision</h2>
+    <div class="metric {{ 'blocked' if gate.decision == 'blocked' else 'hold' }}">{{ gate.decision|upper }}</div>
+    <p class="notice"><strong>自動昇格なし。</strong> learner-facing promotion allowed = false / manual review required = true</p>
+    <p>Blocked: {{ gate.blocked_gates|join(', ') or 'なし' }} / Open: {{ gate.open_gates|join(', ') or 'なし' }}</p>
+  </section>
+
+  <section class="card">
+    <h2>Gate details</h2>
+    {% for key,label in [
+      ('safety','Safety'),
+      ('repeat_audit','Repeat audit'),
+      ('formal_trigger_consistency','Formal trigger'),
+      ('retention','Retention'),
+      ('comparison_diversity','Comparison diversity'),
+      ('profile_consistency','Profile consistency')
+    ] %}
+      {% set item = gate.gates[key] %}
+      <div class="gate-row"><span>{{ label }}</span><span class="{{ item.status }}">{{ item.status|upper }}</span></div>
+    {% endfor %}
+  </section>
+
+  {% set retention = retention_horizon %}
+  <section class="card">
+    <h2>Retention Horizon</h2>
+    <div class="grid">
+      <div><div class="muted">Due now</div><div class="metric">{{ retention.recheck_due_count }}</div></div>
+      <div><div class="muted">24時間以内</div><div class="metric">{{ retention.due_within_24h_count }}</div></div>
+      <div><div class="muted">3日以内</div><div class="metric">{{ retention.due_within_3d_count }}</div></div>
+      <div><div class="muted">7日以内</div><div class="metric">{{ retention.due_within_7d_count }}</div></div>
+    </div>
+    <p>Upcoming {{ retention.upcoming_review_count }} / 最短 {{ retention.earliest_review_at_jst or 'なし' }}{% if retention.earliest_review_in_hours is not none %}（約{{ retention.earliest_review_in_hours }}時間後）{% endif %}</p>
+  </section>
+
+  {% set repair = repair_effectiveness %}
+  <section class="card">
+    <h2>Natural Repair Effectiveness</h2>
+    <p>adaptive repair {{ repair.adaptive_repair_attempt_count }} / STRONG {{ repair.strong_attempt_count }} / STRONG正解 {{ repair.strong_correct_count }}（{{ repair.strong_accuracy_percent if repair.strong_accuracy_percent is not none else '—' }}%）</p>
+    <p>STRONG＋自信あり正解候補 {{ repair.formal_confirmation_candidate_count }} / STRONG誤答 {{ repair.strong_wrong_count }} / recent repeat {{ repair.strong_recent_repeat_count }} / cooldown bypass {{ repair.strong_cooldown_bypass_count }}</p>
+  </section>
+
+  {% set load = session_load %}
+  <section class="card">
+    <h2>Same-day Load</h2>
+    <p>回答 {{ load.answered_count }} / 正答率 {{ load.accuracy_percent if load.accuracy_percent is not none else '—' }}% / unique Q {{ load.unique_question_count }} / repeat {{ load.repeat_attempt_count }}</p>
+    <p>初回正答率 {{ load.first_attempt_accuracy_percent if load.first_attempt_accuracy_percent is not none else '—' }}% / repeat正答率 {{ load.repeat_accuracy_percent if load.repeat_accuracy_percent is not none else '—' }}% / 誤答後repeat正答率 {{ load.repeat_after_wrong_accuracy_percent if load.repeat_after_wrong_accuracy_percent is not none else '—' }}%</p>
+    <p>最大回答間隔 {{ load.max_inter_attempt_gap_minutes if load.max_inter_attempt_gap_minutes is not none else '—' }}分 / 先頭→末尾の50問ブロック差 {{ load.leading_to_trailing_full_block_accuracy_delta_pp if load.leading_to_trailing_full_block_accuracy_delta_pp is not none else '—' }}pt</p>
+    <p class="muted">同日累積の観測値であり、疲労・連続学習・停止判断を自動判定しません。</p>
+  </section>
+
+  <section class="card">
+    <h2>Current formal state</h2>
+    <p>checking {{ diagnostics.state_counts.checking }} / repairing {{ diagnostics.state_counts.repairing }} / repaired {{ diagnostics.state_counts.repaired }} / recheck_due {{ diagnostics.state_counts.recheck_due }} / stable {{ diagnostics.state_counts.stable }}</p>
+    <p>recheck_due→stable {{ diagnostics.due_to_stable }} / recheck_due→repairing {{ diagnostics.due_to_repairing }}</p>
+  </section>
+</main>
+</body>
+</html>

--- a/tests/test_phase11_gate_ui.py
+++ b/tests/test_phase11_gate_ui.py
@@ -1,0 +1,109 @@
+import os
+from pathlib import Path
+
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
+os.environ.setdefault("CHANNEL_ACCESS_TOKEN", "test-token")
+os.environ.setdefault("CHANNEL_SECRET", "test-secret")
+
+from flask import Flask
+
+import phase11_gate_ui
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _app():
+    app = Flask(
+        "phase11-gate-ui-test",
+        template_folder=str(ROOT / "templates"),
+    )
+    phase11_gate_ui.install_phase11_gate_ui(app)
+    return app
+
+
+def test_gate_page_requires_internal_admin_token(monkeypatch):
+    monkeypatch.setenv("LT_INTERNAL_ADMIN_TOKEN", "admin-secret")
+    client = _app().test_client()
+    assert client.get("/internal/phase11-gates?learner_user_id=learner").status_code == 403
+    assert client.get("/internal/phase11-gates?token=wrong&learner_user_id=learner").status_code == 403
+
+
+def test_gate_page_renders_hold_retention_and_no_auto_promotion(monkeypatch):
+    monkeypatch.setenv("LT_INTERNAL_ADMIN_TOKEN", "admin-secret")
+    monkeypatch.setattr(
+        phase11_gate_ui,
+        "build_phase11_gate_dashboard",
+        lambda learner_id, period: {
+            "period": period,
+            "diagnostics": {
+                "state_counts": {"checking": 2, "repairing": 3, "repaired": 1, "recheck_due": 0, "stable": 0},
+                "due_to_stable": 0,
+                "due_to_repairing": 0,
+            },
+            "session_load": {
+                "answered_count": 200,
+                "accuracy_percent": 74.5,
+                "unique_question_count": 148,
+                "repeat_attempt_count": 52,
+                "first_attempt_accuracy_percent": 70.3,
+                "repeat_accuracy_percent": 86.5,
+                "repeat_after_wrong_accuracy_percent": 54.5,
+                "max_inter_attempt_gap_minutes": 322.0,
+                "leading_to_trailing_full_block_accuracy_delta_pp": -10.0,
+            },
+            "repair_effectiveness": {
+                "adaptive_repair_attempt_count": 45,
+                "strong_attempt_count": 35,
+                "strong_correct_count": 26,
+                "strong_accuracy_percent": 74.3,
+                "formal_confirmation_candidate_count": 13,
+                "strong_wrong_count": 9,
+                "strong_recent_repeat_count": 0,
+                "strong_cooldown_bypass_count": 0,
+            },
+            "retention_horizon": {
+                "recheck_due_count": 0,
+                "due_within_24h_count": 0,
+                "due_within_3d_count": 4,
+                "due_within_7d_count": 13,
+                "upcoming_review_count": 13,
+                "earliest_review_at_jst": "2026-09-09T08:26:32+09:00",
+                "earliest_review_in_hours": 63.4,
+            },
+            "gate_status": {
+                "decision": "hold",
+                "blocked_gates": [],
+                "open_gates": ["retention", "comparison_diversity"],
+                "gates": {
+                    "safety": {"status": "pass"},
+                    "repeat_audit": {"status": "pass"},
+                    "formal_trigger_consistency": {"status": "pass"},
+                    "retention": {"status": "open"},
+                    "comparison_diversity": {"status": "open"},
+                    "profile_consistency": {"status": "pass"},
+                },
+            },
+        },
+    )
+    response = _app().test_client().get(
+        "/internal/phase11-gates?token=admin-secret&learner_user_id=learner&period=7"
+    )
+    assert response.status_code == 200
+    html = response.get_data(as_text=True)
+    assert "Phase11 Gate Status" in html
+    assert "HOLD" in html
+    assert "Retention Horizon" in html
+    assert "2026-09-09T08:26:32+09:00" in html
+    assert "自動昇格なし" in html
+    assert "learner-facing promotion allowed = false" in html
+    assert "誤答後repeat正答率 54.5%" in html
+    assert "STRONG＋自信あり正解候補 13" in html
+    assert "admin-secret" not in html
+
+
+def test_install_is_idempotent():
+    app = _app()
+    rules_before = len(list(app.url_map.iter_rules()))
+    phase11_gate_ui.install_phase11_gate_ui(app)
+    assert len(list(app.url_map.iter_rules())) == rules_before

--- a/wsgi.py
+++ b/wsgi.py
@@ -20,6 +20,7 @@ from linebot.models import (
     URIAction,
 )
 
+from phase11_gate_ui import install_phase11_gate_ui
 from prerequisite_attempt_cache import install_prerequisite_attempt_cache
 from site_marketing_hotfix import install_site_marketing_hotfix
 from site_marketing_refresh import install_site_marketing_refresh
@@ -92,6 +93,7 @@ legacy.create_home_message = create_home_message
 install_site_marketing_viewport_fix(legacy.app)
 install_site_marketing_hotfix(legacy.app)
 install_site_marketing_refresh(legacy.app)
+install_phase11_gate_ui(legacy.app)
 
 _apply_rich_menu_v2_if_requested()
 


### PR DESCRIPTION
## Summary
- add a dedicated internal-only `/internal/phase11-gates` dashboard
- show conservative Phase11 gate states, retention horizon, natural repair effectiveness, and same-day load evidence in one compact view
- keep the existing detailed `/internal/pilot-diagnostics` route unchanged
- register the dashboard only in the Production composition layer

## Safety boundary
- no learner-facing behavior change
- no J1-J7 / Phase10 selector / Safety / Recent Cooldown change
- no Node-state mutation
- no Question Bank change
- no DB write or migration
- automatic Phase11 promotion remains impossible

## Tests
- internal admin authentication required
- HOLD/open retention state rendered without exposing token
- natural-use-shaped 200-answer / STRONG repair facts render correctly
- installer is idempotent