### PR TITLE
Audit Phase11 retention STRONG supply before J4 due

### DIFF
--- a/phase11_gate_ui.py
+++ b/phase11_gate_ui.py
@@ -15,6 +15,7 @@ from phase11_promotion_gate_status import build_phase11_promotion_gate_status
 from phase11_repair_effectiveness_facts import build_same_day_repair_effectiveness_facts
 from phase11_retention_horizon_facts import build_retention_horizon_facts
 from phase11_retention_outcome_audit import build_retention_outcome_audit
+from phase11_retention_supply_audit import build_retention_supply_audit
 from phase11_session_load_facts import build_same_day_session_load_facts
 from pilot_diagnostics import build_pilot_diagnostics
 
@@ -30,10 +31,10 @@ def build_phase11_gate_dashboard(learner_id: str, period: str = "7") -> dict:
 
     diagnostics = build_pilot_diagnostics(learner_id, period)
     attempts = get_question_attempts(learner_id)
-    retention_horizon = build_retention_horizon_facts(
-        derive_all_user_node_states(attempts)
-    )
+    node_states = derive_all_user_node_states(attempts)
+    retention_horizon = build_retention_horizon_facts(node_states)
     retention_outcomes = build_retention_outcome_audit(attempts)
+    retention_supply = build_retention_supply_audit(node_states)
     gate_status = build_phase11_promotion_gate_status(
         retrospective_shadow_audit=diagnostics.get("retrospective_shadow_audit"),
         repeat_structure_audit=diagnostics.get("repeat_structure_audit"),
@@ -55,6 +56,7 @@ def build_phase11_gate_dashboard(learner_id: str, period: str = "7") -> dict:
         ),
         "retention_horizon": retention_horizon,
         "retention_outcomes": retention_outcomes,
+        "retention_supply": retention_supply,
         "gate_status": gate_status,
     }
 

--- a/phase11_retention_supply_audit.py
+++ b/phase11_retention_supply_audit.py
@@ -1,0 +1,127 @@
+"""Read-only audit of formal alternate-question supply for retention reviews.
+
+The retention policy requires a STRONG different-question check to move a due
+Node to ``stable``.  This module inspects current formal Node states against the
+existing Question Bank repairability registry so missing retention supply can be
+seen *before* a natural review becomes due.
+
+It never changes Node state, selection, cooldown, Question Bank data, or learner-
+facing recommendations.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+from knowledge_node_repair_evidence import (
+    DIFFERENT_QUESTION_STRONG,
+    DIFFERENT_QUESTION_WEAK,
+    classify_repair_confirmation,
+)
+from knowledge_node_repairability import build_repairability_audit
+
+
+STRONG_AVAILABLE = "strong_available"
+WEAK_ONLY = "weak_only"
+NO_ALTERNATE = "no_formal_alternate"
+
+
+def build_retention_supply_audit(
+    node_states: Iterable[dict[str, Any]],
+    *,
+    repairability_records: Iterable[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Classify retention-question supply for repaired/recheck_due Nodes."""
+    registry = {
+        str(item.get("canonical_node_id") or ""): dict(item)
+        for item in (
+            repairability_records
+            if repairability_records is not None
+            else build_repairability_audit()
+        )
+    }
+
+    details: list[dict[str, Any]] = []
+    for raw in node_states or ():
+        state = str(raw.get("state") or "")
+        if state not in {"repaired", "recheck_due", "stable"}:
+            continue
+        reference_q = str(raw.get("retention_reference_question_id") or "")
+        if not reference_q:
+            continue
+        node_id = str(raw.get("canonical_node_id") or "")
+        static = registry.get(node_id, {})
+        question_ids = [str(value) for value in static.get("question_ids", []) if value]
+
+        strong: list[str] = []
+        weak: list[str] = []
+        for candidate in question_ids:
+            if candidate == reference_q:
+                continue
+            quality = classify_repair_confirmation(reference_q, candidate)
+            if quality == DIFFERENT_QUESTION_STRONG:
+                strong.append(candidate)
+            elif quality == DIFFERENT_QUESTION_WEAK:
+                weak.append(candidate)
+
+        if strong:
+            classification = STRONG_AVAILABLE
+        elif weak:
+            classification = WEAK_ONLY
+        else:
+            classification = NO_ALTERNATE
+
+        details.append({
+            "canonical_node_id": node_id,
+            "state": state,
+            "retention_reference_question_id": reference_q,
+            "next_review_at": raw.get("next_review_at"),
+            "classification": classification,
+            "strong_candidate_question_ids": sorted(strong),
+            "weak_candidate_question_ids": sorted(weak),
+            "strong_candidate_count": len(strong),
+            "weak_candidate_count": len(weak),
+        })
+
+    due = [item for item in details if item["state"] == "recheck_due"]
+    upcoming = [item for item in details if item["state"] == "repaired"]
+    stable = [item for item in details if item["state"] == "stable"]
+
+    def count(items: list[dict[str, Any]], classification: str) -> int:
+        return sum(item["classification"] == classification for item in items)
+
+    return {
+        "retention_node_count": len(details),
+        "due_node_count": len(due),
+        "upcoming_repaired_node_count": len(upcoming),
+        "stable_node_count": len(stable),
+        "strong_available_count": count(details, STRONG_AVAILABLE),
+        "weak_only_count": count(details, WEAK_ONLY),
+        "no_formal_alternate_count": count(details, NO_ALTERNATE),
+        "due_strong_available_count": count(due, STRONG_AVAILABLE),
+        "due_without_strong_count": len(due) - count(due, STRONG_AVAILABLE),
+        "upcoming_without_strong_count": len(upcoming) - count(upcoming, STRONG_AVAILABLE),
+        "all_due_have_strong_supply": bool(due) and all(
+            item["classification"] == STRONG_AVAILABLE for item in due
+        ),
+        "details": details,
+        "diagnostic_only": True,
+        "policy_note": (
+            "STRONG supply availability is a preflight diagnostic only. Exact-Q selection "
+            "remains owned by Phase10 and still must obey Safety and Recent Cooldown."
+        ),
+    }
+
+
+def build_retention_supply_evidence_line(audit: dict[str, Any] | None) -> str:
+    source = audit or {}
+    return "retention_supply=" + ",".join([
+        f"nodes:{int(source.get('retention_node_count') or 0)}",
+        f"due:{int(source.get('due_node_count') or 0)}",
+        f"due_strong:{int(source.get('due_strong_available_count') or 0)}",
+        f"due_without_strong:{int(source.get('due_without_strong_count') or 0)}",
+        f"upcoming:{int(source.get('upcoming_repaired_node_count') or 0)}",
+        f"upcoming_without_strong:{int(source.get('upcoming_without_strong_count') or 0)}",
+        f"weak_only:{int(source.get('weak_only_count') or 0)}",
+        f"no_alt:{int(source.get('no_formal_alternate_count') or 0)}",
+    ])

