### PR TITLE
Fix CI regression after Question Bank 2000 Batch 01

### DIFF
--- a/data/question_bank/schema/question_bank_schema_v1.json
+++ b/data/question_bank/schema/question_bank_schema_v1.json
@@ -5,7 +5,7 @@
   "$defs": {
     "qid": {
       "type": "string",
-      "pattern": "^Q[1-9][0-9]*$"
+      "pattern": "^Q(?:[1-9]|[1-9][0-9]{1,2}|1[0-6][0-9]{2}|17[0-4][0-9])$"
     },
     "ability": {
       "enum": [
@@ -40,7 +40,8 @@
   "properties": {
     "questions": {
       "type": "array",
-      "minItems": 1,
+      "minItems": 1749,
+      "maxItems": 1749,
       "items": {
         "type": "object",
         "additionalProperties": false,
@@ -74,7 +75,8 @@
     },
     "answers": {
       "type": "array",
-      "minItems": 1,
+      "minItems": 1749,
+      "maxItems": 1749,
       "items": {
         "type": "object",
         "additionalProperties": false,
@@ -97,7 +99,8 @@
     },
     "explanations": {
       "type": "array",
-      "minItems": 1,
+      "minItems": 1749,
+      "maxItems": 1749,
       "items": {
         "type": "object",
         "additionalProperties": false,
@@ -115,7 +118,8 @@
     },
     "question_tags": {
       "type": "array",
-      "minItems": 1,
+      "minItems": 1749,
+      "maxItems": 1749,
       "items": {
         "type": "object",
         "additionalProperties": false,

--- a/tests/test_adaptive_learning.py
+++ b/tests/test_adaptive_learning.py
@@ -19,11 +19,11 @@ from learning_engine import (
     summarize_initial_assessment,
     summarize_daily_session,
 )
-from question_bank import get_question_tag, get_quiz_question, question_count
+from question_bank import EXPECTED_QUESTION_COUNT, get_question_tag, get_quiz_question, question_count
 
 
 def test_all_formal_question_tags_load_and_match_ids():
-    assert question_count() == 1737
+    assert question_count() == EXPECTED_QUESTION_COUNT
     assert get_question_tag("Q1")["tag_status"] == "reviewed_sample"
     assert get_question_tag("Q1")["tag_version"] == "0.3"
     assert get_question_tag("Q200")["tag_status"] == "reviewed_sample"

--- a/tests/test_developer_status.py
+++ b/tests/test_developer_status.py
@@ -1,13 +1,17 @@
+import json
+
 import developer_status
 
 
-def test_formal_bank_status_matches_frozen_b12_data():
+def test_formal_bank_status_matches_manifest_and_saved_audit():
     status = developer_status.build_developer_system_status()
     bank = status["question_bank"]
-    assert bank["version"] == "2026-09-b12"
-    assert bank["question_count"] == 1737
-    assert bank["first_question_number"] == 1
-    assert bank["last_question_number"] == 1737
+    manifest = json.loads(developer_status.MANIFEST_PATH.read_text(encoding="utf-8-sig"))
+    assert bank["version"] == manifest["bank_version"]
+    assert bank["question_count"] == manifest["question_count"]
+    assert bank["first_question_number"] == manifest["first_question_number"]
+    assert bank["last_question_number"] == manifest["last_question_number"]
+    # Audit fields are the saved b12 snapshot, not a live recount of the bank.
     assert bank["records"] == 1737
     assert bank["errors"] == 0
     assert bank["status"] == "PASS"

--- a/tests/test_field_evidence.py
+++ b/tests/test_field_evidence.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta, timezone
 import field_evidence
 import knowledge_node_state_transition as transition
 from field_evidence import build_field_evidence
-from question_bank import get_category_small, get_question_tag
+from question_bank import EXPECTED_QUESTION_COUNT, get_category_small, get_question_tag
 
 
 BASE = datetime(2026, 8, 30, tzinfo=timezone.utc)
@@ -33,7 +33,7 @@ def test_empty_user_returns_all_fields_and_formal_totals():
     assert report["status"] == "evidence_only"
     assert report["official_mastery_score"] is None
     assert report["field_count"] == len(report["fields"]) == 18
-    assert report["question_total"] == sum(x["total_question_count"] for x in report["fields"]) == 1737
+    assert report["question_total"] == sum(x["total_question_count"] for x in report["fields"]) == EXPECTED_QUESTION_COUNT
     assert report["canonical_node_total"] == 1508
     assert report["multi_field_node_count"] == 14
     assert report["canonical_node_membership_total"] > report["canonical_node_total"]

--- a/tests/test_knowledge_node_relations.py
+++ b/tests/test_knowledge_node_relations.py
@@ -13,7 +13,7 @@ from knowledge_node_relations import (
     validate_merge_candidates,
     validate_node_relations,
 )
-from question_bank import get_question_tag, question_count
+from question_bank import EXPECTED_QUESTION_COUNT, get_question_tag, question_count
 
 
 BANK_DIR = Path(__file__).parents[1] / "data" / "question_bank"
@@ -132,5 +132,5 @@ def test_invalid_merge_candidate_data_is_rejected(mutation):
 
 
 def test_existing_question_bank_loader_remains_compatible():
-    assert question_count() == 1737
+    assert question_count() == EXPECTED_QUESTION_COUNT
     assert get_question_tag("Q260")["knowledge_node_id"] == "KN0259"

--- a/tests/test_knowledge_node_repairability.py
+++ b/tests/test_knowledge_node_repairability.py
@@ -1,3 +1,10 @@
+import json
+from collections import Counter
+from pathlib import Path
+
+from knowledge_node_canonical import canonicalize_knowledge_node_id
+from question_bank import EXPECTED_QUESTION_COUNT
+
 from knowledge_node_repairability import (
     SAME_QUESTION_ONLY,
     STRONG_ALT,
@@ -12,10 +19,20 @@ def test_all_1508_canonical_nodes_are_classified_and_counts_balance():
     records = build_repairability_audit()
     summary = summarize_repairability(records)
     assert summary["canonical_node_count"] == 1508
-    assert summary["singleton_node_count"] == 1305
-    assert summary["multi_question_node_count"] == 203
+    tags = json.loads(
+        (Path(__file__).parents[1] / "data/question_bank/question_tags.json").read_text(
+            encoding="utf-8-sig"
+        )
+    )
+    node_counts = Counter(canonicalize_knowledge_node_id(tag["knowledge_node_id"]) for tag in tags)
+    assert len(node_counts) == summary["canonical_node_count"]
+    assert sum(node_counts.values()) == EXPECTED_QUESTION_COUNT
+    assert {item["canonical_node_id"]: item["question_count"] for item in records} == node_counts
+    assert summary["singleton_node_count"] == sum(count == 1 for count in node_counts.values())
+    assert summary["multi_question_node_count"] == sum(count > 1 for count in node_counts.values())
     assert summary["singleton_node_count"] + summary["multi_question_node_count"] == 1508
-    assert summary["strong_alt_question_available_node_count"] == 149
+    # Batch01 adds 11 canonical nodes with differing task/ability evidence.
+    assert summary["strong_alt_question_available_node_count"] == 160
     assert summary["weak_alt_question_only_node_count"] == 54
 
 

--- a/tests/test_node_history_backfill_dry_run.py
+++ b/tests/test_node_history_backfill_dry_run.py
@@ -6,6 +6,8 @@ import importlib.util
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
+from question_bank import LAST_QUESTION_NUMBER
+
 
 SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "backfill_node_learning_history.py"
 SPEC = importlib.util.spec_from_file_location("node_backfill_dry_run", SCRIPT)
@@ -79,7 +81,7 @@ def test_normal_history_becomes_candidate_and_joins_formal_node():
 def test_missing_question_invalid_confidence_and_count_mismatches_are_reported():
     results = [
         {"selected_answers": ["A"], "is_correct": True, "confidence": 7},
-        result("Q1738", False, None),
+        result(f"Q{LAST_QUESTION_NUMBER + 1}", False, None),
     ]
     report, candidates = backfill.audit_learning_history(
         [event(results, answered=3, correct=2)], [], resolver

--- a/tests/test_past_exam_normal_import_47_51_lot2_v01.py
+++ b/tests/test_past_exam_normal_import_47_51_lot2_v01.py
@@ -2,6 +2,9 @@ import json
 from pathlib import Path
 
 from question_bank import (
+    EXPECTED_QUESTION_COUNT,
+    FIRST_QUESTION_NUMBER,
+    LAST_QUESTION_NUMBER,
     get_answer,
     get_explanation,
     get_question,
@@ -25,7 +28,7 @@ def _load(name):
 
 
 def test_lot2_imports_keep_official_answers_and_reviewed_nodes():
-    assert question_count() == 1737
+    assert question_count() == EXPECTED_QUESTION_COUNT
     for question_id, (exam_no, session, question_no, answer, _, final_node, _, category) in EXPECTED.items():
         question = get_question(question_id)
         assert question["source"] == "P"
@@ -86,8 +89,8 @@ def test_lot2_does_not_change_strong_different_question_pairs():
 
 
 def test_lot2_question_ids_are_contiguous_and_cross_file_ids_match():
-    expected_ids = [f"Q{number}" for number in range(1, 1738)]
+    expected_ids = [f"Q{number}" for number in range(FIRST_QUESTION_NUMBER, LAST_QUESTION_NUMBER + 1)]
     for name in ("questions.json", "answers.json", "explanations.json", "question_tags.json"):
         ids = [row["id"] for row in _load(name)]
         assert ids == expected_ids
-        assert len(ids) == len(set(ids)) == 1737
+        assert len(ids) == len(set(ids)) == EXPECTED_QUESTION_COUNT

--- a/tests/test_past_exam_normal_import_47_51_v01.py
+++ b/tests/test_past_exam_normal_import_47_51_v01.py
@@ -2,6 +2,9 @@ import json
 from pathlib import Path
 
 from question_bank import (
+    EXPECTED_QUESTION_COUNT,
+    FIRST_QUESTION_NUMBER,
+    LAST_QUESTION_NUMBER,
     get_answer,
     get_explanation,
     get_question,
@@ -39,7 +42,7 @@ def _load(name):
 
 
 def test_imported_questions_keep_official_exam_answer_and_reviewed_node():
-    assert question_count() == 1737
+    assert question_count() == EXPECTED_QUESTION_COUNT
     for question_id, (exam_no, session, question_no, answer, node_id, _, category) in EXPECTED.items():
         question = get_question(question_id)
         assert question["source"] == "P"
@@ -95,11 +98,11 @@ def test_question_ids_are_contiguous_and_cross_file_ids_match():
         "explanations.json",
         "question_tags.json",
     )]
-    expected_ids = [f"Q{number}" for number in range(1, 1738)]
+    expected_ids = [f"Q{number}" for number in range(FIRST_QUESTION_NUMBER, LAST_QUESTION_NUMBER + 1)]
     for rows in collections:
         ids = [row["id"] for row in rows]
         assert ids == expected_ids
-        assert len(ids) == len(set(ids)) == 1737
+        assert len(ids) == len(set(ids)) == EXPECTED_QUESTION_COUNT
 
 
 def test_frontotemporal_dementia_node_uses_psychiatry_category_consistently():

--- a/tests/test_question_bank.py
+++ b/tests/test_question_bank.py
@@ -7,6 +7,7 @@ os.environ.setdefault("CHANNEL_SECRET", "test-secret")
 
 import app as bot_app
 from question_bank import (
+    EXPECTED_QUESTION_COUNT,
     CATEGORY_GROUPS,
     CATEGORY_NAMES,
     get_category_group_names,
@@ -85,7 +86,7 @@ def test_small_category_still_keeps_thirty_question_study_flow():
 
 
 def test_formal_bank_has_all_questions_and_boundary_ids():
-    assert question_count() == 1737
+    assert question_count() == EXPECTED_QUESTION_COUNT
     assert get_question("Q1")["id"] == "Q1"
     assert get_answer("Q500")["id"] == "Q500"
     assert get_question("Q501")["id"] == "Q501"

--- a/tests/test_question_bank_manifest.py
+++ b/tests/test_question_bank_manifest.py
@@ -1,5 +1,6 @@
 import copy
 import json
+import re
 
 import pytest
 
@@ -9,14 +10,20 @@ from scripts.check_question_bank_schema_manifest import check_schema_manifest
 
 def test_runtime_declared_range_comes_from_manifest():
     result = check_schema_manifest()
-    assert result["question_count"] == 1737
-    assert result["first_question_number"] == 1
-    assert result["last_question_number"] == 1737
+    manifest = json.loads(question_bank.BANK_MANIFEST_PATH.read_text(encoding="utf-8-sig"))
+    assert result["question_count"] == manifest["question_count"]
+    assert result["first_question_number"] == manifest["first_question_number"]
+    assert result["last_question_number"] == manifest["last_question_number"]
     assert question_bank.QUESTION_BANK_VERSION == result["bank_version"]
     assert question_bank.EXPECTED_QUESTION_COUNT == result["question_count"]
     assert len(question_bank.EXPECTED_QUESTION_IDS) == result["question_count"]
     assert "Q1" in question_bank.EXPECTED_QUESTION_IDS
-    assert "Q1737" in question_bank.EXPECTED_QUESTION_IDS
+    assert f"Q{result['last_question_number']}" in question_bank.EXPECTED_QUESTION_IDS
+    schema_path = question_bank.BANK_MANIFEST_PATH.parent / "schema/question_bank_schema_v1.json"
+    pattern = json.loads(schema_path.read_text(encoding="utf-8-sig"))["$defs"]["qid"]["pattern"]
+    assert all(re.fullmatch(pattern, qid) for qid in question_bank.EXPECTED_QUESTION_IDS)
+    for invalid in ("Q0", "Q01", f"Q{result['last_question_number'] + 1}", f"Q{result['last_question_number'] + 1000}"):
+        assert re.fullmatch(pattern, invalid) is None
 
 
 def test_manifest_range_count_contract_is_fail_closed(tmp_path):


### PR DESCRIPTION
## Problem and root cause
PR #264 expanded the formal bank from 1737 to 1749 questions, but main tests run #413 (34183701332, latest attempt job 101930199765) and PR run #412 (34180745405) both failed the same 12 tests. All 12 failures were reproduced locally before editing.

- **B: stale assertions/fixtures (11 tests):** old count/range/version and canonical-node totals; Q1738 is now a valid question and cannot represent an out-of-range backfill fixture.
- **C: schema/manifest contract (1 test):** PR #264 replaced exact array counts with minItems=1 and removed the QID upper bound. check_schema_manifest raised `ValueError: questions: schema count is stale relative to manifest`.

Failing tests:
```
tests/test_adaptive_learning.py::test_all_formal_question_tags_load_and_match_ids
tests/test_developer_status.py::test_formal_bank_status_matches_frozen_b12_data
tests/test_field_evidence.py::test_empty_user_returns_all_fields_and_formal_totals
tests/test_knowledge_node_relations.py::test_existing_question_bank_loader_remains_compatible
tests/test_knowledge_node_repairability.py::test_all_1508_canonical_nodes_are_classified_and_counts_balance
tests/test_node_history_backfill_dry_run.py::test_missing_question_invalid_confidence_and_count_mismatches_are_reported
tests/test_past_exam_normal_import_47_51_lot2_v01.py::test_lot2_imports_keep_official_answers_and_reviewed_nodes
tests/test_past_exam_normal_import_47_51_lot2_v01.py::test_lot2_question_ids_are_contiguous_and_cross_file_ids_match
tests/test_past_exam_normal_import_47_51_v01.py::test_imported_questions_keep_official_exam_answer_and_reviewed_node
tests/test_past_exam_normal_import_47_51_v01.py::test_question_ids_are_contiguous_and_cross_file_ids_match
tests/test_question_bank.py::test_formal_bank_has_all_questions_and_boundary_ids
tests/test_question_bank_manifest.py::test_runtime_declared_range_comes_from_manifest
```

## Changes (11 files)
- `data/question_bank/schema/question_bank_schema_v1.json`: restore exact minItems/maxItems=1749 for all four stores and Q1–Q1749 pattern.
- `tests/test_adaptive_learning.py`, `test_field_evidence.py`, `test_knowledge_node_relations.py`, `test_question_bank.py`: use manifest-backed count.
- `tests/test_past_exam_normal_import_47_51_v01.py`, `test_past_exam_normal_import_47_51_lot2_v01.py`: use declared count/range while retaining ordered cross-file IDs, duplicate checks and historical answer/node assertions.
- `tests/test_node_history_backfill_dry_run.py`: invalid fixture uses LAST_QUESTION_NUMBER+1.
- `tests/test_developer_status.py`: verify live manifest metadata separately from the existing saved b12 audit snapshot; snapshot assertions remain unchanged.
- `tests/test_knowledge_node_repairability.py`: reconcile every canonical node count against formal tags; retain exact 1508 canonical nodes and 54 weak-only nodes, update strong-node baseline from 149 to 160 (Batch01 adds 11 canonical strong nodes).
- `tests/test_question_bank_manifest.py`: check manifest-backed values and every declared QID plus invalid lower/upper boundaries.

No assertions or tests removed. Existing workflow deselection unchanged.

## Validation
Local Windows, Python 3.13.14, isolated venv installed from requirements.txt plus pytest; dummy CI secrets, empty DATABASE_URL, PYTHONPATH=.
GitHub runner uses Ubuntu/Python 3.13.15; actual PR Actions result will be checked before reporting completion.

- Before: exact original failing selection **12 failed**.
- After: all original failures pass in full suite.
- `python -m pytest -q tests/test_question_bank_manifest.py tests/test_question_bank_2000_batch01_integration.py tests/test_question_bank_schema.py`: **11 passed**.
- `python scripts/check_question_bank_schema_manifest.py`: PASS, b13 / 1749 / Q1–Q1749.
- `python scripts/validate_question_bank.py`: PASS, four stores each 1749, missing/duplicates/ID mismatch/schema issues/node mapping issues all 0.
- `python reports/question_bank_2000_batch01_validate.py`: accepted=12, integrated=12, hard_errors=[], warnings=[].
- `python -m pytest -q --deselect=tests/test_quiz_answer_numbering.py::ConfigurableQuizTest::test_runtime_loader_supports_current_utf16_and_candidate_utf8`: **1140 passed, 1 deselected, 16 warnings, 125 subtests passed**.
- `git diff --check`: PASS.

## Scope
Formal question/answer/explanation/tag content, manifest and Knowledge Nodes unchanged. No app.py, selector, Phase11, adaptive runtime, Production DB, Render, LINE or production configuration changes. No main push or merge. This PR awaits human merge decision.
