### PR TITLE
Audit Phase11 J5 intent vs Phase10 exact-Q alignment

### DIFF
--- a/phase11_gate_ui.py
+++ b/phase11_gate_ui.py
@@ -11,6 +11,7 @@ from flask import abort, render_template, request
 from database import get_learning_events, get_question_attempts
 from developer_ui import require_developer_authorization
 from knowledge_node_state_transition import derive_all_user_node_states
+from phase11_intent_selection_alignment import build_phase11_intent_selection_alignment
 from phase11_promotion_gate_status import build_phase11_promotion_gate_status
 from phase11_repair_effectiveness_facts import build_same_day_repair_effectiveness_facts
 from phase11_retention_horizon_facts import build_retention_horizon_facts
@@ -25,21 +26,25 @@ ENDPOINT = "internal_phase11_gates"
 
 
 def build_phase11_gate_dashboard(learner_id: str, period: str = "7") -> dict:
-    """Build one read-only snapshot from formal history and existing diagnostics."""
     if period not in {"7", "30", "all"}:
         period = "7"
 
     diagnostics = build_pilot_diagnostics(learner_id, period)
     attempts = get_question_attempts(learner_id)
+    learning_events = get_learning_events(learner_id)
     node_states = derive_all_user_node_states(attempts)
     retention_horizon = build_retention_horizon_facts(node_states)
     retention_outcomes = build_retention_outcome_audit(attempts)
     retention_supply = build_retention_supply_audit(node_states, attempts=attempts)
