### PR TITLE
Restore separate developer and learner QA access

### DIFF
--- a/developer_access_recovery.py
+++ b/developer_access_recovery.py
@@ -1,0 +1,89 @@
+"""Internal-only recovery hub for LicenseTown developer and learner QA views."""
+
+from __future__ import annotations
+
+from urllib.parse import parse_qs, urlsplit
+
+from flask import abort, render_template, request, url_for
+
+from developer_ui import require_developer_authorization
+from goukaku_ui import authorized_supporter_learner
+
+
+ROUTE = "/internal/recovery"
+ENDPOINT = "internal_recovery"
+
+
+def _supporter_token_from_input(value: str) -> str:
+    raw = str(value or "").strip()
+    if not raw:
+        return ""
+    if "://" not in raw:
+        return raw
+    try:
+        query = parse_qs(urlsplit(raw).query, keep_blank_values=False)
+    except ValueError:
+        return ""
+    values = query.get("token") or []
+    return str(values[0]).strip() if values else ""
+
+
+def install_developer_access_recovery(app) -> None:
+    if ENDPOINT in app.view_functions:
+        return
+
+    def internal_recovery():
+        token = require_developer_authorization()
+        learner_id = str(request.args.get("learner_user_id") or "").strip()
+        supporter_input = str(request.args.get("supporter") or "").strip()
+        error = ""
+
+        if supporter_input and not learner_id:
+            supporter_token = _supporter_token_from_input(supporter_input)
+            if not supporter_token:
+                error = "見守りURLまたはsupporter tokenを確認してください。"
+            else:
+                try:
+                    _, learner_id = authorized_supporter_learner(supporter_token)
+                except Exception as exc:
+                    code = getattr(exc, "code", None)
+                    if code in {403, 404}:
+                        error = "見守りURLから学習者を確認できませんでした。"
+                    else:
+                        raise
+
+        urls = None
+        if learner_id:
+            urls = {
+                "developer": url_for(
+                    "site_ui.internal_index",
+                    token=token,
+                    learner_user_id=learner_id,
+                ),
+                "preview": url_for(
+                    "site_ui.internal_learner_preview",
+                    token=token,
+                    learner_user_id=learner_id,
+                ),
+                "diagnostics": url_for(
+                    "site_ui.internal_pilot_diagnostics",
+                    token=token,
+                    learner_user_id=learner_id,
+                ),
+                "phase11": url_for(
+                    "internal_phase11_gates",
+                    token=token,
+                    learner_user_id=learner_id,
+                ),
+            }
+
+        return render_template(
+            "internal/recovery.html",
+            internal_token=token,
+            learner_id=learner_id,
+            supporter_input=supporter_input,
+            error=error,
+            urls=urls,
+        )
+
+    app.add_url_rule(ROUTE, ENDPOINT, internal_recovery, methods=["GET"])

