### PR TITLE
Add one-question starter and align beta messaging

### DIFF
--- a/one_question_starter.py
+++ b/one_question_starter.py
@@ -1,1 +1,69 @@
-x
+from __future__ import annotations
+
+import time
+
+from linebot.models import MessageAction, QuickReplyButton
+from question_bank import select_random_questions
+
+
+ONE_QUESTION_COMMAND = "源さんと1問だけ"
+
+
+def install_one_question_starter(legacy) -> None:
+    """Add a safe one-question learning entry without changing the normal 5/30 flow."""
+    original_process_study_flow_command = legacy.process_study_flow_command
+
+    def start_one_question(reply_token, user_id):
+        questions = select_random_questions(1)
+        question = questions[0]
+        now = time.time()
+        legacy.user_modes[user_id] = "study"
+        legacy.quiz_category_selections.pop(user_id, None)
+        legacy.study_sessions[user_id] = {
+            "session_id": str(time.time_ns()),
+            "status": "waiting_for_answers",
+            "current_set": 1,
+            "question_count": 1,
+            "questions_per_set": 1,
+            "total_sets": 1,
+            "questions": [question],
+            "all_questions": [question],
+            "all_answers": {},
+            "expected_numbers": [1],
+            "mode": "study",
+            "started_at": now,
+            "active_started_at": now,
+            "nekketsu_correct": 0,
+            "category_small": None,
+            "session_kind": "one_question_starter",
+        }
+        legacy.reply_current_quiz(
+            reply_token,
+            legacy.study_sessions[user_id],
+            intro_text=(
+                "30問やれとは言わんｗ\n"
+                "まず1問だけ付き合え＾＾\n"
+                "これで今日の一歩は始まるぞ。"
+            ),
+        )
+
+    def process_study_flow_command(reply_token, user_id, user_message):
+        if str(user_message).strip() == ONE_QUESTION_COMMAND:
+            try:
+                start_one_question(reply_token, user_id)
+            except Exception:
+                legacy.logging.exception("One-question starter failed: user_id=%s", user_id)
+                legacy.reply_to_line(
+                    reply_token,
+                    "おう、悪い。1問の準備でズッコケたｗ\n少し待って、もう一度押してくれ＾＾",
+                )
+            return True
+        return original_process_study_flow_command(reply_token, user_id, user_message)
+
+    legacy.process_study_flow_command = process_study_flow_command
+
+
+def one_question_quick_reply_item():
+    return QuickReplyButton(
+        action=MessageAction(label="☝️ 源さんと1問だけ", text=ONE_QUESTION_COMMAND)
+    )

--- a/site_beta_copy.py
+++ b/site_beta_copy.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from flask import request
+
+
+_REPLACEMENTS = (
+    (
+        "現在は検証期間中のため、利用料金はいただいていません。実際に使っていただきながら改善を続けています。",
+        "現在はβ期間のため、完全版の機能を無料で開放しています。実際に使っていただきながら改善を続けています。",
+    ),
+    (
+        "ありません。将来、有料化する場合は事前にHPなどでお知らせします。知らないうちに料金が発生することはありません。",
+        "ありません。正式リリース後は一部機能を月額プランにする予定ですが、料金が発生する場合は事前にHPなどでお知らせします。知らないうちに料金が発生することはありません。",
+    ),
+    ("検証期間中 無料公開", "β期間中 完全版を無料開放"),
+    (
+        "LicenseTownは現在、実際に使っていただきながら改善を続けています。<br>検証期間中は利用料金をいただいていません。",
+        "LicenseTownは現在、実際に使っていただきながら改善を続けています。<br>β期間中は完全版の機能を無料で開放しています。",
+    ),
+    (
+        "※将来、有料化する場合は事前にHPなどでお知らせします。知らないうちに料金が発生することはありません。",
+        "※正式リリース後は一部機能を月額プランにする予定です。料金が発生する場合は事前にご案内し、知らないうちに課金されることはありません。",
+    ),
+    (
+        "LicenseTownは現在、検証期間中のため無料で利用できます。",
+        "LicenseTownは現在β期間中のため、完全版の機能を無料で利用できます。",
+    ),
+)
+
+
+def install_site_beta_copy(app) -> None:
+    @app.after_request
+    def apply_site_beta_copy(response):
+        if response.status_code != 200 or response.mimetype != "text/html" or response.direct_passthrough:
+            return response
+        if request.path not in {"/site/view/pc", "/site/view/mobile", "/site/line-start"}:
+            return response
+        html = response.get_data(as_text=True)
+        for before, after in _REPLACEMENTS:
+            html = html.replace(before, after)
+        response.set_data(html)
+        response.headers["Content-Length"] = str(len(response.get_data()))
+        return response

