### PR TITLE
Link Phase11 gate dashboard from internal console

### DIFF
--- a/templates/internal/index.html
+++ b/templates/internal/index.html
@@ -87,6 +87,7 @@
         {% if learner_id %}
         <p style="margin-bottom:0;">
           <a class="action" href="{{ pilot_url }}">学習診断 / Phase11・repeat・cooldown</a>
+          <a class="action" href="/internal/phase11-gates?token={{ internal_token|urlencode }}&learner_user_id={{ learner_id|urlencode }}">Phase11 Gate Status</a>
           <a class="action" href="{{ preview_url }}">本人画面プレビュー（開発QA）</a>
         </p>
         {% endif %}

--- a/tests/test_internal_developer_boundary.py
+++ b/tests/test_internal_developer_boundary.py
@@ -24,6 +24,8 @@ def test_internal_index_accepts_header_token(monkeypatch):
     assert response.status_code == 200
     text = response.get_data(as_text=True)
     assert "/internal/pilot-diagnostics" in text
+    assert "/internal/phase11-gates" in text
+    assert "Phase11 Gate Status" in text
     assert "/internal/learner-preview" in text
     assert "システム概要" in text
     assert "Question Bank" in text


### PR DESCRIPTION
## Summary
- add the new internal Phase11 Gate Status page to the existing learner-specific internal actions
- keep the existing detailed diagnostics and learner preview links unchanged
- use the already-authenticated internal token/learner context only for navigation

## Safety boundary
- internal-only navigation change
- no learner-facing behavior, selector, Safety, Question Bank, DB, or Phase11 policy change

## Tests
- internal console with a learner target exposes the Phase11 gate dashboard link