### PR TITLE
Add J5 alignment to internal Phase11 evidence bundle

### DIFF
--- a/developer_ui.py
+++ b/developer_ui.py
@@ -27,6 +27,10 @@ from feedback_store import (
 )
 from goukaku_ui import build_dashboard
 from knowledge_node_state_transition import derive_all_user_node_states
+from phase11_intent_selection_alignment import (
+    build_intent_selection_alignment_evidence_line,
+    build_phase11_intent_selection_alignment,
+)
 from phase11_promotion_gate_status import (
     build_phase11_promotion_gate_evidence_line,
     build_phase11_promotion_gate_status,
@@ -241,19 +245,22 @@ def register_developer_routes(blueprint) -> None:
             period = "7"
         diagnostics = build_pilot_diagnostics(learner_id, period)
         attempts = get_question_attempts(learner_id)
+        learning_events = get_learning_events(learner_id)
         node_states = derive_all_user_node_states(attempts)
         same_day_session_load = build_same_day_session_load_facts(attempts)
-        repair_effectiveness = build_same_day_repair_effectiveness_facts(
-            get_learning_events(learner_id)
-        )
+        repair_effectiveness = build_same_day_repair_effectiveness_facts(learning_events)
         retention_horizon = build_retention_horizon_facts(node_states)
         retention_outcomes = build_retention_outcome_audit(attempts)
         retention_supply = build_retention_supply_audit(node_states, attempts=attempts)
+        intent_selection_alignment = build_phase11_intent_selection_alignment(
+            attempts, learning_events
+        )
         promotion_gate_status = build_phase11_promotion_gate_status(
             retrospective_shadow_audit=diagnostics.get("retrospective_shadow_audit"),
             repeat_structure_audit=diagnostics.get("repeat_structure_audit"),
             retention_horizon=retention_horizon,
             retention_outcome_audit=retention_outcomes,
+            intent_selection_alignment=intent_selection_alignment,
             state_counts=diagnostics.get("state_counts"),
             transitions={
                 "recheck_due_to_stable": diagnostics.get("due_to_stable", 0),
@@ -266,6 +273,7 @@ def register_developer_routes(blueprint) -> None:
         diagnostics["retention_horizon"] = retention_horizon
         diagnostics["retention_outcomes"] = retention_outcomes
         diagnostics["retention_supply"] = retention_supply
+        diagnostics["intent_selection_alignment"] = intent_selection_alignment
         diagnostics["promotion_gate_status"] = promotion_gate_status
         diagnostics["promotion_evidence_text"] = (
             str(diagnostics.get("promotion_evidence_text") or "").rstrip()
@@ -279,6 +287,8 @@ def register_developer_routes(blueprint) -> None:
             + build_retention_outcome_evidence_line(retention_outcomes)
             + "\n"
             + build_retention_supply_evidence_line(retention_supply)
+            + "\n"
+            + build_intent_selection_alignment_evidence_line(intent_selection_alignment)
             + "\n"
             + build_phase11_promotion_gate_evidence_line(promotion_gate_status)
         ).lstrip("\n")


### PR DESCRIPTION
## Summary
- compute J5 intent-selection alignment on the detailed internal diagnostics route
- add the aggregate J5 evidence line to `promotion_evidence_text`
- pass the same J5 audit into the conservative promotion gate status

## Safety boundary
- internal/read-only only
- no selector, Node state, Question Bank, DB write, learner-facing recommendation, or promotion behavior change