--- a/tests/test_one_question_starter.py
+++ b/tests/test_one_question_starter.py
@@ -1,1 +1,57 @@
-# placeholder
+from types import SimpleNamespace
+
+import one_question_starter as starter
+
+
+def test_one_question_command_builds_single_question_session(monkeypatch):
+    captured = {}
+    question = {
+        "id": "Q1",
+        "question": "test",
+        "choices": {"A": "a", "B": "b"},
+        "answer": "A",
+    }
+    monkeypatch.setattr(starter, "select_random_questions", lambda count: [question])
+
+    legacy = SimpleNamespace(
+        process_study_flow_command=lambda *args: False,
+        user_modes={},
+        quiz_category_selections={"u1": {"category_small": "old"}},
+        study_sessions={},
+        reply_current_quiz=lambda reply_token, session, intro_text=None: captured.update(
+            reply_token=reply_token, session=session, intro_text=intro_text
+        ),
+        logging=__import__("logging"),
+        reply_to_line=lambda *args: None,
+    )
+    starter.install_one_question_starter(legacy)
+
+    assert legacy.process_study_flow_command("r1", "u1", starter.ONE_QUESTION_COMMAND) is True
+    session = legacy.study_sessions["u1"]
+    assert session["question_count"] == 1
+    assert session["questions_per_set"] == 1
+    assert session["total_sets"] == 1
+    assert session["expected_numbers"] == [1]
+    assert session["session_kind"] == "one_question_starter"
+    assert session["questions"] == [question]
+    assert legacy.user_modes["u1"] == "study"
+    assert "u1" not in legacy.quiz_category_selections
+    assert captured["reply_token"] == "r1"
+    assert "まず1問だけ" in captured["intro_text"]
+
+
+def test_other_commands_fall_through():
+    calls = []
+    legacy = SimpleNamespace(
+        process_study_flow_command=lambda *args: calls.append(args) or "original",
+        user_modes={},
+        quiz_category_selections={},
+        study_sessions={},
+        reply_current_quiz=lambda *args, **kwargs: None,
+        logging=__import__("logging"),
+        reply_to_line=lambda *args: None,
+    )
+    starter.install_one_question_starter(legacy)
+
+    assert legacy.process_study_flow_command("r", "u", "勉強する") == "original"
+    assert calls == [("r", "u", "勉強する")]

--- a/tests/test_site_beta_copy.py
+++ b/tests/test_site_beta_copy.py
@@ -1,0 +1,27 @@
+from flask import Flask
+
+from site_beta_copy import install_site_beta_copy
+
+
+def test_public_hp_beta_copy_is_explicit():
+    app = Flask(__name__)
+    app.add_url_rule(
+        "/site/view/pc",
+        "pc",
+        lambda: (
+            "<html><body>"
+            "検証期間中 無料公開"
+            "LicenseTownは現在、実際に使っていただきながら改善を続けています。<br>"
+            "検証期間中は利用料金をいただいていません。"
+            "※将来、有料化する場合は事前にHPなどでお知らせします。"
+            "知らないうちに料金が発生することはありません。"
+            "</body></html>"
+        ),
+    )
+    install_site_beta_copy(app)
+
+    html = app.test_client().get("/site/view/pc").get_data(as_text=True)
+    assert "β期間中 完全版を無料開放" in html
+    assert "β期間中は完全版の機能を無料で開放しています" in html
+    assert "正式リリース後は一部機能を月額プランにする予定です" in html
+    assert "知らないうちに課金されることはありません" in html

--- a/tests/test_site_public_interactions.py
+++ b/tests/test_site_public_interactions.py
@@ -46,7 +46,7 @@ def test_mobile_faq_has_compact_answer_preview_and_single_open_accordion_behavio
     css = client.get("/site/preview-responsive/mobile.css").get_data(as_text=True)
 
     assert html.count('class="faq-answer"') == 3
