### PR TITLE
Require qualified STRONG retention evidence to clear J4 gate

### DIFF
--- a/phase11_promotion_gate_status.py
+++ b/phase11_promotion_gate_status.py
@@ -55,19 +55,25 @@ def build_phase11_promotion_gate_status(
     stable_now = _int(states, "stable")
     due_to_stable = _int(transition_counts, "recheck_due_to_stable")
     due_to_repairing = _int(transition_counts, "recheck_due_to_repairing")
-    # New callers provide an explicit due-before-attempt outcome audit.  This is
-    # authoritative for whether a natural spaced review was actually observed,
-    # because prefix timelines can jump repaired -> stable on the review attempt.
+    # New callers provide an explicit due-before-attempt outcome audit. A natural
+    # review by itself is not enough to clear J4: the observed review must use
+    # STRONG different-question evidence and produce a decisive formal outcome
+    # (stable or repairing). Weak/same-Q or STRONG-but-still-due attempts remain
+    # useful evidence, but they keep the retention gate OPEN.
     if outcomes is not None:
         retention_review_count = _int(outcomes, "review_attempt_count")
+        qualified_retention_count = _int(outcomes, "qualified_strong_outcome_count")
         retention_observed = retention_review_count > 0
-        retention_status = PASS if retention_observed else OPEN
+        retention_qualified = qualified_retention_count > 0
+        retention_status = PASS if retention_qualified else OPEN
     else:
         # Backward-compatible fallback for callers not yet wired to the explicit
         # retention outcome audit.
         retention_review_count = 0
+        qualified_retention_count = 0
         retention_observed = bool(due_now or stable_now or due_to_stable or due_to_repairing)
-        retention_status = PASS if (due_to_stable or due_to_repairing or stable_now) else OPEN
+        retention_qualified = bool(due_to_stable or due_to_repairing or stable_now)
+        retention_status = PASS if retention_qualified else OPEN
 
     eligible = _int(replay, "eligible_snapshot_count")
     shadow_stronger = _int(replay, "shadow_stronger_disagreement_count")
@@ -77,7 +83,7 @@ def build_phase11_promotion_gate_status(
     observed_directions = sum(
         value > 0 for value in (shadow_stronger, current_stronger, agreement, inconclusive)
     )
-    # No fixed sample threshold is encoded.  Diversity is OPEN until at least two
+    # No fixed sample threshold is encoded. Diversity is OPEN until at least two
     # naturally observed result directions exist, then PASS as a collection gate.
     prospective_status = PASS if observed_directions >= 2 else OPEN
 
@@ -101,10 +107,15 @@ def build_phase11_promotion_gate_status(
         "retention": {
             "status": retention_status,
             "natural_retention_observed": retention_observed,
+            "qualified_strong_retention_observed": retention_qualified,
             "review_attempt_count": retention_review_count,
+            "qualified_strong_outcome_count": qualified_retention_count,
             "review_stable_count": _int(outcomes, "stable_count") if outcomes is not None else 0,
             "review_repairing_count": _int(outcomes, "repairing_count") if outcomes is not None else 0,
             "review_still_due_count": _int(outcomes, "still_due_count") if outcomes is not None else 0,
+            "strong_stable_count": _int(outcomes, "strong_stable_count") if outcomes is not None else 0,
+            "strong_repairing_count": _int(outcomes, "strong_repairing_count") if outcomes is not None else 0,
+            "strong_still_due_count": _int(outcomes, "strong_still_due_count") if outcomes is not None else 0,
             "recheck_due_count": due_now,
             "stable_count": stable_now,
             "recheck_due_to_stable": due_to_stable,

--- a/phase11_retention_outcome_audit.py
+++ b/phase11_retention_outcome_audit.py
@@ -18,7 +18,10 @@ from typing import Any, Iterable
 from zoneinfo import ZoneInfo
 
 from knowledge_node_canonical import canonicalize_knowledge_node_id
-from knowledge_node_repair_evidence import classify_repair_confirmation
+from knowledge_node_repair_evidence import (
+    DIFFERENT_QUESTION_STRONG,
+    classify_repair_confirmation,
+)
 from knowledge_node_state_transition import derive_knowledge_node_state
 
 
@@ -122,6 +125,23 @@ def build_retention_outcome_audit(
 
     outcome_counts = Counter(item["outcome"] for item in reviews)
     evidence_counts = Counter(item["evidence_quality"] for item in reviews)
+    strong_stable_count = sum(
+        item["evidence_quality"] == DIFFERENT_QUESTION_STRONG
+        and item["outcome"] == "stable"
+        for item in reviews
+    )
+    strong_repairing_count = sum(
+        item["evidence_quality"] == DIFFERENT_QUESTION_STRONG
+        and item["outcome"] == "repairing"
+        for item in reviews
+    )
+    strong_still_due_count = sum(
+        item["evidence_quality"] == DIFFERENT_QUESTION_STRONG
+        and item["outcome"] == "still_due"
+        for item in reviews
+    )
+    qualified_strong_outcome_count = strong_stable_count + strong_repairing_count
+
     return {
         "review_attempt_count": len(reviews),
         "stable_count": outcome_counts["stable"],
@@ -131,17 +151,22 @@ def build_retention_outcome_audit(
         - outcome_counts["stable"]
         - outcome_counts["repairing"]
         - outcome_counts["still_due"],
-        "strong_evidence_count": evidence_counts["different_question_strong"],
+        "strong_evidence_count": evidence_counts[DIFFERENT_QUESTION_STRONG],
         "weak_evidence_count": evidence_counts["different_question_weak"],
         "same_question_count": evidence_counts["same_question"],
+        "strong_stable_count": strong_stable_count,
+        "strong_repairing_count": strong_repairing_count,
+        "strong_still_due_count": strong_still_due_count,
+        "qualified_strong_outcome_count": qualified_strong_outcome_count,
         "confident_correct_count": sum(
             item["is_correct"] and item.get("confidence") == 1 for item in reviews
         ),
         "reviews": reviews,
         "diagnostic_only": True,
         "policy_note": (
-            "These are naturally occurring formal retention-review attempts. "
-            "The audit does not create due states or authorize Phase11 promotion."
+            "A retention review is promotion-gate qualified only when STRONG different-Q "
+            "evidence produces a decisive formal outcome (stable or repairing). Weak/same-Q "
+            "or STRONG-but-still-due reviews remain observable but do not clear J4."
         ),
     }
 
@@ -156,6 +181,10 @@ def build_retention_outcome_evidence_line(audit: dict[str, Any] | None) -> str:
         f"still_due:{int(source.get('still_due_count') or 0)}",
         f"other:{int(source.get('other_outcome_count') or 0)}",
         f"strong:{int(source.get('strong_evidence_count') or 0)}",
+        f"strong_stable:{int(source.get('strong_stable_count') or 0)}",
+        f"strong_repairing:{int(source.get('strong_repairing_count') or 0)}",
+        f"strong_still_due:{int(source.get('strong_still_due_count') or 0)}",
+        f"qualified_strong:{int(source.get('qualified_strong_outcome_count') or 0)}",
         f"weak:{int(source.get('weak_evidence_count') or 0)}",
         f"same_q:{int(source.get('same_question_count') or 0)}",
         f"confident_correct:{int(source.get('confident_correct_count') or 0)}",

--- a/tests/test_phase11_promotion_gate_status.py
+++ b/tests/test_phase11_promotion_gate_status.py
@@ -79,7 +79,7 @@ def test_safety_repeat_or_trigger_regression_blocks_without_enabling_promotion()
     assert result["learner_facing_promotion_allowed"] is False
 
 
-def test_explicit_retention_outcome_and_direction_diversity_clear_checkable_gates_only():
+def test_qualified_strong_retention_outcome_and_direction_diversity_clear_checkable_gates_only():
     result = _status(
         retrospective_shadow_audit={
             "eligible_snapshot_count": 4,
@@ -96,6 +96,10 @@ def test_explicit_retention_outcome_and_direction_diversity_clear_checkable_gate
             "stable_count": 1,
             "repairing_count": 0,
             "still_due_count": 0,
+            "strong_stable_count": 1,
+            "strong_repairing_count": 0,
+            "strong_still_due_count": 0,
+            "qualified_strong_outcome_count": 1,
         },
         state_counts={"stable": 1},
         transitions={
@@ -105,12 +109,41 @@ def test_explicit_retention_outcome_and_direction_diversity_clear_checkable_gate
     )
     assert result["gates"]["retention"]["status"] == PASS
     assert result["gates"]["retention"]["review_attempt_count"] == 1
-    assert result["gates"]["retention"]["review_stable_count"] == 1
+    assert result["gates"]["retention"]["qualified_strong_outcome_count"] == 1
+    assert result["gates"]["retention"]["qualified_strong_retention_observed"] is True
     assert result["gates"]["comparison_diversity"]["status"] == PASS
     assert result["automatically_clear"] is True
     assert result["decision"] == "hold"
     assert result["learner_facing_promotion_allowed"] is False
     assert result["manual_review_required"] is True
+
+
+def test_weak_or_same_q_natural_review_does_not_false_pass_j4():
+    result = _status(
+        retention_outcome_audit={
+            "review_attempt_count": 2,
+            "stable_count": 0,
+            "repairing_count": 0,
+            "still_due_count": 2,
+            "qualified_strong_outcome_count": 0,
+        }
+    )
+    assert result["gates"]["retention"]["natural_retention_observed"] is True
+    assert result["gates"]["retention"]["qualified_strong_retention_observed"] is False
+    assert result["gates"]["retention"]["status"] == OPEN
+
+
+def test_strong_but_still_due_review_does_not_false_pass_j4():
+    result = _status(
+        retention_outcome_audit={
+            "review_attempt_count": 1,
+            "still_due_count": 1,
+            "strong_still_due_count": 1,
+            "qualified_strong_outcome_count": 0,
+        }
+    )
+    assert result["gates"]["retention"]["status"] == OPEN
+    assert result["gates"]["retention"]["strong_still_due_count"] == 1
 
 
 def test_explicit_zero_review_does_not_use_legacy_stable_or_timeline_as_false_pass():

--- a/tests/test_phase11_retention_outcome_audit.py
+++ b/tests/test_phase11_retention_outcome_audit.py
@@ -65,6 +65,8 @@ def test_captures_hidden_repaired_to_due_to_stable_review(monkeypatch):
     assert result["review_attempt_count"] == 1
     assert result["stable_count"] == 1
     assert result["strong_evidence_count"] == 1
+    assert result["strong_stable_count"] == 1
+    assert result["qualified_strong_outcome_count"] == 1
     review = result["reviews"][0]
     assert review["outcome"] == "stable"
     assert review["retention_reference_question_id"] == "Q2"
@@ -72,17 +74,19 @@ def test_captures_hidden_repaired_to_due_to_stable_review(monkeypatch):
     assert review["hours_after_due"] == 0.0
 
 
-def test_due_wrong_is_recorded_as_repairing(monkeypatch):
-    install_classifier(monkeypatch, {("Q1", "Q2")})
+def test_due_strong_wrong_is_qualified_repairing_outcome(monkeypatch):
+    install_classifier(monkeypatch, {("Q1", "Q2"), ("Q2", "Q3")})
     result = audit.build_retention_outcome_audit(
         repaired_history() + [attempt("Q3", correct=False, confidence=2, day=8)]
     )
     assert result["review_attempt_count"] == 1
     assert result["repairing_count"] == 1
+    assert result["strong_repairing_count"] == 1
+    assert result["qualified_strong_outcome_count"] == 1
     assert result["reviews"][0]["outcome"] == "repairing"
 
 
-def test_due_weak_correct_remains_due(monkeypatch):
+def test_due_weak_correct_remains_due_and_does_not_qualify(monkeypatch):
     install_classifier(monkeypatch, {("Q1", "Q2")})
     result = audit.build_retention_outcome_audit(
         repaired_history() + [attempt("Q3", correct=True, confidence=1, day=8)]
@@ -90,6 +94,18 @@ def test_due_weak_correct_remains_due(monkeypatch):
     assert result["review_attempt_count"] == 1
     assert result["still_due_count"] == 1
     assert result["weak_evidence_count"] == 1
+    assert result["qualified_strong_outcome_count"] == 0
+
+
+def test_due_strong_uncertain_correct_stays_due_and_does_not_qualify(monkeypatch):
+    install_classifier(monkeypatch, {("Q1", "Q2"), ("Q2", "Q3")})
+    result = audit.build_retention_outcome_audit(
+        repaired_history() + [attempt("Q3", correct=True, confidence=2, day=8)]
+    )
+    assert result["review_attempt_count"] == 1
+    assert result["strong_evidence_count"] == 1
+    assert result["strong_still_due_count"] == 1
+    assert result["qualified_strong_outcome_count"] == 0
 
 
 def test_before_due_attempt_is_not_retention_review(monkeypatch):
@@ -98,6 +114,7 @@ def test_before_due_attempt_is_not_retention_review(monkeypatch):
         repaired_history() + [attempt("Q3", correct=True, confidence=1, day=7)]
     )
     assert result["review_attempt_count"] == 0
+    assert result["qualified_strong_outcome_count"] == 0
 
 
 def test_evidence_line_excludes_identity_and_question_ids(monkeypatch):
@@ -108,6 +125,7 @@ def test_evidence_line_excludes_identity_and_question_ids(monkeypatch):
     result["user_id"] = "must-not-leak"
     line = audit.build_retention_outcome_evidence_line(result)
     assert line.startswith("retention_outcomes=reviews:1,stable:1")
+    assert "qualified_strong:1" in line
     assert "must-not-leak" not in line
     assert "learner" not in line
     assert "Q1" not in line and "Q2" not in line and "Q3" not in line


### PR DESCRIPTION
## Summary
- distinguish any natural recheck_due attempt from a promotion-gate-qualified retention outcome
- count STRONG->stable and STRONG->repairing outcomes separately
- keep J4 OPEN for weak/same-Q reviews or STRONG reviews that remain recheck_due
- clear J4 only after a natural STRONG different-question review produces a decisive formal outcome

## Safety boundary
- read-only diagnostics/gate evaluation only
- no Node-state rule change
- no selector/ranking/Safety/Recent Cooldown change
- no Question Bank change
- no DB write or migration
- automatic learner-facing promotion remains impossible

## Why
The previous gate could PASS after any natural retention attempt. That was too permissive relative to the stated J4 requirement that the review use valid STRONG evidence and produce a meaningful formal outcome.