+    intent_selection_alignment = build_phase11_intent_selection_alignment(
+        attempts, learning_events
+    )
     gate_status = build_phase11_promotion_gate_status(
         retrospective_shadow_audit=diagnostics.get("retrospective_shadow_audit"),
         repeat_structure_audit=diagnostics.get("repeat_structure_audit"),
         retention_horizon=retention_horizon,
         retention_outcome_audit=retention_outcomes,
+        intent_selection_alignment=intent_selection_alignment,
         state_counts=diagnostics.get("state_counts"),
         transitions={
             "recheck_due_to_stable": diagnostics.get("due_to_stable", 0),
@@ -51,18 +56,16 @@ def build_phase11_gate_dashboard(learner_id: str, period: str = "7") -> dict:
         "period": period,
         "diagnostics": diagnostics,
         "session_load": build_same_day_session_load_facts(attempts),
-        "repair_effectiveness": build_same_day_repair_effectiveness_facts(
-            get_learning_events(learner_id)
-        ),
+        "repair_effectiveness": build_same_day_repair_effectiveness_facts(learning_events),
         "retention_horizon": retention_horizon,
         "retention_outcomes": retention_outcomes,
         "retention_supply": retention_supply,
+        "intent_selection_alignment": intent_selection_alignment,
         "gate_status": gate_status,
     }
 
 
 def install_phase11_gate_ui(flask_app) -> None:
-    """Register the internal dashboard exactly once."""
     if ENDPOINT in flask_app.view_functions:
         return
 

--- a/phase11_intent_selection_alignment.py
+++ b/phase11_intent_selection_alignment.py
@@ -1,0 +1,195 @@
+"""Read-only Phase11 intent vs Phase10 exact-Q alignment audit.
+
+This audit does not change either policy.  It inspects persisted adaptive_daily
+selection metadata together with formal attempt history and asks whether exact-Q
+execution was directionally compatible with the Phase11-relevant intent encoded
+in the saved selector reason.
+
+The first supported hard check is J4/recheck_due: when a persisted adaptive row
+was selected for ``recheck_due`` and the formal Node was still due immediately
+before that answer, the chosen Q should be STRONG different-question evidence
+against the retention reference.  Weak/same-Q choices remain visible as J5
+alignment defects/candidates; they are never silently reinterpreted as valid J4.
+"""
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+from datetime import datetime, timezone
+from typing import Any, Iterable
+
+from knowledge_node_canonical import canonicalize_knowledge_node_id
+from knowledge_node_repair_evidence import (
+    DIFFERENT_QUESTION_STRONG,
+    DIFFERENT_QUESTION_WEAK,
+    SAME_QUESTION,
+    classify_repair_confirmation,
+)
+from knowledge_node_state_transition import derive_knowledge_node_state
+
+
+RECHECK_REASON = "recheck_due"
+
+
+def _dt(value: Any) -> datetime | None:
+    if isinstance(value, datetime):
+        parsed = value
+    elif value:
+        try:
+            parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+        except (TypeError, ValueError):
+            return None
+    else:
+        return None
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+
+
+def _sort_key(item: dict[str, Any]) -> tuple:
+    return (
+        _dt(item.get("answered_at") or item.get("attempted_at"))
+        or datetime.min.replace(tzinfo=timezone.utc),
+        str(item.get("event_key") or ""),
+        int(item.get("attempt_position") or 0),
+        int(item.get("id") or 0),
+    )
+
+
+def _event_results(events: Iterable[dict[str, Any]]) -> dict[tuple[str, str], dict[str, Any]]:
+    import json
+
+    lookup: dict[tuple[str, str], dict[str, Any]] = {}
+    for event in events or ():
+        event_key = str(event.get("event_key") or "")
+        rows = event.get("question_results")
+        if isinstance(rows, str):
+            try:
+                rows = json.loads(rows)
+            except (TypeError, ValueError):
+                rows = []
+        if not isinstance(rows, list):
+            continue
+        for row in rows:
+            if not isinstance(row, dict) or not row.get("question_id"):
+                continue
+            lookup[(event_key, str(row["question_id"]))] = dict(row)
+    return lookup
+
+
+def build_phase11_intent_selection_alignment(
+    attempts: Iterable[dict[str, Any]],
+    learning_events: Iterable[dict[str, Any]],
+) -> dict[str, Any]:
+    """Audit saved adaptive intent against the exact Q actually answered."""
+    attempts = sorted((dict(item) for item in attempts or ()), key=_sort_key)
+    metadata = _event_results(learning_events)
+
+    histories: dict[tuple[str, str], list[dict[str, Any]]] = defaultdict(list)
+    details: list[dict[str, Any]] = []
+
+    for attempt in attempts:
+        user_id = str(attempt.get("user_id") or "")
+        node_id = canonicalize_knowledge_node_id(
+            str(attempt.get("knowledge_node_id") or "")
+        )
+        if not node_id:
+            continue
+        key = (user_id, node_id)
+        prior = histories[key]
+        event_key = str(attempt.get("event_key") or "")
+        question_id = str(attempt.get("question_id") or "")
+        saved = metadata.get((event_key, question_id))
+
+        if saved and str(saved.get("selection_reason") or "") == RECHECK_REASON:
+            attempted_at = _dt(attempt.get("answered_at") or attempt.get("attempted_at"))
+            before = (
+                derive_knowledge_node_state(
+                    prior,
+                    canonical_node_id=node_id,
+                    as_of=attempted_at,
+                )
+                if prior and attempted_at
+                else None
+            )
+            before_state = str((before or {}).get("state") or "")
+            reference_q = str((before or {}).get("retention_reference_question_id") or "")
+            if before_state == "recheck_due" and reference_q:
+                quality = classify_repair_confirmation(reference_q, question_id)
+                status = "aligned" if quality == DIFFERENT_QUESTION_STRONG else "misaligned"
+                evaluable = True
+                reason = (
+                    "recheck_due selected Q is STRONG vs retention reference"
+                    if status == "aligned"
+                    else "recheck_due selected Q is not STRONG vs retention reference"
+                )
+            else:
+                quality = None
+                status = "not_evaluable"
+                evaluable = False
+                reason = (
+                    "saved recheck_due intent could not be revalidated at answer time; "
+                    "state may have changed inside the already-generated set"
+                )
+            details.append({
+                "canonical_node_id": node_id,
+                "question_id": question_id,
+                "event_key": event_key,
+                "selection_reason": RECHECK_REASON,
+                "selection_group": saved.get("selection_group"),
+                "saved_repair_evidence_quality": saved.get("repair_evidence_quality"),
+                "recent_question_repeat": saved.get("recent_question_repeat") is True,
+                "recent_cooldown_bypassed": saved.get("recent_cooldown_bypassed") is True,
+                "formal_state_before_answer": before_state or None,
+                "retention_reference_question_id": reference_q or None,
+                "retention_evidence_quality": quality,
+                "evaluable": evaluable,
+                "status": status,
+                "reason": reason,
+            })
+
+        prior.append(attempt)
+
+    counts = Counter(item["status"] for item in details)
+    evaluable = [item for item in details if item["evaluable"]]
+    quality_counts = Counter(item["retention_evidence_quality"] for item in evaluable)
+    return {
+        "saved_recheck_selection_count": len(details),
+        "evaluable_recheck_selection_count": len(evaluable),
+        "aligned_recheck_selection_count": counts["aligned"],
+        "misaligned_recheck_selection_count": counts["misaligned"],
+        "not_evaluable_recheck_selection_count": counts["not_evaluable"],
+        "strong_retention_q_count": quality_counts[DIFFERENT_QUESTION_STRONG],
+        "weak_retention_q_count": quality_counts[DIFFERENT_QUESTION_WEAK],
+        "same_question_retention_q_count": quality_counts[SAME_QUESTION],
+        "recent_repeat_recheck_count": sum(item["recent_question_repeat"] for item in details),
+        "cooldown_bypass_recheck_count": sum(item["recent_cooldown_bypassed"] for item in details),
+        "alignment_status": (
+            "blocked"
+            if counts["misaligned"]
+            else "pass"
+            if evaluable
+            else "open"
+        ),
+        "details": details,
+        "diagnostic_only": True,
+        "policy_note": (
+            "This audit detects J5 compatibility evidence only. It does not change the "
+            "Phase10 selector or authorize Phase11 learner-facing promotion."
+        ),
+    }
+
+
+def build_intent_selection_alignment_evidence_line(audit: dict[str, Any] | None) -> str:
+    source = audit or {}
+    return "intent_selection_alignment=" + ",".join([
+        f"status:{source.get('alignment_status') or 'open'}",
+        f"saved_recheck:{int(source.get('saved_recheck_selection_count') or 0)}",
+        f"evaluable:{int(source.get('evaluable_recheck_selection_count') or 0)}",
+        f"aligned:{int(source.get('aligned_recheck_selection_count') or 0)}",
+        f"misaligned:{int(source.get('misaligned_recheck_selection_count') or 0)}",
+        f"not_evaluable:{int(source.get('not_evaluable_recheck_selection_count') or 0)}",
+        f"strong:{int(source.get('strong_retention_q_count') or 0)}",
+        f"weak:{int(source.get('weak_retention_q_count') or 0)}",
+        f"same_q:{int(source.get('same_question_retention_q_count') or 0)}",
+        f"recent_repeat:{int(source.get('recent_repeat_recheck_count') or 0)}",
+        f"cooldown_bypass:{int(source.get('cooldown_bypass_recheck_count') or 0)}",
+    ])

--- a/phase11_promotion_gate_status.py
+++ b/phase11_promotion_gate_status.py
@@ -1,15 +1,11 @@
 """Read-only Phase 11 promotion gate status from existing diagnostic evidence.
 
-This module is intentionally conservative.  It can report PASS / OPEN / BLOCKED
-for evidence classes, but it never authorizes learner-facing promotion.  A human
-promotion review remains required even when every automatically checkable gate
-is clear.
+This module is intentionally conservative. It reports PASS / OPEN / BLOCKED for
+checkable evidence classes but never authorizes learner-facing promotion.
 """
 
 from __future__ import annotations
-
 from typing import Any
-
 
 PASS = "pass"
 OPEN = "open"
@@ -29,17 +25,16 @@ def build_phase11_promotion_gate_status(
     transitions: dict[str, Any] | None,
     shadow_judgment: dict[str, Any] | None,
     retention_outcome_audit: dict[str, Any] | None = None,
+    intent_selection_alignment: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    """Return deterministic gate states without inventing promotion thresholds."""
     replay = retrospective_shadow_audit or {}
-    repeat = repeat_structure_audit or {}
-    repeat_counts = repeat.get("category_counts") or {}
+    repeat_counts = (repeat_structure_audit or {}).get("category_counts") or {}
     retention = retention_horizon or {}
     states = state_counts or {}
     transition_counts = transitions or {}
     outcomes = retention_outcome_audit
-    shadow = shadow_judgment or {}
-    comparison = shadow.get("comparison") or {}
+    alignment = intent_selection_alignment
+    comparison = (shadow_judgment or {}).get("comparison") or {}
 
     safety_misses = _int(replay, "phase11_critical_safety_miss_candidate_count")
     safety_status = BLOCKED if safety_misses else PASS
@@ -55,11 +50,6 @@ def build_phase11_promotion_gate_status(
     stable_now = _int(states, "stable")
     due_to_stable = _int(transition_counts, "recheck_due_to_stable")
     due_to_repairing = _int(transition_counts, "recheck_due_to_repairing")
-    # New callers provide an explicit due-before-attempt outcome audit. A natural
-    # review by itself is not enough to clear J4: the observed review must use
-    # STRONG different-question evidence and produce a decisive formal outcome
-    # (stable or repairing). Weak/same-Q or STRONG-but-still-due attempts remain
-    # useful evidence, but they keep the retention gate OPEN.
     if outcomes is not None:
         retention_review_count = _int(outcomes, "review_attempt_count")
         qualified_retention_count = _int(outcomes, "qualified_strong_outcome_count")
@@ -67,13 +57,21 @@ def build_phase11_promotion_gate_status(
         retention_qualified = qualified_retention_count > 0
         retention_status = PASS if retention_qualified else OPEN
     else:
-        # Backward-compatible fallback for callers not yet wired to the explicit
-        # retention outcome audit.
         retention_review_count = 0
         qualified_retention_count = 0
         retention_observed = bool(due_now or stable_now or due_to_stable or due_to_repairing)
         retention_qualified = bool(due_to_stable or due_to_repairing or stable_now)
         retention_status = PASS if retention_qualified else OPEN
+
+    if alignment is None:
+        alignment_status = OPEN
+    else:
+        raw_alignment_status = str(alignment.get("alignment_status") or OPEN)
+        alignment_status = (
+            BLOCKED if raw_alignment_status == "blocked"
+            else PASS if raw_alignment_status == "pass"
+            else OPEN
+        )
 
     eligible = _int(replay, "eligible_snapshot_count")
     shadow_stronger = _int(replay, "shadow_stronger_disagreement_count")
@@ -83,18 +81,13 @@ def build_phase11_promotion_gate_status(
     observed_directions = sum(
         value > 0 for value in (shadow_stronger, current_stronger, agreement, inconclusive)
     )
-    # No fixed sample threshold is encoded. Diversity is OPEN until at least two
-    # naturally observed result directions exist, then PASS as a collection gate.
     prospective_status = PASS if observed_directions >= 2 else OPEN
 
     profile_consistent = bool(comparison.get("shadow_reason_profile_consistent", True))
     comparison_status = PASS if profile_consistent else BLOCKED
 
     gates = {
-        "safety": {
-            "status": safety_status,
-            "critical_miss_count": safety_misses,
-        },
+        "safety": {"status": safety_status, "critical_miss_count": safety_misses},
         "repeat_audit": {
             "status": repeat_status,
             "unexplained_recent_repeat_count": unexplained_repeat,
@@ -123,6 +116,14 @@ def build_phase11_promotion_gate_status(
             "upcoming_review_count": _int(retention, "upcoming_review_count"),
             "earliest_review_at_jst": retention.get("earliest_review_at_jst"),
         },
+        "intent_selection_alignment": {
+            "status": alignment_status,
+            "saved_recheck_selection_count": _int(alignment, "saved_recheck_selection_count"),
+            "evaluable_recheck_selection_count": _int(alignment, "evaluable_recheck_selection_count"),
+            "aligned_recheck_selection_count": _int(alignment, "aligned_recheck_selection_count"),
+            "misaligned_recheck_selection_count": _int(alignment, "misaligned_recheck_selection_count"),
+            "not_evaluable_recheck_selection_count": _int(alignment, "not_evaluable_recheck_selection_count"),
+        },
         "comparison_diversity": {
             "status": prospective_status,
             "eligible_snapshot_count": eligible,
@@ -140,13 +141,11 @@ def build_phase11_promotion_gate_status(
 
     blocked = [name for name, item in gates.items() if item["status"] == BLOCKED]
     open_gates = [name for name, item in gates.items() if item["status"] == OPEN]
-    automatically_clear = not blocked and not open_gates
-
     return {
         "decision": "blocked" if blocked else "hold",
         "learner_facing_promotion_allowed": False,
         "manual_review_required": True,
-        "automatically_clear": automatically_clear,
+        "automatically_clear": not blocked and not open_gates,
         "blocked_gates": blocked,
         "open_gates": open_gates,
         "gates": gates,
@@ -158,13 +157,10 @@ def build_phase11_promotion_gate_status(
 
 
 def build_phase11_promotion_gate_evidence_line(status: dict[str, Any] | None) -> str:
-    """Serialize a compact non-identifying status line for the evidence bundle."""
     source = status or {}
     gates = source.get("gates") or {}
-
     def gate(name: str) -> str:
         return str((gates.get(name) or {}).get("status") or OPEN)
-
     blocked = "|".join(source.get("blocked_gates") or []) or "none"
     open_gates = "|".join(source.get("open_gates") or []) or "none"
     return "phase11_gate_status=" + ",".join([
@@ -173,6 +169,7 @@ def build_phase11_promotion_gate_evidence_line(status: dict[str, Any] | None) ->
         f"repeat:{gate('repeat_audit')}",
         f"trigger:{gate('formal_trigger_consistency')}",
         f"retention:{gate('retention')}",
+        f"intent_selection:{gate('intent_selection_alignment')}",
         f"diversity:{gate('comparison_diversity')}",
         f"profile:{gate('profile_consistency')}",
         f"blocked:{blocked}",

--- a/templates/internal/phase11_gates.html
+++ b/templates/internal/phase11_gates.html
@@ -44,7 +44,8 @@
       ('safety','Safety'),
       ('repeat_audit','Repeat audit'),
       ('formal_trigger_consistency','Formal trigger'),
-      ('retention','Retention'),
+      ('retention','Retention / J4'),
+      ('intent_selection_alignment','Intent vs exact-Q / J5'),
       ('comparison_diversity','Comparison diversity'),
       ('profile_consistency','Profile consistency')
     ] %}
@@ -74,15 +75,21 @@
     <p>STRONGはあるが現在cooldown制約中のNode {{ supply.cooldown_constrained_strong_node_count }} / recent Q {{ supply.recent_question_count }}</p>
     {% endif %}
     <p>upcoming repaired {{ supply.upcoming_repaired_node_count }} / upcomingでSTRONGなし {{ supply.upcoming_without_strong_count }} / weak-only {{ supply.weak_only_count }} / formal alternateなし {{ supply.no_formal_alternate_count }}</p>
-    <p class="muted">J4が自然発生する前に、retention referenceと別のSTRONG問題が存在するか、さらに現在の30回答Recent Cooldownを避けて使えるSTRONGがあるかを先行監査します。実際のQ選択と制御fallbackはPhase10が最終決定します。</p>
+  </section>
+
+  {% set align = intent_selection_alignment %}
+  <section class="card">
+    <h2>J5 Intent vs Exact-Q Alignment</h2>
+    <p>saved recheck {{ align.saved_recheck_selection_count }} / evaluable {{ align.evaluable_recheck_selection_count }} / aligned {{ align.aligned_recheck_selection_count }} / misaligned {{ align.misaligned_recheck_selection_count }} / not evaluable {{ align.not_evaluable_recheck_selection_count }}</p>
+    <p>retention-reference基準: STRONG {{ align.strong_retention_q_count }} / weak {{ align.weak_retention_q_count }} / same-Q {{ align.same_question_retention_q_count }} / recent repeat {{ align.recent_repeat_recheck_count }} / cooldown bypass {{ align.cooldown_bypass_recheck_count }}</p>
+    <p class="muted">保存された selection_reason=recheck_due の実回答だけを対象に、回答直前のformal retention referenceに対してPhase10の実QがSTRONGだったかを再検証します。Phase10の選択ロジック自体は変更しません。</p>
   </section>
 
   {% set outcomes = retention_outcomes %}
   <section class="card">
     <h2>Natural Retention Outcomes</h2>
     <p>自然なretention review {{ outcomes.review_attempt_count }} / stable {{ outcomes.stable_count }} / repairing {{ outcomes.repairing_count }} / still due {{ outcomes.still_due_count }}</p>
-    <p>STRONG {{ outcomes.strong_evidence_count }} / weak {{ outcomes.weak_evidence_count }} / same-Q {{ outcomes.same_question_count }} / 自信あり正解 {{ outcomes.confident_correct_count }}</p>
-    <p class="muted">各実回答の直前時点で formal state が recheck_due だったかを再生して数えます。repaired→stable が1回答内で起きても取りこぼしません。</p>
+    <p>STRONG {{ outcomes.strong_evidence_count }} / qualified STRONG {{ outcomes.qualified_strong_outcome_count }} / weak {{ outcomes.weak_evidence_count }} / same-Q {{ outcomes.same_question_count }}</p>
   </section>
 
   {% set repair = repair_effectiveness %}
@@ -98,13 +105,11 @@
     <p>回答 {{ load.answered_count }} / 正答率 {{ load.accuracy_percent if load.accuracy_percent is not none else '—' }}% / unique Q {{ load.unique_question_count }} / repeat {{ load.repeat_attempt_count }}</p>
     <p>初回正答率 {{ load.first_attempt_accuracy_percent if load.first_attempt_accuracy_percent is not none else '—' }}% / repeat正答率 {{ load.repeat_accuracy_percent if load.repeat_accuracy_percent is not none else '—' }}% / 誤答後repeat正答率 {{ load.repeat_after_wrong_accuracy_percent if load.repeat_after_wrong_accuracy_percent is not none else '—' }}%</p>
     <p>最大回答間隔 {{ load.max_inter_attempt_gap_minutes if load.max_inter_attempt_gap_minutes is not none else '—' }}分 / 先頭→末尾の50問ブロック差 {{ load.leading_to_trailing_full_block_accuracy_delta_pp if load.leading_to_trailing_full_block_accuracy_delta_pp is not none else '—' }}pt</p>
-    <p class="muted">同日累積の観測値であり、疲労・連続学習・停止判断を自動判定しません。</p>
   </section>
 
   <section class="card">
     <h2>Current formal state</h2>
     <p>checking {{ diagnostics.state_counts.checking }} / repairing {{ diagnostics.state_counts.repairing }} / repaired {{ diagnostics.state_counts.repaired }} / recheck_due {{ diagnostics.state_counts.recheck_due }} / stable {{ diagnostics.state_counts.stable }}</p>
-    <p>legacy timeline counter: recheck_due→stable {{ diagnostics.due_to_stable }} / recheck_due→repairing {{ diagnostics.due_to_repairing }}</p>
   </section>
 </main>
 </body>

--- a/tests/test_phase11_gate_ui.py
+++ b/tests/test_phase11_gate_ui.py
@@ -6,18 +6,13 @@ os.environ.setdefault("CHANNEL_ACCESS_TOKEN", "test-token")
 os.environ.setdefault("CHANNEL_SECRET", "test-secret")
 
 from flask import Flask
-
 import phase11_gate_ui
-
 
 ROOT = Path(__file__).resolve().parents[1]
 
 
 def _app():
-    app = Flask(
-        "phase11-gate-ui-test",
-        template_folder=str(ROOT / "templates"),
-    )
+    app = Flask("phase11-gate-ui-test", template_folder=str(ROOT / "templates"))
     phase11_gate_ui.install_phase11_gate_ui(app)
     return app
 
@@ -29,7 +24,7 @@ def test_gate_page_requires_internal_admin_token(monkeypatch):
     assert client.get("/internal/phase11-gates?token=wrong&learner_user_id=learner").status_code == 403
 
 
-def test_gate_page_renders_hold_retention_and_no_auto_promotion(monkeypatch):
+def test_gate_page_renders_hold_retention_j5_and_no_auto_promotion(monkeypatch):
     monkeypatch.setenv("LT_INTERNAL_ADMIN_TOKEN", "admin-secret")
     monkeypatch.setattr(
         phase11_gate_ui,
@@ -87,25 +82,38 @@ def test_gate_page_renders_hold_retention_and_no_auto_promotion(monkeypatch):
                 "upcoming_without_non_recent_strong_count": 4,
                 "cooldown_constrained_strong_node_count": 2,
             },
+            "intent_selection_alignment": {
+                "saved_recheck_selection_count": 0,
+                "evaluable_recheck_selection_count": 0,
+                "aligned_recheck_selection_count": 0,
+                "misaligned_recheck_selection_count": 0,
+                "not_evaluable_recheck_selection_count": 0,
+                "strong_retention_q_count": 0,
+                "weak_retention_q_count": 0,
+                "same_question_retention_q_count": 0,
+                "recent_repeat_recheck_count": 0,
+                "cooldown_bypass_recheck_count": 0,
+            },
             "retention_outcomes": {
                 "review_attempt_count": 0,
                 "stable_count": 0,
                 "repairing_count": 0,
                 "still_due_count": 0,
                 "strong_evidence_count": 0,
+                "qualified_strong_outcome_count": 0,
                 "weak_evidence_count": 0,
                 "same_question_count": 0,
-                "confident_correct_count": 0,
             },
             "gate_status": {
                 "decision": "hold",
                 "blocked_gates": [],
-                "open_gates": ["retention", "comparison_diversity"],
+                "open_gates": ["retention", "intent_selection_alignment", "comparison_diversity"],
                 "gates": {
                     "safety": {"status": "pass"},
                     "repeat_audit": {"status": "pass"},
                     "formal_trigger_consistency": {"status": "pass"},
                     "retention": {"status": "open"},
+                    "intent_selection_alignment": {"status": "open"},
                     "comparison_diversity": {"status": "open"},
                     "profile_consistency": {"status": "pass"},
                 },
@@ -124,8 +132,10 @@ def test_gate_page_renders_hold_retention_and_no_auto_promotion(monkeypatch):
     assert "upcomingでSTRONGなし 2" in html
     assert "upcomingで非recent STRONGなし 4" in html
     assert "cooldown制約中のNode 2" in html
+    assert "J5 Intent vs Exact-Q Alignment" in html
+    assert "saved recheck 0" in html
     assert "Natural Retention Outcomes" in html
-    assert "自然なretention review 0" in html
+    assert "qualified STRONG 0" in html
     assert "2026-09-09T08:26:32+09:00" in html
     assert "自動昇格なし" in html
     assert "learner-facing promotion allowed = false" in html

--- a/tests/test_phase11_intent_selection_alignment.py
+++ b/tests/test_phase11_intent_selection_alignment.py
@@ -1,0 +1,166 @@
+from datetime import datetime, timedelta, timezone
+
+import knowledge_node_state_transition as transition
+import phase11_intent_selection_alignment as audit
+from knowledge_node_repair_evidence import (
+    DIFFERENT_QUESTION_STRONG,
+    DIFFERENT_QUESTION_WEAK,
+    SAME_QUESTION,
+)
+
+
+BASE = datetime(2026, 9, 1, tzinfo=timezone.utc)
+
+
+def attempt(q, *, correct, confidence, day, event, position=1):
+    return {
+        "id": day * 100 + position,
+        "event_key": event,
+        "user_id": "learner",
+        "question_id": q,
+        "knowledge_node_id": "KN0001",
+        "selected_answers": ["1"],
+        "answer_status": "answered",
+        "is_correct": correct,
+        "confidence": confidence,
+        "answered_at": BASE + timedelta(days=day, minutes=position),
+        "attempt_position": position,
+    }
+
+
+def event(event_key, q, *, reason="recheck_due", repair_quality=None, recent=False, bypass=False):
+    return {
+        "event_key": event_key,
+        "question_results": [{
+            "question_id": q,
+            "selection_reason": reason,
+            "selection_group": "checking",
+            "selection_score": 700,
+            "repair_evidence_quality": repair_quality,
+            "recent_question_repeat": recent,
+            "recent_cooldown_bypassed": bypass,
+        }],
+    }
+
+
+def classifier(strong_pairs):
+    strong_pairs = set(strong_pairs)
+
+    def classify(old, new):
+        if old == new:
+            return SAME_QUESTION
+        return DIFFERENT_QUESTION_STRONG if (old, new) in strong_pairs else DIFFERENT_QUESTION_WEAK
+
+    return classify
+
+
+def install(monkeypatch, strong_pairs):
+    classify = classifier(strong_pairs)
+    monkeypatch.setattr(transition, "classify_repair_confirmation", classify)
+    monkeypatch.setattr(audit, "classify_repair_confirmation", classify)
+
+
+def repaired_history():
+    return [
+        attempt("Q1", correct=False, confidence=2, day=0, event="old:1"),
+        attempt("Q2", correct=True, confidence=1, day=1, event="repair:1"),
+    ]
+
+
+def test_recheck_exact_q_strong_vs_retention_reference_is_aligned(monkeypatch):
+    install(monkeypatch, {("Q1", "Q2"), ("Q2", "Q3")})
+    history = repaired_history() + [
+        attempt("Q3", correct=True, confidence=1, day=8, event="session:1")
+    ]
+    result = audit.build_phase11_intent_selection_alignment(
+        history,
+        [event("session:1", "Q3", repair_quality=DIFFERENT_QUESTION_WEAK)],
+    )
+    assert result["saved_recheck_selection_count"] == 1
+    assert result["evaluable_recheck_selection_count"] == 1
+    assert result["aligned_recheck_selection_count"] == 1
+    assert result["misaligned_recheck_selection_count"] == 0
+    assert result["strong_retention_q_count"] == 1
+    assert result["alignment_status"] == "pass"
+    # Important J5 fact: saved generic repair quality may disagree with the
+    # retention-reference-specific quality; retention reference is authoritative here.
+    assert result["details"][0]["saved_repair_evidence_quality"] == DIFFERENT_QUESTION_WEAK
+    assert result["details"][0]["retention_evidence_quality"] == DIFFERENT_QUESTION_STRONG
+
+
+def test_recheck_exact_q_weak_vs_retention_reference_is_misaligned(monkeypatch):
+    install(monkeypatch, {("Q1", "Q2")})
+    history = repaired_history() + [
+        attempt("Q3", correct=True, confidence=1, day=8, event="session:1")
+    ]
+    result = audit.build_phase11_intent_selection_alignment(
+        history,
+        [event("session:1", "Q3", repair_quality=DIFFERENT_QUESTION_STRONG)],
+    )
+    assert result["evaluable_recheck_selection_count"] == 1
+    assert result["aligned_recheck_selection_count"] == 0
+    assert result["misaligned_recheck_selection_count"] == 1
+    assert result["weak_retention_q_count"] == 1
+    assert result["alignment_status"] == "blocked"
+
+
+def test_recheck_same_reference_question_is_misaligned(monkeypatch):
+    install(monkeypatch, {("Q1", "Q2")})
+    history = repaired_history() + [
+        attempt("Q2", correct=True, confidence=1, day=8, event="session:1")
+    ]
+    result = audit.build_phase11_intent_selection_alignment(
+        history,
+        [event("session:1", "Q2", recent=True, bypass=True)],
+    )
+    assert result["same_question_retention_q_count"] == 1
+    assert result["misaligned_recheck_selection_count"] == 1
+    assert result["recent_repeat_recheck_count"] == 1
+    assert result["cooldown_bypass_recheck_count"] == 1
+    assert result["alignment_status"] == "blocked"
+
+
+def test_saved_recheck_is_open_when_answer_time_state_is_not_due(monkeypatch):
+    install(monkeypatch, {("Q1", "Q2"), ("Q2", "Q3")})
+    # day 7 is still repaired under the formal seven-day policy.
+    history = repaired_history() + [
+        attempt("Q3", correct=True, confidence=1, day=7, event="session:1")
+    ]
+    result = audit.build_phase11_intent_selection_alignment(
+        history,
+        [event("session:1", "Q3")],
+    )
+    assert result["saved_recheck_selection_count"] == 1
+    assert result["evaluable_recheck_selection_count"] == 0
+    assert result["not_evaluable_recheck_selection_count"] == 1
+    assert result["alignment_status"] == "open"
+
+
+def test_non_recheck_saved_rows_are_not_claimed_as_j5_evidence(monkeypatch):
+    install(monkeypatch, {("Q1", "Q2"), ("Q2", "Q3")})
+    history = repaired_history() + [
+        attempt("Q3", correct=True, confidence=1, day=8, event="session:1")
+    ]
+    result = audit.build_phase11_intent_selection_alignment(
+        history,
+        [event("session:1", "Q3", reason="checking")],
+    )
+    assert result["saved_recheck_selection_count"] == 0
+    assert result["alignment_status"] == "open"
+
+
+def test_evidence_line_is_aggregate_and_non_identifying(monkeypatch):
+    install(monkeypatch, {("Q1", "Q2"), ("Q2", "Q3")})
+    history = repaired_history() + [
+        attempt("Q3", correct=True, confidence=1, day=8, event="session:1")
+    ]
+    result = audit.build_phase11_intent_selection_alignment(
+        history,
+        [event("session:1", "Q3")],
+    )
+    result["user_id"] = "must-not-leak"
+    line = audit.build_intent_selection_alignment_evidence_line(result)
+    assert line.startswith("intent_selection_alignment=status:pass,saved_recheck:1")
+    assert "must-not-leak" not in line
+    assert "learner" not in line
+    assert "Q2" not in line and "Q3" not in line

--- a/tests/test_phase11_promotion_gate_status.py
+++ b/tests/test_phase11_promotion_gate_status.py
@@ -30,12 +30,15 @@ def _status(**overrides):
             "earliest_review_at_jst": "2026-09-09T08:26:32+09:00",
         },
         state_counts={"stable": 0},
-        transitions={
-            "recheck_due_to_stable": 0,
-            "recheck_due_to_repairing": 0,
-        },
-        shadow_judgment={
-            "comparison": {"shadow_reason_profile_consistent": True}
+        transitions={"recheck_due_to_stable": 0, "recheck_due_to_repairing": 0},
+        shadow_judgment={"comparison": {"shadow_reason_profile_consistent": True}},
+        intent_selection_alignment={
+            "alignment_status": "pass",
+            "saved_recheck_selection_count": 1,
+            "evaluable_recheck_selection_count": 1,
+            "aligned_recheck_selection_count": 1,
+            "misaligned_recheck_selection_count": 0,
+            "not_evaluable_recheck_selection_count": 0,
         },
     )
     kwargs.update(overrides)
@@ -51,8 +54,39 @@ def test_current_natural_shape_stays_hold_with_retention_and_diversity_open():
     assert result["gates"]["repeat_audit"]["status"] == PASS
     assert result["gates"]["formal_trigger_consistency"]["status"] == PASS
     assert result["gates"]["retention"]["status"] == OPEN
+    assert result["gates"]["intent_selection_alignment"]["status"] == PASS
     assert result["gates"]["comparison_diversity"]["status"] == OPEN
     assert set(result["open_gates"]) == {"retention", "comparison_diversity"}
+
+
+def test_j5_misalignment_blocks_promotion_review_status():
+    result = _status(
+        retention_outcome_audit={"review_attempt_count": 0},
+        intent_selection_alignment={
+            "alignment_status": "blocked",
+            "saved_recheck_selection_count": 1,
+            "evaluable_recheck_selection_count": 1,
+            "aligned_recheck_selection_count": 0,
+            "misaligned_recheck_selection_count": 1,
+        },
+    )
+    assert result["decision"] == "blocked"
+    assert result["gates"]["intent_selection_alignment"]["status"] == BLOCKED
+    assert "intent_selection_alignment" in result["blocked_gates"]
+    assert result["learner_facing_promotion_allowed"] is False
+
+
+def test_j5_without_evaluable_natural_recheck_stays_open():
+    result = _status(
+        retention_outcome_audit={"review_attempt_count": 0},
+        intent_selection_alignment={
+            "alignment_status": "open",
+            "saved_recheck_selection_count": 0,
+            "evaluable_recheck_selection_count": 0,
+        },
+    )
+    assert result["gates"]["intent_selection_alignment"]["status"] == OPEN
+    assert "intent_selection_alignment" in result["open_gates"]
 
 
 def test_safety_repeat_or_trigger_regression_blocks_without_enabling_promotion():
@@ -102,58 +136,43 @@ def test_qualified_strong_retention_outcome_and_direction_diversity_clear_checka
             "qualified_strong_outcome_count": 1,
         },
         state_counts={"stable": 1},
-        transitions={
-            "recheck_due_to_stable": 0,
-            "recheck_due_to_repairing": 0,
-        },
+        transitions={"recheck_due_to_stable": 0, "recheck_due_to_repairing": 0},
     )
     assert result["gates"]["retention"]["status"] == PASS
-    assert result["gates"]["retention"]["review_attempt_count"] == 1
     assert result["gates"]["retention"]["qualified_strong_outcome_count"] == 1
-    assert result["gates"]["retention"]["qualified_strong_retention_observed"] is True
     assert result["gates"]["comparison_diversity"]["status"] == PASS
+    assert result["gates"]["intent_selection_alignment"]["status"] == PASS
     assert result["automatically_clear"] is True
     assert result["decision"] == "hold"
     assert result["learner_facing_promotion_allowed"] is False
-    assert result["manual_review_required"] is True
 
 
 def test_weak_or_same_q_natural_review_does_not_false_pass_j4():
-    result = _status(
-        retention_outcome_audit={
-            "review_attempt_count": 2,
-            "stable_count": 0,
-            "repairing_count": 0,
-            "still_due_count": 2,
-            "qualified_strong_outcome_count": 0,
-        }
-    )
+    result = _status(retention_outcome_audit={
+        "review_attempt_count": 2,
+        "still_due_count": 2,
+        "qualified_strong_outcome_count": 0,
+    })
     assert result["gates"]["retention"]["natural_retention_observed"] is True
     assert result["gates"]["retention"]["qualified_strong_retention_observed"] is False
     assert result["gates"]["retention"]["status"] == OPEN
 
 
 def test_strong_but_still_due_review_does_not_false_pass_j4():
-    result = _status(
-        retention_outcome_audit={
-            "review_attempt_count": 1,
-            "still_due_count": 1,
-            "strong_still_due_count": 1,
-            "qualified_strong_outcome_count": 0,
-        }
-    )
+    result = _status(retention_outcome_audit={
+        "review_attempt_count": 1,
+        "still_due_count": 1,
+        "strong_still_due_count": 1,
+        "qualified_strong_outcome_count": 0,
+    })
     assert result["gates"]["retention"]["status"] == OPEN
-    assert result["gates"]["retention"]["strong_still_due_count"] == 1
 
 
 def test_explicit_zero_review_does_not_use_legacy_stable_or_timeline_as_false_pass():
     result = _status(
         retention_outcome_audit={"review_attempt_count": 0},
         state_counts={"stable": 5},
-        transitions={
-            "recheck_due_to_stable": 4,
-            "recheck_due_to_repairing": 2,
-        },
+        transitions={"recheck_due_to_stable": 4, "recheck_due_to_repairing": 2},
     )
     assert result["gates"]["retention"]["status"] == OPEN
     assert result["gates"]["retention"]["natural_retention_observed"] is False
@@ -166,9 +185,6 @@ def test_evidence_line_is_non_identifying_and_never_says_promotion_allowed_true(
     line = build_phase11_promotion_gate_evidence_line(result)
     assert line.startswith("phase11_gate_status=decision:hold")
     assert "retention:open" in line
-    assert "diversity:open" in line
+    assert "intent_selection:pass" in line
     assert "promotion_allowed:false" in line
-    assert "manual_review_required:true" in line
     assert "must-not-leak" not in line
-    assert "user_id" not in line
-    assert "token" not in line


### PR DESCRIPTION
## Summary
- add a read-only J5 audit joining persisted adaptive selection metadata to formal attempt history
- for saved `selection_reason=recheck_due`, revalidate the exact answered Q against the formal retention reference immediately before answer time
- classify STRONG as aligned, weak/same-Q as misaligned, and state-changed cases as not evaluable
- add a conservative J5 promotion gate: BLOCKED on observed misalignment, PASS only with evaluable aligned evidence, otherwise OPEN
- show J5 counts on the internal Phase11 Gate Status page

## Important finding encoded by the audit
The selector's saved generic `repair_evidence_quality` is based on historical wrong-question evidence. J4 needs a different question-specific check: exact Q vs the current retention reference. This audit treats the formal retention reference as authoritative for J5 without changing Phase10 behavior.

## Safety boundary
- read-only diagnostics/gate evaluation only
- no selector/ranking/Safety/Recent Cooldown behavior change
- no Node-state mutation
- no Question Bank change
- no DB write or migration
- no learner-facing recommendation change or automatic promotion