-    assert "検証期間中のため、利用料金はいただいていません" in html
+    assert "β期間のため、完全版の機能を無料で開放しています" in html
     assert "理学療法士国家試験に向けて" in html
     assert (
         'href="/site/view/mobile#faq-all-panel">その他の質問はこちら' in html

--- a/wsgi.py
+++ b/wsgi.py
@@ -29,6 +29,7 @@ from developer_access_recovery import install_developer_access_recovery
 from one_question_starter import install_one_question_starter, one_question_quick_reply_item
 from phase11_gate_ui import install_phase11_gate_ui
 from prerequisite_attempt_cache import install_prerequisite_attempt_cache
+from site_beta_copy import install_site_beta_copy
 from site_direct_line_cta import install_site_direct_line_cta
 from site_marketing_hotfix import install_site_marketing_hotfix
 from site_marketing_refresh import install_site_marketing_refresh
@@ -137,9 +138,8 @@ legacy.create_text_response = create_text_response
 legacy.create_home_message = create_home_message
 legacy.reply_new_user_welcome = reply_new_user_welcome
 # Flask executes after_request handlers in reverse registration order.
-# Register the viewport pass first so it runs last. The direct CTA pass is
-# registered before hotfix so it runs after hotfix and restores the verified
-# onboarding link as the final public action.
+# Register beta copy first so it runs last and normalizes final public wording.
+install_site_beta_copy(legacy.app)
 install_site_marketing_viewport_fix(legacy.app)
 install_site_direct_line_cta(legacy.app)
 install_site_marketing_hotfix(legacy.app)

--- a/wsgi.py
+++ b/wsgi.py
@@ -26,6 +26,7 @@ from linebot.models import (
 from daily_wrong_review import REVIEW_COMMAND, install_daily_wrong_review
 from dashboard_progress_trend import install_dashboard_progress_trend
 from developer_access_recovery import install_developer_access_recovery
+from one_question_starter import install_one_question_starter, one_question_quick_reply_item
 from phase11_gate_ui import install_phase11_gate_ui
 from prerequisite_attempt_cache import install_prerequisite_attempt_cache
 from site_direct_line_cta import install_site_direct_line_cta
@@ -61,6 +62,7 @@ def create_home_message(user_id=None):
                 label="📊 合格への道",
                 uri=dashboard_url,
             )),
+            one_question_quick_reply_item(),
             QuickReplyButton(action=MessageAction(
                 label="📘 勉強する！",
                 text="勉強する",
@@ -78,6 +80,23 @@ def create_home_message(user_id=None):
                 text="熱血モード",
             )),
         ]),
+    )
+
+
+def reply_new_user_welcome(reply_token):
+    """Explain the beta offer clearly before handing the learner to Gensan."""
+    legacy.reply_to_line(
+        reply_token,
+        (
+            "ようこそ、ライセンスタウンへ！\n\n"
+            "LicenseTownは、理学療法士国家試験の合格までを一緒に歩く学習サービスです。\n\n"
+            "【現在はβ期間】\n"
+            "いまは改善に協力してもらう期間なので、完全版の機能を無料で開放しています。\n"
+            "正式リリース後は、一部機能を月額プランにする予定です。"
+            "料金が発生する場合は事前に案内し、知らないうちに課金されることはありません。\n\n"
+            "まずは気軽に使ってみてください＾＾\n"
+            "それでは、ここからは源さんにバトンタッチします！"
+        ),
     )
 
 
@@ -99,6 +118,7 @@ def _apply_rich_menu_v2_if_requested() -> None:
 # call time, so production behavior can be composed without rewriting app.py.
 install_prerequisite_attempt_cache(legacy)
 install_dashboard_progress_trend(legacy, goukaku_module)
+install_one_question_starter(legacy)
 # Preview helpers imported build_dashboard by value before composition. Rebind
 # them to the same decorated builder used by the live learner route.
 supporter_preview_module.build_dashboard = goukaku_module.build_dashboard
@@ -115,6 +135,7 @@ developer_ui_module.build_dashboard = _build_full_developer_preview_dashboard
 install_daily_wrong_review(legacy)
 legacy.create_text_response = create_text_response
 legacy.create_home_message = create_home_message
+legacy.reply_new_user_welcome = reply_new_user_welcome
 # Flask executes after_request handlers in reverse registration order.
 # Register the viewport pass first so it runs last. The direct CTA pass is
 # registered before hotfix so it runs after hotfix and restores the verified


### PR DESCRIPTION
Instagram前のβ導線仕上げです。

1. LINE HOMEに「☝️ 源さんと1問だけ」を追加し、通常の5問/30問フローを変えずに正式Question Bankから1問だけ解ける低ハードル入口を追加。
2. 新規LINE案内とHP表記を「β期間中は完全版を無料開放」「正式リリース後は一部機能を月額プラン予定」「課金時は事前案内」に統一。

既存の本人画面・親見守り・Phase11・DB schema・課金設定は変更しません。新規費用なし。