### PR TITLE
Add cooldown-aware J4 retention supply preflight

### DIFF
--- a/developer_ui.py
+++ b/developer_ui.py
@@ -43,6 +43,10 @@ from phase11_retention_outcome_audit import (
     build_retention_outcome_audit,
     build_retention_outcome_evidence_line,
 )
+from phase11_retention_supply_audit import (
+    build_retention_supply_audit,
+    build_retention_supply_evidence_line,
+)
 from phase11_session_load_facts import (
     build_same_day_session_load_evidence_line,
     build_same_day_session_load_facts,
@@ -237,14 +241,14 @@ def register_developer_routes(blueprint) -> None:
             period = "7"
         diagnostics = build_pilot_diagnostics(learner_id, period)
         attempts = get_question_attempts(learner_id)
+        node_states = derive_all_user_node_states(attempts)
         same_day_session_load = build_same_day_session_load_facts(attempts)
         repair_effectiveness = build_same_day_repair_effectiveness_facts(
             get_learning_events(learner_id)
         )
-        retention_horizon = build_retention_horizon_facts(
-            derive_all_user_node_states(attempts)
-        )
+        retention_horizon = build_retention_horizon_facts(node_states)
         retention_outcomes = build_retention_outcome_audit(attempts)
+        retention_supply = build_retention_supply_audit(node_states, attempts=attempts)
         promotion_gate_status = build_phase11_promotion_gate_status(
             retrospective_shadow_audit=diagnostics.get("retrospective_shadow_audit"),
             repeat_structure_audit=diagnostics.get("repeat_structure_audit"),
@@ -261,6 +265,7 @@ def register_developer_routes(blueprint) -> None:
         diagnostics["repair_effectiveness"] = repair_effectiveness
         diagnostics["retention_horizon"] = retention_horizon
         diagnostics["retention_outcomes"] = retention_outcomes
+        diagnostics["retention_supply"] = retention_supply
         diagnostics["promotion_gate_status"] = promotion_gate_status
         diagnostics["promotion_evidence_text"] = (
             str(diagnostics.get("promotion_evidence_text") or "").rstrip()
@@ -272,6 +277,8 @@ def register_developer_routes(blueprint) -> None:
             + build_retention_horizon_evidence_line(retention_horizon)
             + "\n"
             + build_retention_outcome_evidence_line(retention_outcomes)
+            + "\n"
+            + build_retention_supply_evidence_line(retention_supply)
             + "\n"
             + build_phase11_promotion_gate_evidence_line(promotion_gate_status)
         ).lstrip("\n")

--- a/phase11_gate_ui.py
+++ b/phase11_gate_ui.py
@@ -34,7 +34,7 @@ def build_phase11_gate_dashboard(learner_id: str, period: str = "7") -> dict:
     node_states = derive_all_user_node_states(attempts)
     retention_horizon = build_retention_horizon_facts(node_states)
     retention_outcomes = build_retention_outcome_audit(attempts)
-    retention_supply = build_retention_supply_audit(node_states)
+    retention_supply = build_retention_supply_audit(node_states, attempts=attempts)
     gate_status = build_phase11_promotion_gate_status(
         retrospective_shadow_audit=diagnostics.get("retrospective_shadow_audit"),
         repeat_structure_audit=diagnostics.get("repeat_structure_audit"),

--- a/phase11_retention_supply_audit.py
+++ b/phase11_retention_supply_audit.py
@@ -5,12 +5,18 @@ Node to ``stable``.  This module inspects current formal Node states against the
 existing Question Bank repairability registry so missing retention supply can be
 seen *before* a natural review becomes due.
 
+When attempt history is supplied, the audit also mirrors the selector's current
+30-attempt Recent Question Cooldown window so it can distinguish STRONG supply
+that is immediately non-recent from STRONG supply that is currently cooldown-
+constrained.  This remains diagnostic only; it does not decide exact Q selection.
+
 It never changes Node state, selection, cooldown, Question Bank data, or learner-
 facing recommendations.
 """
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from typing import Any, Iterable
 
 from knowledge_node_repair_evidence import (
@@ -24,14 +30,39 @@ from knowledge_node_repairability import build_repairability_audit
 STRONG_AVAILABLE = "strong_available"
 WEAK_ONLY = "weak_only"
 NO_ALTERNATE = "no_formal_alternate"
+RECENT_WINDOW = 30
+
+
+def _as_datetime(value: Any) -> datetime:
+    if isinstance(value, datetime):
+        parsed = value
+    elif value:
+        try:
+            parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+        except (TypeError, ValueError):
+            parsed = datetime.min.replace(tzinfo=timezone.utc)
+    else:
+        parsed = datetime.min.replace(tzinfo=timezone.utc)
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+
+
+def _attempt_sort_key(item: dict[str, Any]) -> tuple:
+    return (
+        _as_datetime(item.get("answered_at") or item.get("attempted_at")),
+        str(item.get("event_key") or ""),
+        int(item.get("attempt_position") or 0),
+        int(item.get("id") or 0),
+    )
 
 
 def build_retention_supply_audit(
     node_states: Iterable[dict[str, Any]],
     *,
+    attempts: Iterable[dict[str, Any]] | None = None,
     repairability_records: Iterable[dict[str, Any]] | None = None,
+    recent_window: int = RECENT_WINDOW,
 ) -> dict[str, Any]:
-    """Classify retention-question supply for repaired/recheck_due Nodes."""
+    """Classify retention-question supply for repaired/recheck_due/stable Nodes."""
     registry = {
         str(item.get("canonical_node_id") or ""): dict(item)
         for item in (
@@ -40,6 +71,18 @@ def build_retention_supply_audit(
             else build_repairability_audit()
         )
     }
+
+    cooldown_known = attempts is not None
+    recent_question_ids: set[str] = set()
+    if attempts is not None:
+        ordered_attempts = sorted(
+            (dict(item) for item in attempts), key=_attempt_sort_key, reverse=True
+        )[: max(0, int(recent_window))]
+        recent_question_ids = {
+            str(item.get("question_id") or "")
+            for item in ordered_attempts
+            if item.get("question_id")
+        }
 
     details: list[dict[str, Any]] = []
     for raw in node_states or ():
@@ -64,6 +107,19 @@ def build_retention_supply_audit(
             elif quality == DIFFERENT_QUESTION_WEAK:
                 weak.append(candidate)
 
+        strong = sorted(strong)
+        weak = sorted(weak)
+        non_recent_strong = (
+            [qid for qid in strong if qid not in recent_question_ids]
+            if cooldown_known
+            else []
+        )
+        recent_strong = (
+            [qid for qid in strong if qid in recent_question_ids]
+            if cooldown_known
+            else []
+        )
+
         if strong:
             classification = STRONG_AVAILABLE
         elif weak:
@@ -77,10 +133,22 @@ def build_retention_supply_audit(
             "retention_reference_question_id": reference_q,
             "next_review_at": raw.get("next_review_at"),
             "classification": classification,
-            "strong_candidate_question_ids": sorted(strong),
-            "weak_candidate_question_ids": sorted(weak),
+            "strong_candidate_question_ids": strong,
+            "weak_candidate_question_ids": weak,
             "strong_candidate_count": len(strong),
             "weak_candidate_count": len(weak),
+            "cooldown_known": cooldown_known,
+            "non_recent_strong_candidate_question_ids": non_recent_strong,
+            "recent_strong_candidate_question_ids": recent_strong,
+            "non_recent_strong_candidate_count": (
+                len(non_recent_strong) if cooldown_known else None
+            ),
+            "recent_strong_candidate_count": (
+                len(recent_strong) if cooldown_known else None
+            ),
+            "strong_supply_currently_cooldown_constrained": bool(
+                cooldown_known and strong and not non_recent_strong
+            ),
         })
 
     due = [item for item in details if item["state"] == "recheck_due"]
@@ -89,6 +157,16 @@ def build_retention_supply_audit(
 
     def count(items: list[dict[str, Any]], classification: str) -> int:
         return sum(item["classification"] == classification for item in items)
+
+    due_non_recent_strong = sum(
+        bool(item.get("non_recent_strong_candidate_count")) for item in due
+    ) if cooldown_known else None
+    upcoming_non_recent_strong = sum(
+        bool(item.get("non_recent_strong_candidate_count")) for item in upcoming
+    ) if cooldown_known else None
+    cooldown_constrained = sum(
+        item["strong_supply_currently_cooldown_constrained"] for item in details
+    ) if cooldown_known else None
 
     return {
         "retention_node_count": len(details),
@@ -104,11 +182,25 @@ def build_retention_supply_audit(
         "all_due_have_strong_supply": bool(due) and all(
             item["classification"] == STRONG_AVAILABLE for item in due
         ),
+        "cooldown_known": cooldown_known,
+        "recent_window": max(0, int(recent_window)),
+        "recent_question_count": len(recent_question_ids) if cooldown_known else None,
+        "cooldown_constrained_strong_node_count": cooldown_constrained,
+        "due_non_recent_strong_available_count": due_non_recent_strong,
+        "due_without_non_recent_strong_count": (
+            len(due) - int(due_non_recent_strong or 0) if cooldown_known else None
+        ),
+        "upcoming_non_recent_strong_available_count": upcoming_non_recent_strong,
+        "upcoming_without_non_recent_strong_count": (
+            len(upcoming) - int(upcoming_non_recent_strong or 0)
+            if cooldown_known else None
+        ),
         "details": details,
         "diagnostic_only": True,
         "policy_note": (
-            "STRONG supply availability is a preflight diagnostic only. Exact-Q selection "
-            "remains owned by Phase10 and still must obey Safety and Recent Cooldown."
+            "STRONG supply and current cooldown eligibility are preflight diagnostics only. "
+            "Exact-Q selection remains owned by Phase10; Safety and the selector's controlled "
+            "cooldown fallback remain authoritative."
         ),
     }
 
@@ -122,6 +214,11 @@ def build_retention_supply_evidence_line(audit: dict[str, Any] | None) -> str:
         f"due_without_strong:{int(source.get('due_without_strong_count') or 0)}",
         f"upcoming:{int(source.get('upcoming_repaired_node_count') or 0)}",
         f"upcoming_without_strong:{int(source.get('upcoming_without_strong_count') or 0)}",
+        f"cooldown_known:{1 if source.get('cooldown_known') else 0}",
+        f"due_nonrecent_strong:{int(source.get('due_non_recent_strong_available_count') or 0)}",
+        f"due_without_nonrecent_strong:{int(source.get('due_without_non_recent_strong_count') or 0)}",
+        f"upcoming_without_nonrecent_strong:{int(source.get('upcoming_without_non_recent_strong_count') or 0)}",
+        f"cooldown_constrained:{int(source.get('cooldown_constrained_strong_node_count') or 0)}",
         f"weak_only:{int(source.get('weak_only_count') or 0)}",
         f"no_alt:{int(source.get('no_formal_alternate_count') or 0)}",
     ])

--- a/templates/internal/phase11_gates.html
+++ b/templates/internal/phase11_gates.html
@@ -69,8 +69,12 @@
   <section class="card">
     <h2>Retention STRONG Supply Preflight</h2>
     <p>due {{ supply.due_node_count }} / dueでSTRONGあり {{ supply.due_strong_available_count }} / dueでSTRONGなし {{ supply.due_without_strong_count }}</p>
+    {% if supply.cooldown_known %}
+    <p>直近{{ supply.recent_window }}回答を除いて使えるSTRONG: due {{ supply.due_non_recent_strong_available_count }} / dueで非recent STRONGなし {{ supply.due_without_non_recent_strong_count }} / upcomingで非recent STRONGなし {{ supply.upcoming_without_non_recent_strong_count }}</p>
+    <p>STRONGはあるが現在cooldown制約中のNode {{ supply.cooldown_constrained_strong_node_count }} / recent Q {{ supply.recent_question_count }}</p>
+    {% endif %}
     <p>upcoming repaired {{ supply.upcoming_repaired_node_count }} / upcomingでSTRONGなし {{ supply.upcoming_without_strong_count }} / weak-only {{ supply.weak_only_count }} / formal alternateなし {{ supply.no_formal_alternate_count }}</p>
-    <p class="muted">J4が自然発生する前に、retention referenceと別のSTRONG問題が存在するかだけを先行監査します。実際のQ選択はPhase10、Safety・Recent Cooldownの制約は従来どおりです。</p>
+    <p class="muted">J4が自然発生する前に、retention referenceと別のSTRONG問題が存在するか、さらに現在の30回答Recent Cooldownを避けて使えるSTRONGがあるかを先行監査します。実際のQ選択と制御fallbackはPhase10が最終決定します。</p>
   </section>
 
   {% set outcomes = retention_outcomes %}

--- a/tests/test_phase11_gate_ui.py
+++ b/tests/test_phase11_gate_ui.py
@@ -79,6 +79,13 @@ def test_gate_page_renders_hold_retention_and_no_auto_promotion(monkeypatch):
                 "upcoming_without_strong_count": 2,
                 "weak_only_count": 1,
                 "no_formal_alternate_count": 1,
+                "cooldown_known": True,
+                "recent_window": 30,
+                "recent_question_count": 30,
+                "due_non_recent_strong_available_count": 0,
+                "due_without_non_recent_strong_count": 0,
+                "upcoming_without_non_recent_strong_count": 4,
+                "cooldown_constrained_strong_node_count": 2,
             },
             "retention_outcomes": {
                 "review_attempt_count": 0,
@@ -115,6 +122,8 @@ def test_gate_page_renders_hold_retention_and_no_auto_promotion(monkeypatch):
     assert "Retention Horizon" in html
     assert "Retention STRONG Supply Preflight" in html
     assert "upcomingでSTRONGなし 2" in html
+    assert "upcomingで非recent STRONGなし 4" in html
+    assert "cooldown制約中のNode 2" in html
     assert "Natural Retention Outcomes" in html
     assert "自然なretention review 0" in html
     assert "2026-09-09T08:26:32+09:00" in html

--- a/tests/test_phase11_retention_supply_audit.py
+++ b/tests/test_phase11_retention_supply_audit.py
@@ -1,3 +1,5 @@
+from datetime import datetime, timedelta, timezone
+
 from phase11_retention_supply_audit import (
     NO_ALTERNATE,
     STRONG_AVAILABLE,
@@ -7,9 +9,12 @@ from phase11_retention_supply_audit import (
 )
 
 
+BASE = datetime(2026, 9, 6, tzinfo=timezone.utc)
+
+
 def registry():
     return [
-        {"canonical_node_id": "KN1", "question_ids": ["Q1", "Q2"]},
+        {"canonical_node_id": "KN1", "question_ids": ["Q1", "Q2", "Q6"]},
         {"canonical_node_id": "KN2", "question_ids": ["Q3", "Q4"]},
         {"canonical_node_id": "KN3", "question_ids": ["Q5"]},
     ]
@@ -39,16 +44,26 @@ def states():
     ]
 
 
-def test_classifies_strong_weak_and_missing_supply(monkeypatch):
-    def classify(old, new):
-        if (old, new) == ("Q1", "Q2"):
-            return "different_question_strong"
-        if (old, new) == ("Q3", "Q4"):
-            return "different_question_weak"
-        return "same_question"
+def attempt(q, minutes):
+    return {
+        "question_id": q,
+        "answered_at": BASE + timedelta(minutes=minutes),
+        "event_key": f"e-{minutes}-{q}",
+        "attempt_position": 1,
+    }
 
+
+def classifier(old, new):
+    if (old, new) in {("Q1", "Q2"), ("Q1", "Q6")}:
+        return "different_question_strong"
+    if (old, new) == ("Q3", "Q4"):
+        return "different_question_weak"
+    return "same_question"
+
+
+def test_classifies_strong_weak_and_missing_supply(monkeypatch):
     monkeypatch.setattr(
-        "phase11_retention_supply_audit.classify_repair_confirmation", classify
+        "phase11_retention_supply_audit.classify_repair_confirmation", classifier
     )
     result = build_retention_supply_audit(states(), repairability_records=registry())
     by_node = {item["canonical_node_id"]: item for item in result["details"]}
@@ -61,6 +76,43 @@ def test_classifies_strong_weak_and_missing_supply(monkeypatch):
     assert result["due_without_strong_count"] == 0
     assert result["upcoming_without_strong_count"] == 1
     assert result["all_due_have_strong_supply"] is True
+    assert result["cooldown_known"] is False
+    assert result["due_without_non_recent_strong_count"] is None
+
+
+def test_cooldown_preflight_distinguishes_recent_from_non_recent_strong(monkeypatch):
+    monkeypatch.setattr(
+        "phase11_retention_supply_audit.classify_repair_confirmation", classifier
+    )
+    # Q2 is recent, but Q6 is not, so J4 has one immediately non-recent STRONG option.
+    history = [attempt(f"QX{i}", i) for i in range(29)] + [attempt("Q2", 29)]
+    result = build_retention_supply_audit(
+        [states()[0]], attempts=history, repairability_records=registry()
+    )
+    detail = result["details"][0]
+    assert detail["recent_strong_candidate_question_ids"] == ["Q2"]
+    assert detail["non_recent_strong_candidate_question_ids"] == ["Q6"]
+    assert result["due_non_recent_strong_available_count"] == 1
+    assert result["due_without_non_recent_strong_count"] == 0
+    assert result["cooldown_constrained_strong_node_count"] == 0
+
+
+def test_all_strong_candidates_recent_is_visible_as_cooldown_constrained(monkeypatch):
+    monkeypatch.setattr(
+        "phase11_retention_supply_audit.classify_repair_confirmation", classifier
+    )
+    history = [attempt(f"QX{i}", i) for i in range(28)] + [
+        attempt("Q2", 28),
+        attempt("Q6", 29),
+    ]
+    result = build_retention_supply_audit(
+        [states()[0]], attempts=history, repairability_records=registry()
+    )
+    assert result["due_strong_available_count"] == 1
+    assert result["due_non_recent_strong_available_count"] == 0
+    assert result["due_without_non_recent_strong_count"] == 1
+    assert result["cooldown_constrained_strong_node_count"] == 1
+    assert result["details"][0]["strong_supply_currently_cooldown_constrained"] is True
 
 
 def test_due_without_strong_is_visible_and_not_falsely_clear(monkeypatch):
@@ -69,10 +121,11 @@ def test_due_without_strong_is_visible_and_not_falsely_clear(monkeypatch):
         lambda old, new: "different_question_weak",
     )
     result = build_retention_supply_audit(
-        [states()[0]], repairability_records=registry()
+        [states()[0]], attempts=[], repairability_records=registry()
     )
     assert result["due_node_count"] == 1
     assert result["due_without_strong_count"] == 1
+    assert result["due_without_non_recent_strong_count"] == 1
     assert result["all_due_have_strong_supply"] is False
 
 
@@ -82,7 +135,7 @@ def test_no_due_nodes_does_not_claim_all_due_supply_is_verified(monkeypatch):
         lambda old, new: "different_question_strong",
     )
     result = build_retention_supply_audit(
-        [states()[1]], repairability_records=registry()
+        [states()[1]], attempts=[], repairability_records=registry()
     )
     assert result["due_node_count"] == 0
     assert result["all_due_have_strong_supply"] is False
@@ -90,13 +143,14 @@ def test_no_due_nodes_does_not_claim_all_due_supply_is_verified(monkeypatch):
 
 def test_evidence_line_is_aggregate_only(monkeypatch):
     monkeypatch.setattr(
-        "phase11_retention_supply_audit.classify_repair_confirmation",
-        lambda old, new: "different_question_strong",
+        "phase11_retention_supply_audit.classify_repair_confirmation", classifier
     )
     result = build_retention_supply_audit(
-        [states()[0]], repairability_records=registry()
+        [states()[0]], attempts=[attempt("Q2", 1)], repairability_records=registry()
     )
     line = build_retention_supply_evidence_line(result)
     assert line.startswith("retention_supply=nodes:1,due:1,due_strong:1")
+    assert "cooldown_known:1" in line
+    assert "due_nonrecent_strong:1" in line
     assert "KN1" not in line
     assert "Q1" not in line


### PR DESCRIPTION
## Summary
- extend retention STRONG-supply preflight with the selector's current 30-attempt Recent Question Cooldown window
- distinguish static STRONG availability from immediately non-recent STRONG availability
- expose due/upcoming Nodes whose STRONG alternatives are currently cooldown-constrained
- keep exact-Q selection and controlled fallback owned by Phase10

## Safety boundary
- diagnostic-only
- no selector/ranking/Safety/Recent Cooldown behavior change
- no Node-state mutation
- no Question Bank change
- no DB write or migration
- no learner-facing recommendation change

## Why
A static alternate may exist but still be unavailable under the current cooldown window when J4 naturally becomes due. This makes that risk visible before the first forecast natural J4 window.