--- a/templates/internal/phase11_gates.html
+++ b/templates/internal/phase11_gates.html
@@ -65,6 +65,14 @@
     <p>Upcoming {{ retention.upcoming_review_count }} / 最短 {{ retention.earliest_review_at_jst or 'なし' }}{% if retention.earliest_review_in_hours is not none %}（約{{ retention.earliest_review_in_hours }}時間後）{% endif %}</p>
   </section>
 
+  {% set supply = retention_supply %}
+  <section class="card">
+    <h2>Retention STRONG Supply Preflight</h2>
+    <p>due {{ supply.due_node_count }} / dueでSTRONGあり {{ supply.due_strong_available_count }} / dueでSTRONGなし {{ supply.due_without_strong_count }}</p>
+    <p>upcoming repaired {{ supply.upcoming_repaired_node_count }} / upcomingでSTRONGなし {{ supply.upcoming_without_strong_count }} / weak-only {{ supply.weak_only_count }} / formal alternateなし {{ supply.no_formal_alternate_count }}</p>
+    <p class="muted">J4が自然発生する前に、retention referenceと別のSTRONG問題が存在するかだけを先行監査します。実際のQ選択はPhase10、Safety・Recent Cooldownの制約は従来どおりです。</p>
+  </section>
+
   {% set outcomes = retention_outcomes %}
   <section class="card">
     <h2>Natural Retention Outcomes</h2>

--- a/tests/test_phase11_gate_ui.py
+++ b/tests/test_phase11_gate_ui.py
@@ -71,6 +71,15 @@ def test_gate_page_renders_hold_retention_and_no_auto_promotion(monkeypatch):
                 "earliest_review_at_jst": "2026-09-09T08:26:32+09:00",
                 "earliest_review_in_hours": 63.4,
             },
