### PR TITLE
Open LINE directly from HP start CTA

### DIFF
--- a/site_direct_line_cta.py
+++ b/site_direct_line_cta.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import re
+from html import escape
+
+from flask import request
+
+from site_marketing_refresh import _onboarding_url
+
+
+DIRECT_CTA_STYLE = """<style id="site-direct-line-cta-v01">
+.marketing-line-button{box-shadow:0 5px 14px rgba(7,131,41,.18)!important}
+@media(max-width:760px){
+  .marketing-mobile-free .marketing-line-start{display:flex!important;flex-direction:column!important;gap:8px!important}
+  .marketing-mobile-free .marketing-line-start>div{order:1!important;width:100%!important}
+  .marketing-mobile-free .marketing-line-qr{order:2!important;margin-top:7px!important}
+  .marketing-mobile-free .marketing-line-button{display:block!important;width:min(360px,100%)!important;margin:0 auto!important;padding:14px 18px!important;font-size:16px!important}
+  .marketing-mobile-free .marketing-qr-help{display:block!important;margin:7px 0 0!important;font-size:9px!important}
+  .marketing-mobile-free .marketing-qr-help:before{content:'スマホで見ている方は、上のボタンからそのままLINEを開けます。';display:block;margin-bottom:5px;color:#087d2d;font-weight:700}
+  .marketing-mobile-free .marketing-line-qr{width:104px!important;height:104px!important;opacity:.92}
+}
+</style>"""
+
+
+def _apply_direct_line_cta(html: str, page_path: str) -> str:
+    target = _onboarding_url()
+    if not target:
+        return html
+
+    escaped_target = escape(target, quote=True)
+    modal_href = re.escape(f'{page_path}#line-start-panel')
+    html = re.sub(
+        rf'<a class="marketing-line-button" href="{modal_href}">LINEで無料ではじめる　›</a>',
+        f'<a class="marketing-line-button" href="{escaped_target}" target="_blank" rel="noopener noreferrer">LINEで無料ではじめる　›</a>',
+        html,
+        count=1,
+    )
+    html = re.sub(r'<style id="site-direct-line-cta-v01">.*?</style>', '', html, flags=re.DOTALL)
+    return html.replace('</head>', DIRECT_CTA_STYLE + '</head>', 1)
+
+
+def install_site_direct_line_cta(app) -> None:
+    @app.after_request
+    def apply_site_direct_line_cta(response):
+        if response.status_code != 200 or response.mimetype != 'text/html' or response.direct_passthrough:
+            return response
+        if request.path not in {'/site/view/pc', '/site/view/mobile'}:
+            return response
+        html = response.get_data(as_text=True)
+        response.set_data(_apply_direct_line_cta(html, request.path))
+        response.headers['Content-Length'] = str(len(response.get_data()))
+        return response

--- a/tests/test_site_direct_line_cta_v01.py
+++ b/tests/test_site_direct_line_cta_v01.py
@@ -1,0 +1,54 @@
+from flask import Flask
+
+from site_direct_line_cta import install_site_direct_line_cta
+from site_marketing_hotfix import install_site_marketing_hotfix
+from site_marketing_refresh import install_site_marketing_refresh
+
+
+def _app(monkeypatch):
+    monkeypatch.setenv("SITE_ONBOARDING_URL", "https://example.com/line-start")
+    app = Flask(__name__)
+    app.add_url_rule(
+        "/site/view/pc",
+        "pc",
+        lambda: '''<html><head></head><body>
+        <article class="faq-panel marketing-faq-panel" id="faq">
+          <div class="marketing-faq-list"><details><summary>old</summary><p class="faq-answer">old</p></details></div>
+          <a class="marketing-contact-link" href="/site/faq">その他の質問はこちら　›</a>
+        </article>
+        <a class="marketing-line-button" href="https://example.com/line-start">LINEで無料ではじめる　›</a>
+        <img class="marketing-line-qr" src="/site/line-qr.svg">
+        </body></html>''',
+    )
+    app.add_url_rule(
+        "/site/view/mobile",
+        "mobile",
+        lambda: '''<html><head></head><body>
+        <a class="marketing-line-button" href="https://example.com/line-start">LINEで無料ではじめる　›</a>
+        <img class="marketing-line-qr" src="/site/line-qr.svg">
+        </body></html>''',
+    )
+    # Flask after_request handlers run in reverse registration order.
+    # Match Production: direct pass runs after hotfix and refresh.
+    install_site_direct_line_cta(app)
+    install_site_marketing_hotfix(app)
+    install_site_marketing_refresh(app)
+    return app
+
+
+def test_final_cta_goes_straight_to_verified_line_url(monkeypatch):
+    html = _app(monkeypatch).test_client().get("/site/view/pc").get_data(as_text=True)
+    assert 'class="marketing-line-button" href="https://example.com/line-start"' in html
+    assert 'target="_blank" rel="noopener noreferrer"' in html
+    assert '/site/view/pc#line-start-panel">LINEで無料ではじめる' not in html
+    assert '/site/line-qr.svg' in html
+
+
+def test_mobile_direct_button_is_primary_and_qr_remains_secondary(monkeypatch):
+    html = _app(monkeypatch).test_client().get("/site/view/mobile").get_data(as_text=True)
+    assert 'class="marketing-line-button" href="https://example.com/line-start"' in html
+    assert 'site-direct-line-cta-v01' in html
+    assert '.marketing-mobile-free .marketing-line-start>div{order:1!important' in html
+    assert '.marketing-mobile-free .marketing-line-qr{order:2!important' in html
+    assert 'スマホで見ている方は、上のボタンからそのままLINEを開けます。' in html
+    assert '/site/line-qr.svg' in html

--- a/wsgi.py
+++ b/wsgi.py
@@ -28,6 +28,7 @@ from dashboard_progress_trend import install_dashboard_progress_trend
 from developer_access_recovery import install_developer_access_recovery
 from phase11_gate_ui import install_phase11_gate_ui
 from prerequisite_attempt_cache import install_prerequisite_attempt_cache
+from site_direct_line_cta import install_site_direct_line_cta
 from site_marketing_hotfix import install_site_marketing_hotfix
 from site_marketing_refresh import install_site_marketing_refresh
 from site_marketing_viewport_fix import install_site_marketing_viewport_fix
@@ -115,8 +116,11 @@ install_daily_wrong_review(legacy)
 legacy.create_text_response = create_text_response
 legacy.create_home_message = create_home_message
 # Flask executes after_request handlers in reverse registration order.
-# Register the viewport pass first so it runs last, after refresh + hotfix.
+# Register the viewport pass first so it runs last. The direct CTA pass is
+# registered before hotfix so it runs after hotfix and restores the verified
+# onboarding link as the final public action.
 install_site_marketing_viewport_fix(legacy.app)
+install_site_direct_line_cta(legacy.app)
 install_site_marketing_hotfix(legacy.app)
 install_site_marketing_refresh(legacy.app)
 install_phase11_gate_ui(legacy.app)


### PR DESCRIPTION
スマホでLicenseTown HPを見ている利用者が、同じ端末上のQRコードに詰まらず1タップでLINE友だち追加へ進めるようにします。

- 既存の verified `SITE_ONBOARDING_URL` をそのまま利用
- HPの「LINEで無料ではじめる」を中間モーダルではなくLINEへ直接接続
- スマホではボタンを主役、QRを補助表示に変更
- PCではQRを残し、ボタンも併設
- 新規外部サービス・課金・DB変更なし
- 既存のFAQ/LINE開始補助ページは維持