--- a/templates/internal/recovery.html
+++ b/templates/internal/recovery.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>LicenseTown 開発者アクセス</title>
+  <style>
+    :root{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;color:#173d2d;background:#f4f7f5}
+    body{margin:0}main{width:min(860px,calc(100% - 28px));margin:28px auto 56px}.card{background:#fff;border:1px solid #dce7e0;border-radius:16px;padding:20px;box-shadow:0 8px 24px rgba(24,61,45,.06);margin-top:14px}h1{margin:0 0 6px;font-size:26px}h2{margin:0 0 12px}.muted{color:#65746b;line-height:1.65}.warn{color:#a66200;font-weight:700}.grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:12px}.action{display:block;padding:16px;border-radius:14px;text-decoration:none;font-weight:800;border:1px solid #d6e5dc;background:#f6fbf8;color:#176b42}.action strong{display:block;font-size:18px;margin-bottom:4px}.action span{display:block;color:#5e6f65;font-size:13px;font-weight:500}.action.primary{background:#176b42;color:#fff;border-color:#176b42}.action.primary span{color:#e6f4ec}form{display:grid;gap:10px}input{box-sizing:border-box;width:100%;padding:12px 13px;border:1px solid #afbeb5;border-radius:10px;font-size:15px}button{justify-self:start;border:0;border-radius:10px;padding:11px 16px;background:#176b42;color:#fff;font-weight:800;cursor:pointer}.id{font-family:ui-monospace,SFMono-Regular,Consolas,monospace;word-break:break-all;background:#f5f7f6;border-radius:8px;padding:8px}.note{padding:12px;border-radius:10px;background:#fff8e8;color:#72551d}@media(max-width:620px){.grid{grid-template-columns:1fr}.card{padding:16px}h1{font-size:22px}}
+  </style>
+</head>
+<body>
+<main>
+  <h1>LicenseTown 開発者アクセス</h1>
+  <p class="muted">親向け「学習見守り」と完全に分けた、開発・確認専用の入口です。一般の親画面には表示されません。</p>
+
+  <section class="card">
+    <h2>息子さんの画面を呼び出す</h2>
+    <p class="muted">今開いている「学習見守り」のURLを、そのまま貼れば対象学習者を自動で判定します。learner_user_id が分かる場合は直接入力でもOKです。</p>
+    <form method="get">
+      <input type="hidden" name="token" value="{{ internal_token }}">
+      <label>見守りURL / supporter token
+        <input name="supporter" value="{{ supporter_input }}" placeholder="https://.../supporter?token=...">
+      </label>
+      <label>learner_user_id（分かる場合だけ）
+        <input name="learner_user_id" value="{{ learner_id }}" placeholder="空欄でOK">
+      </label>
+      <button type="submit">対象を開く</button>
+    </form>
+    {% if error %}<p class="warn">{{ error }}</p>{% endif %}
+  </section>
+
+  {% if urls %}
+  <section class="card">
+    <h2>開発用ショートカット</h2>
+    <p class="muted">対象 learner_user_id</p>
+    <p class="id">{{ learner_id }}</p>
+    <div class="grid">
+      <a class="action primary" href="{{ urls.preview }}"><strong>本人のリアル画面</strong><span>現在の実データで「合格への道」をそのまま確認</span></a>
+      <a class="action" href="{{ urls.developer }}"><strong>開発者向け画面</strong><span>内部ダッシュボード・各開発ツールへの入口</span></a>
+      <a class="action" href="{{ urls.diagnostics }}"><strong>学習診断</strong><span>Phase11・repeat・cooldown などの詳細確認</span></a>
+      <a class="action" href="{{ urls.phase11 }}"><strong>Phase11 Gate Status</strong><span>自然データのGate・retention・repair確認</span></a>
+    </div>
+    <p class="note">このページと各リンクは LT_INTERNAL_ADMIN_TOKEN で保護されています。親向け画面には出しません。</p>
+  </section>
+  {% endif %}
+</main>
+</body>
+</html>

--- a/tests/test_developer_access_recovery_v01.py
+++ b/tests/test_developer_access_recovery_v01.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_recovery_hub_is_internal_token_protected_and_separate():
+    source = (ROOT / "developer_access_recovery.py").read_text(encoding="utf-8")
+    assert 'ROUTE = "/internal/recovery"' in source
+    assert "require_developer_authorization()" in source
+    assert "authorized_supporter_learner" in source
+    assert '"site_ui.internal_learner_preview"' in source
+    assert '"site_ui.internal_pilot_diagnostics"' in source
+    assert '"internal_phase11_gates"' in source
+
+
+def test_recovery_hub_is_installed_in_production_composition():
+    source = (ROOT / "wsgi.py").read_text(encoding="utf-8")
+    assert "from developer_access_recovery import install_developer_access_recovery" in source
+    assert "install_developer_access_recovery(legacy.app)" in source
+
+
+def test_recovery_template_has_two_primary_recovery_destinations():
+    html = (ROOT / "templates" / "internal" / "recovery.html").read_text(encoding="utf-8")
+    assert "本人のリアル画面" in html
+    assert "開発者向け画面" in html
+    assert "一般の親画面には表示されません" in html

--- a/wsgi.py
+++ b/wsgi.py
@@ -24,6 +24,7 @@ from linebot.models import (
 
 from daily_wrong_review import REVIEW_COMMAND, install_daily_wrong_review
 from dashboard_progress_trend import install_dashboard_progress_trend
+from developer_access_recovery import install_developer_access_recovery
 from phase11_gate_ui import install_phase11_gate_ui
 from prerequisite_attempt_cache import install_prerequisite_attempt_cache
 from site_marketing_hotfix import install_site_marketing_hotfix
@@ -109,6 +110,7 @@ install_site_marketing_hotfix(legacy.app)
 install_site_marketing_refresh(legacy.app)
 install_phase11_gate_ui(legacy.app)
 install_supporter_learner_preview_bridge(legacy.app)
+install_developer_access_recovery(legacy.app)
 
 _apply_rich_menu_v2_if_requested()
 


### PR DESCRIPTION
## Goal
Restore immediate access to the two views needed for LT development without putting detailed learner controls back into the parent-facing 学習見守り page.

## Changes
- Adds `/internal/recovery`, protected by existing `LT_INTERNAL_ADMIN_TOKEN` authorization.
- Accepts the current supporter URL/token and resolves the linked learner safely.
- Provides direct shortcuts to:
  - 本人のリアル画面
  - 開発者向け画面
  - 学習診断
  - Phase11 Gate Status
- Keeps the parent-facing supporter page unchanged and clean.
- No DB migration/write, learner-state change, AI call, or billing change.