+            "retention_supply": {
+                "due_node_count": 0,
+                "due_strong_available_count": 0,
+                "due_without_strong_count": 0,
+                "upcoming_repaired_node_count": 13,
+                "upcoming_without_strong_count": 2,
+                "weak_only_count": 1,
+                "no_formal_alternate_count": 1,
+            },
             "retention_outcomes": {
                 "review_attempt_count": 0,
                 "stable_count": 0,
@@ -104,6 +113,8 @@ def test_gate_page_renders_hold_retention_and_no_auto_promotion(monkeypatch):
     assert "Phase11 Gate Status" in html
     assert "HOLD" in html
     assert "Retention Horizon" in html
+    assert "Retention STRONG Supply Preflight" in html
+    assert "upcomingでSTRONGなし 2" in html
     assert "Natural Retention Outcomes" in html
     assert "自然なretention review 0" in html
     assert "2026-09-09T08:26:32+09:00" in html

--- a/tests/test_phase11_retention_supply_audit.py
+++ b/tests/test_phase11_retention_supply_audit.py
@@ -1,0 +1,102 @@
+from phase11_retention_supply_audit import (
+    NO_ALTERNATE,
+    STRONG_AVAILABLE,
+    WEAK_ONLY,
+    build_retention_supply_audit,
+    build_retention_supply_evidence_line,
+)
+
+
+def registry():
+    return [
+        {"canonical_node_id": "KN1", "question_ids": ["Q1", "Q2"]},
+        {"canonical_node_id": "KN2", "question_ids": ["Q3", "Q4"]},
+        {"canonical_node_id": "KN3", "question_ids": ["Q5"]},
+    ]
+
+
+def states():
+    return [
+        {
+            "canonical_node_id": "KN1",
+            "state": "recheck_due",
+            "retention_reference_question_id": "Q1",
+            "next_review_at": "2026-09-09T00:00:00+00:00",
+        },
+        {
+            "canonical_node_id": "KN2",
+            "state": "repaired",
+            "retention_reference_question_id": "Q3",
+            "next_review_at": "2026-09-13T00:00:00+00:00",
+        },
+        {
+            "canonical_node_id": "KN3",
+            "state": "stable",
+            "retention_reference_question_id": "Q5",
+            "next_review_at": "2026-10-01T00:00:00+00:00",
+        },
+        {"canonical_node_id": "KNX", "state": "repairing"},
+    ]
+
+
+def test_classifies_strong_weak_and_missing_supply(monkeypatch):
+    def classify(old, new):
+        if (old, new) == ("Q1", "Q2"):
+            return "different_question_strong"
+        if (old, new) == ("Q3", "Q4"):
+            return "different_question_weak"
+        return "same_question"
+
+    monkeypatch.setattr(
+        "phase11_retention_supply_audit.classify_repair_confirmation", classify
+    )
+    result = build_retention_supply_audit(states(), repairability_records=registry())
+    by_node = {item["canonical_node_id"]: item for item in result["details"]}
+
+    assert by_node["KN1"]["classification"] == STRONG_AVAILABLE
+    assert by_node["KN2"]["classification"] == WEAK_ONLY
+    assert by_node["KN3"]["classification"] == NO_ALTERNATE
+    assert result["due_node_count"] == 1
+    assert result["due_strong_available_count"] == 1
+    assert result["due_without_strong_count"] == 0
+    assert result["upcoming_without_strong_count"] == 1
+    assert result["all_due_have_strong_supply"] is True
+
+
+def test_due_without_strong_is_visible_and_not_falsely_clear(monkeypatch):
+    monkeypatch.setattr(
+        "phase11_retention_supply_audit.classify_repair_confirmation",
+        lambda old, new: "different_question_weak",
+    )
+    result = build_retention_supply_audit(
+        [states()[0]], repairability_records=registry()
+    )
+    assert result["due_node_count"] == 1
+    assert result["due_without_strong_count"] == 1
+    assert result["all_due_have_strong_supply"] is False
+
+
+def test_no_due_nodes_does_not_claim_all_due_supply_is_verified(monkeypatch):
+    monkeypatch.setattr(
+        "phase11_retention_supply_audit.classify_repair_confirmation",
+        lambda old, new: "different_question_strong",
+    )
+    result = build_retention_supply_audit(
+        [states()[1]], repairability_records=registry()
+    )
+    assert result["due_node_count"] == 0
+    assert result["all_due_have_strong_supply"] is False
+
+
+def test_evidence_line_is_aggregate_only(monkeypatch):
+    monkeypatch.setattr(
+        "phase11_retention_supply_audit.classify_repair_confirmation",
+        lambda old, new: "different_question_strong",
+    )
+    result = build_retention_supply_audit(
+        [states()[0]], repairability_records=registry()
+    )
+    line = build_retention_supply_evidence_line(result)
+    assert line.startswith("retention_supply=nodes:1,due:1,due_strong:1")
+    assert "KN1" not in line
+    assert "Q1" not in line


### PR DESCRIPTION
## Summary
- add a read-only preflight audit for STRONG different-question supply on repaired/recheck_due/stable Nodes
- surface due/upcoming Nodes that lack formal STRONG retention alternatives before natural J4 review time
- show aggregate supply counts on the internal Phase11 gate dashboard

## Safety boundary
- diagnostic-only
- no Node-state mutation
- no selector/ranking/Safety/Recent Cooldown change
- no Question Bank change
- no DB write or migration
- no learner-facing recommendation change

## Why now
The first natural J4 window is forecast around 2026-09-09 JST. This preflight lets us find supply problems before that natural review arrives without manufacturing any learner data.