### PR TITLE
Audit natural Phase11 retention outcomes explicitly

### DIFF
--- a/developer_ui.py
+++ b/developer_ui.py
@@ -39,6 +39,10 @@ from phase11_retention_horizon_facts import (
     build_retention_horizon_evidence_line,
     build_retention_horizon_facts,
 )
+from phase11_retention_outcome_audit import (
+    build_retention_outcome_audit,
+    build_retention_outcome_evidence_line,
+)
 from phase11_session_load_facts import (
     build_same_day_session_load_evidence_line,
     build_same_day_session_load_facts,
@@ -240,10 +244,12 @@ def register_developer_routes(blueprint) -> None:
         retention_horizon = build_retention_horizon_facts(
             derive_all_user_node_states(attempts)
         )
+        retention_outcomes = build_retention_outcome_audit(attempts)
         promotion_gate_status = build_phase11_promotion_gate_status(
             retrospective_shadow_audit=diagnostics.get("retrospective_shadow_audit"),
             repeat_structure_audit=diagnostics.get("repeat_structure_audit"),
             retention_horizon=retention_horizon,
+            retention_outcome_audit=retention_outcomes,
             state_counts=diagnostics.get("state_counts"),
             transitions={
                 "recheck_due_to_stable": diagnostics.get("due_to_stable", 0),
@@ -254,6 +260,7 @@ def register_developer_routes(blueprint) -> None:
         diagnostics["same_day_session_load"] = same_day_session_load
         diagnostics["repair_effectiveness"] = repair_effectiveness
         diagnostics["retention_horizon"] = retention_horizon
+        diagnostics["retention_outcomes"] = retention_outcomes
         diagnostics["promotion_gate_status"] = promotion_gate_status
         diagnostics["promotion_evidence_text"] = (
             str(diagnostics.get("promotion_evidence_text") or "").rstrip()
@@ -263,6 +270,8 @@ def register_developer_routes(blueprint) -> None:
             + build_repair_effectiveness_evidence_line(repair_effectiveness)
             + "\n"
             + build_retention_horizon_evidence_line(retention_horizon)
+            + "\n"
+            + build_retention_outcome_evidence_line(retention_outcomes)
             + "\n"
             + build_phase11_promotion_gate_evidence_line(promotion_gate_status)
         ).lstrip("\n")

--- a/phase11_gate_ui.py
+++ b/phase11_gate_ui.py
@@ -14,6 +14,7 @@ from knowledge_node_state_transition import derive_all_user_node_states
 from phase11_promotion_gate_status import build_phase11_promotion_gate_status
 from phase11_repair_effectiveness_facts import build_same_day_repair_effectiveness_facts
 from phase11_retention_horizon_facts import build_retention_horizon_facts
+from phase11_retention_outcome_audit import build_retention_outcome_audit
 from phase11_session_load_facts import build_same_day_session_load_facts
 from pilot_diagnostics import build_pilot_diagnostics
 
@@ -32,10 +33,12 @@ def build_phase11_gate_dashboard(learner_id: str, period: str = "7") -> dict:
     retention_horizon = build_retention_horizon_facts(
         derive_all_user_node_states(attempts)
     )
+    retention_outcomes = build_retention_outcome_audit(attempts)
     gate_status = build_phase11_promotion_gate_status(
         retrospective_shadow_audit=diagnostics.get("retrospective_shadow_audit"),
         repeat_structure_audit=diagnostics.get("repeat_structure_audit"),
         retention_horizon=retention_horizon,
+        retention_outcome_audit=retention_outcomes,
         state_counts=diagnostics.get("state_counts"),
         transitions={
             "recheck_due_to_stable": diagnostics.get("due_to_stable", 0),
@@ -51,6 +54,7 @@ def build_phase11_gate_dashboard(learner_id: str, period: str = "7") -> dict:
             get_learning_events(learner_id)
         ),
         "retention_horizon": retention_horizon,
+        "retention_outcomes": retention_outcomes,
         "gate_status": gate_status,
     }
 

--- a/phase11_promotion_gate_status.py
+++ b/phase11_promotion_gate_status.py
@@ -28,6 +28,7 @@ def build_phase11_promotion_gate_status(
     state_counts: dict[str, Any] | None,
     transitions: dict[str, Any] | None,
     shadow_judgment: dict[str, Any] | None,
+    retention_outcome_audit: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Return deterministic gate states without inventing promotion thresholds."""
     replay = retrospective_shadow_audit or {}
@@ -36,6 +37,7 @@ def build_phase11_promotion_gate_status(
     retention = retention_horizon or {}
     states = state_counts or {}
     transition_counts = transitions or {}
+    outcomes = retention_outcome_audit
     shadow = shadow_judgment or {}
     comparison = shadow.get("comparison") or {}
 
@@ -53,8 +55,19 @@ def build_phase11_promotion_gate_status(
     stable_now = _int(states, "stable")
     due_to_stable = _int(transition_counts, "recheck_due_to_stable")
     due_to_repairing = _int(transition_counts, "recheck_due_to_repairing")
-    retention_observed = bool(due_now or stable_now or due_to_stable or due_to_repairing)
-    retention_status = PASS if (due_to_stable or due_to_repairing or stable_now) else OPEN
+    # New callers provide an explicit due-before-attempt outcome audit.  This is
+    # authoritative for whether a natural spaced review was actually observed,
+    # because prefix timelines can jump repaired -> stable on the review attempt.
+    if outcomes is not None:
+        retention_review_count = _int(outcomes, "review_attempt_count")
+        retention_observed = retention_review_count > 0
+        retention_status = PASS if retention_observed else OPEN
+    else:
+        # Backward-compatible fallback for callers not yet wired to the explicit
+        # retention outcome audit.
+        retention_review_count = 0
+        retention_observed = bool(due_now or stable_now or due_to_stable or due_to_repairing)
+        retention_status = PASS if (due_to_stable or due_to_repairing or stable_now) else OPEN
 
     eligible = _int(replay, "eligible_snapshot_count")
     shadow_stronger = _int(replay, "shadow_stronger_disagreement_count")
@@ -88,6 +101,10 @@ def build_phase11_promotion_gate_status(
         "retention": {
             "status": retention_status,
             "natural_retention_observed": retention_observed,
+            "review_attempt_count": retention_review_count,
+            "review_stable_count": _int(outcomes, "stable_count") if outcomes is not None else 0,
+            "review_repairing_count": _int(outcomes, "repairing_count") if outcomes is not None else 0,
+            "review_still_due_count": _int(outcomes, "still_due_count") if outcomes is not None else 0,
             "recheck_due_count": due_now,
             "stable_count": stable_now,
             "recheck_due_to_stable": due_to_stable,

--- a/phase11_retention_outcome_audit.py
+++ b/phase11_retention_outcome_audit.py
@@ -1,0 +1,162 @@
+"""Read-only audit of naturally occurring spaced-retention review attempts.
+
+The core state machine can move ``repaired -> recheck_due -> stable`` while
+processing one attempt.  A prefix-only state timeline therefore may not expose
+``recheck_due`` as an adjacent persisted state.  This audit asks the formal state
+machine for the state immediately *before* each real attempt at that attempt's
+timestamp, then processes the attempt and records the outcome.
+
+No timestamps, attempts, Node states, selectors, or learner-facing decisions are
+mutated here.
+"""
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from datetime import datetime, timezone
+from typing import Any, Iterable
+from zoneinfo import ZoneInfo
+
+from knowledge_node_canonical import canonicalize_knowledge_node_id
+from knowledge_node_repair_evidence import classify_repair_confirmation
+from knowledge_node_state_transition import derive_knowledge_node_state
+
+
+TOKYO = ZoneInfo("Asia/Tokyo")
+
+
+def _as_datetime(value: Any) -> datetime | None:
+    if isinstance(value, datetime):
+        parsed = value
+    elif value:
+        try:
+            parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+        except (TypeError, ValueError):
+            return None
+    else:
+        return None
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+
+
+def _sort_key(item: dict[str, Any]) -> tuple:
+    return (
+        _as_datetime(item.get("attempted_at") or item.get("answered_at"))
+        or datetime.min.replace(tzinfo=timezone.utc),
+        str(item.get("event_key") or ""),
+        int(item.get("attempt_position") or 0),
+        int(item.get("id") or 0),
+    )
+
+
+def build_retention_outcome_audit(
+    attempts: Iterable[dict[str, Any]],
+) -> dict[str, Any]:
+    """Find real attempts that occurred after a formal retention review became due."""
+    grouped: dict[tuple[str, str], list[dict[str, Any]]] = defaultdict(list)
+    for source in attempts or ():
+        item = dict(source)
+        node_id = canonicalize_knowledge_node_id(
+            str(item.get("knowledge_node_id") or "")
+        )
+        if not node_id:
+            continue
+        grouped[(str(item.get("user_id") or ""), node_id)].append(item)
+
+    reviews: list[dict[str, Any]] = []
+    for (_user_id, node_id), raw_history in sorted(grouped.items()):
+        history = sorted(raw_history, key=_sort_key)
+        prior: list[dict[str, Any]] = []
+        for attempt in history:
+            attempted_at = _as_datetime(
+                attempt.get("attempted_at") or attempt.get("answered_at")
+            )
+            if not attempted_at:
+                prior.append(attempt)
+                continue
+            if not prior:
+                prior.append(attempt)
+                continue
+
+            before = derive_knowledge_node_state(
+                prior,
+                canonical_node_id=node_id,
+                as_of=attempted_at,
+            )
+            if before.get("state") != "recheck_due":
+                prior.append(attempt)
+                continue
+
+            reference_q = str(before.get("retention_reference_question_id") or "")
+            question_id = str(attempt.get("question_id") or "")
+            evidence_quality = classify_repair_confirmation(reference_q, question_id)
+            after = derive_knowledge_node_state(
+                prior + [attempt],
+                canonical_node_id=node_id,
+                as_of=attempted_at,
+            )
+            after_state = str(after.get("state") or "")
+            outcome = {
+                "stable": "stable",
+                "repairing": "repairing",
+                "recheck_due": "still_due",
+            }.get(after_state, after_state or "unknown")
+            due_at = _as_datetime(before.get("next_review_at"))
+            reviews.append({
+                "canonical_node_id": node_id,
+                "question_id": question_id,
+                "retention_reference_question_id": reference_q or None,
+                "review_attempted_at_jst": attempted_at.astimezone(TOKYO).isoformat(),
+                "due_at_jst": due_at.astimezone(TOKYO).isoformat() if due_at else None,
+                "hours_after_due": (
+                    round((attempted_at - due_at).total_seconds() / 3600.0, 1)
+                    if due_at else None
+                ),
+                "outcome": outcome,
+                "post_state": after_state,
+                "evidence_quality": evidence_quality,
+                "confidence": attempt.get("confidence"),
+                "is_correct": attempt.get("is_correct") is True,
+                "answer_status": str(attempt.get("answer_status") or "answered"),
+            })
+            prior.append(attempt)
+
+    outcome_counts = Counter(item["outcome"] for item in reviews)
+    evidence_counts = Counter(item["evidence_quality"] for item in reviews)
+    return {
+        "review_attempt_count": len(reviews),
+        "stable_count": outcome_counts["stable"],
+        "repairing_count": outcome_counts["repairing"],
+        "still_due_count": outcome_counts["still_due"],
+        "other_outcome_count": len(reviews)
+        - outcome_counts["stable"]
+        - outcome_counts["repairing"]
+        - outcome_counts["still_due"],
+        "strong_evidence_count": evidence_counts["different_question_strong"],
+        "weak_evidence_count": evidence_counts["different_question_weak"],
+        "same_question_count": evidence_counts["same_question"],
+        "confident_correct_count": sum(
+            item["is_correct"] and item.get("confidence") == 1 for item in reviews
+        ),
+        "reviews": reviews,
+        "diagnostic_only": True,
+        "policy_note": (
+            "These are naturally occurring formal retention-review attempts. "
+            "The audit does not create due states or authorize Phase11 promotion."
+        ),
+    }
+
+
+def build_retention_outcome_evidence_line(audit: dict[str, Any] | None) -> str:
+    """Serialize aggregate, non-identifying retention outcome evidence."""
+    source = audit or {}
+    return "retention_outcomes=" + ",".join([
+        f"reviews:{int(source.get('review_attempt_count') or 0)}",
+        f"stable:{int(source.get('stable_count') or 0)}",
+        f"repairing:{int(source.get('repairing_count') or 0)}",
+        f"still_due:{int(source.get('still_due_count') or 0)}",
+        f"other:{int(source.get('other_outcome_count') or 0)}",
+        f"strong:{int(source.get('strong_evidence_count') or 0)}",
+        f"weak:{int(source.get('weak_evidence_count') or 0)}",
+        f"same_q:{int(source.get('same_question_count') or 0)}",
+        f"confident_correct:{int(source.get('confident_correct_count') or 0)}",
+    ])

--- a/templates/internal/phase11_gates.html
+++ b/templates/internal/phase11_gates.html
@@ -65,6 +65,14 @@
     <p>Upcoming {{ retention.upcoming_review_count }} / 最短 {{ retention.earliest_review_at_jst or 'なし' }}{% if retention.earliest_review_in_hours is not none %}（約{{ retention.earliest_review_in_hours }}時間後）{% endif %}</p>
   </section>
 
+  {% set outcomes = retention_outcomes %}
+  <section class="card">
+    <h2>Natural Retention Outcomes</h2>
+    <p>自然なretention review {{ outcomes.review_attempt_count }} / stable {{ outcomes.stable_count }} / repairing {{ outcomes.repairing_count }} / still due {{ outcomes.still_due_count }}</p>
+    <p>STRONG {{ outcomes.strong_evidence_count }} / weak {{ outcomes.weak_evidence_count }} / same-Q {{ outcomes.same_question_count }} / 自信あり正解 {{ outcomes.confident_correct_count }}</p>
+    <p class="muted">各実回答の直前時点で formal state が recheck_due だったかを再生して数えます。repaired→stable が1回答内で起きても取りこぼしません。</p>
+  </section>
+
   {% set repair = repair_effectiveness %}
   <section class="card">
     <h2>Natural Repair Effectiveness</h2>
@@ -84,7 +92,7 @@
   <section class="card">
     <h2>Current formal state</h2>
     <p>checking {{ diagnostics.state_counts.checking }} / repairing {{ diagnostics.state_counts.repairing }} / repaired {{ diagnostics.state_counts.repaired }} / recheck_due {{ diagnostics.state_counts.recheck_due }} / stable {{ diagnostics.state_counts.stable }}</p>
-    <p>recheck_due→stable {{ diagnostics.due_to_stable }} / recheck_due→repairing {{ diagnostics.due_to_repairing }}</p>
+    <p>legacy timeline counter: recheck_due→stable {{ diagnostics.due_to_stable }} / recheck_due→repairing {{ diagnostics.due_to_repairing }}</p>
   </section>
 </main>
 </body>

--- a/tests/test_phase11_gate_ui.py
+++ b/tests/test_phase11_gate_ui.py
@@ -71,6 +71,16 @@ def test_gate_page_renders_hold_retention_and_no_auto_promotion(monkeypatch):
                 "earliest_review_at_jst": "2026-09-09T08:26:32+09:00",
                 "earliest_review_in_hours": 63.4,
             },
+            "retention_outcomes": {
+                "review_attempt_count": 0,
+                "stable_count": 0,
+                "repairing_count": 0,
+                "still_due_count": 0,
+                "strong_evidence_count": 0,
+                "weak_evidence_count": 0,
+                "same_question_count": 0,
+                "confident_correct_count": 0,
+            },
             "gate_status": {
                 "decision": "hold",
                 "blocked_gates": [],
@@ -94,6 +104,8 @@ def test_gate_page_renders_hold_retention_and_no_auto_promotion(monkeypatch):
     assert "Phase11 Gate Status" in html
     assert "HOLD" in html
     assert "Retention Horizon" in html
+    assert "Natural Retention Outcomes" in html
+    assert "自然なretention review 0" in html
     assert "2026-09-09T08:26:32+09:00" in html
     assert "自動昇格なし" in html
     assert "learner-facing promotion allowed = false" in html

--- a/tests/test_phase11_promotion_gate_status.py
+++ b/tests/test_phase11_promotion_gate_status.py
@@ -43,7 +43,7 @@ def _status(**overrides):
 
 
 def test_current_natural_shape_stays_hold_with_retention_and_diversity_open():
-    result = _status()
+    result = _status(retention_outcome_audit={"review_attempt_count": 0})
     assert result["decision"] == "hold"
     assert result["learner_facing_promotion_allowed"] is False
     assert result["manual_review_required"] is True
@@ -70,6 +70,7 @@ def test_safety_repeat_or_trigger_regression_blocks_without_enabling_promotion()
                 "adaptive_metadata_inconsistent": 1,
             }
         },
+        retention_outcome_audit={"review_attempt_count": 0},
     )
     assert result["decision"] == "blocked"
     assert result["gates"]["safety"]["status"] == BLOCKED
@@ -78,7 +79,7 @@ def test_safety_repeat_or_trigger_regression_blocks_without_enabling_promotion()
     assert result["learner_facing_promotion_allowed"] is False
 
 
-def test_retention_outcome_and_direction_diversity_can_clear_checkable_gates_only():
+def test_explicit_retention_outcome_and_direction_diversity_clear_checkable_gates_only():
     result = _status(
         retrospective_shadow_audit={
             "eligible_snapshot_count": 4,
@@ -90,13 +91,21 @@ def test_retention_outcome_and_direction_diversity_can_clear_checkable_gates_onl
             "ordinary_single_wrong_takeover_candidate_count": 0,
         },
         retention_horizon={"recheck_due_count": 0, "upcoming_review_count": 8},
+        retention_outcome_audit={
+            "review_attempt_count": 1,
+            "stable_count": 1,
+            "repairing_count": 0,
+            "still_due_count": 0,
+        },
         state_counts={"stable": 1},
         transitions={
-            "recheck_due_to_stable": 1,
+            "recheck_due_to_stable": 0,
             "recheck_due_to_repairing": 0,
         },
     )
     assert result["gates"]["retention"]["status"] == PASS
+    assert result["gates"]["retention"]["review_attempt_count"] == 1
+    assert result["gates"]["retention"]["review_stable_count"] == 1
     assert result["gates"]["comparison_diversity"]["status"] == PASS
     assert result["automatically_clear"] is True
     assert result["decision"] == "hold"
@@ -104,8 +113,21 @@ def test_retention_outcome_and_direction_diversity_can_clear_checkable_gates_onl
     assert result["manual_review_required"] is True
 
 
+def test_explicit_zero_review_does_not_use_legacy_stable_or_timeline_as_false_pass():
+    result = _status(
+        retention_outcome_audit={"review_attempt_count": 0},
+        state_counts={"stable": 5},
+        transitions={
+            "recheck_due_to_stable": 4,
+            "recheck_due_to_repairing": 2,
+        },
+    )
+    assert result["gates"]["retention"]["status"] == OPEN
+    assert result["gates"]["retention"]["natural_retention_observed"] is False
+
+
 def test_evidence_line_is_non_identifying_and_never_says_promotion_allowed_true():
-    result = _status()
+    result = _status(retention_outcome_audit={"review_attempt_count": 0})
     result["user_id"] = "must-not-leak"
     result["token"] = "must-not-leak"
     line = build_phase11_promotion_gate_evidence_line(result)

--- a/tests/test_phase11_retention_outcome_audit.py
+++ b/tests/test_phase11_retention_outcome_audit.py
@@ -1,0 +1,113 @@
+from datetime import datetime, timedelta, timezone
+
+import knowledge_node_state_transition as transition
+import phase11_retention_outcome_audit as audit
+from knowledge_node_repair_evidence import (
+    DIFFERENT_QUESTION_STRONG,
+    DIFFERENT_QUESTION_WEAK,
+    SAME_QUESTION,
+)
+
+
+BASE = datetime(2026, 9, 1, tzinfo=timezone.utc)
+
+
+def attempt(q, *, correct, confidence, day, minute=0, unknown=False):
+    return {
+        "id": day * 100 + minute + 1,
+        "event_key": f"e-{day}-{minute}-{q}",
+        "user_id": "learner",
+        "question_id": q,
+        "knowledge_node_id": "KN0001",
+        "selected_answers": [] if unknown else ["1"],
+        "answer_status": "unknown" if unknown else "answered",
+        "is_correct": correct,
+        "confidence": confidence,
+        "answered_at": BASE + timedelta(days=day, minutes=minute),
+        "attempt_position": 1,
+    }
+
+
+def classifier(strong_pairs):
+    strong_pairs = set(strong_pairs)
+
+    def classify(old, new):
+        if old == new:
+            return SAME_QUESTION
+        return DIFFERENT_QUESTION_STRONG if (old, new) in strong_pairs else DIFFERENT_QUESTION_WEAK
+
+    return classify
+
+
+def install_classifier(monkeypatch, strong_pairs):
+    classify = classifier(strong_pairs)
+    monkeypatch.setattr(transition, "classify_repair_confirmation", classify)
+    monkeypatch.setattr(audit, "classify_repair_confirmation", classify)
+
+
+def repaired_history():
+    return [
+        attempt("Q1", correct=False, confidence=2, day=0),
+        attempt("Q2", correct=True, confidence=1, day=1),
+    ]
+
+
+def test_captures_hidden_repaired_to_due_to_stable_review(monkeypatch):
+    install_classifier(monkeypatch, {("Q1", "Q2"), ("Q2", "Q3")})
+    history = repaired_history() + [attempt("Q3", correct=True, confidence=1, day=8)]
+
+    # Prefix timeline jumps directly repaired -> stable; the audit must still
+    # recover the due-before-attempt retention event.
+    assert [item["state"] for item in transition.derive_state_timeline(history)] == [
+        "repairing", "repaired", "stable"
+    ]
+    result = audit.build_retention_outcome_audit(history)
+    assert result["review_attempt_count"] == 1
+    assert result["stable_count"] == 1
+    assert result["strong_evidence_count"] == 1
+    review = result["reviews"][0]
+    assert review["outcome"] == "stable"
+    assert review["retention_reference_question_id"] == "Q2"
+    assert review["question_id"] == "Q3"
+    assert review["hours_after_due"] == 0.0
+
+
+def test_due_wrong_is_recorded_as_repairing(monkeypatch):
+    install_classifier(monkeypatch, {("Q1", "Q2")})
+    result = audit.build_retention_outcome_audit(
+        repaired_history() + [attempt("Q3", correct=False, confidence=2, day=8)]
+    )
+    assert result["review_attempt_count"] == 1
+    assert result["repairing_count"] == 1
+    assert result["reviews"][0]["outcome"] == "repairing"
+
+
+def test_due_weak_correct_remains_due(monkeypatch):
+    install_classifier(monkeypatch, {("Q1", "Q2")})
+    result = audit.build_retention_outcome_audit(
+        repaired_history() + [attempt("Q3", correct=True, confidence=1, day=8)]
+    )
+    assert result["review_attempt_count"] == 1
+    assert result["still_due_count"] == 1
+    assert result["weak_evidence_count"] == 1
+
+
+def test_before_due_attempt_is_not_retention_review(monkeypatch):
+    install_classifier(monkeypatch, {("Q1", "Q2"), ("Q2", "Q3")})
+    result = audit.build_retention_outcome_audit(
+        repaired_history() + [attempt("Q3", correct=True, confidence=1, day=7)]
+    )
+    assert result["review_attempt_count"] == 0
+
+
+def test_evidence_line_excludes_identity_and_question_ids(monkeypatch):
+    install_classifier(monkeypatch, {("Q1", "Q2"), ("Q2", "Q3")})
+    result = audit.build_retention_outcome_audit(
+        repaired_history() + [attempt("Q3", correct=True, confidence=1, day=8)]
+    )
+    result["user_id"] = "must-not-leak"
+    line = audit.build_retention_outcome_evidence_line(result)
+    assert line.startswith("retention_outcomes=reviews:1,stable:1")
+    assert "must-not-leak" not in line
+    assert "learner" not in line
+    assert "Q1" not in line and "Q2" not in line and "Q3" not in line


### PR DESCRIPTION
## Summary
- add a read-only audit that detects real retention-review attempts from the formal state immediately before each persisted attempt
- capture `repaired -> recheck_due -> stable` reviews that prefix-only timelines can otherwise appear to skip
- classify retention outcomes as stable / repairing / still_due with strong/weak/same-Q evidence
- wire explicit retention outcomes into Phase11 gate status, detailed evidence bundle, and internal gate dashboard

## Correctness boundary
- the core Knowledge Node state machine is unchanged
- no timestamps or learner history are mutated
- no J1-J7 / Phase10 selector / Safety / Recent Cooldown change
- no Question Bank change
- no DB write or migration
- learner-facing promotion remains impossible automatically

## Tests
- catches the hidden due-before-attempt transition when a review immediately becomes stable
- records due wrong as repairing and due weak-correct as still_due
- excludes attempts before due time
- aggregate evidence line excludes identity/question IDs
- explicit zero-review audit cannot be falsely cleared by legacy timeline counters