### PR TITLE
Add reviewed exact-question evidence equivalence

### DIFF
--- a/adaptive_question_selector.py
+++ b/adaptive_question_selector.py
@@ -7,7 +7,6 @@ from collections import Counter, defaultdict
 from datetime import datetime, timezone
 from typing import Any, Iterable
 
-from knowledge_node_canonical import canonicalize_knowledge_node_id
 from knowledge_node_state_transition import derive_all_user_node_states
 from knowledge_node_repair_evidence import (
     DIFFERENT_QUESTION_WEAK,
@@ -16,6 +15,10 @@ from knowledge_node_repair_evidence import (
     classify_repair_confirmation,
 )
 from question_bank import get_category_small, get_question_tag, get_quiz_question, question_ids
+from question_equivalence import (
+    canonicalize_question_evidence_id,
+    canonicalize_question_evidence_node,
+)
 from prerequisite_backtrack_pilot import (
     is_prerequisite_backtrack_pilot_enabled,
     parse_prerequisite_backtrack_pilot_user_ids,
@@ -53,11 +56,15 @@ def _node_attempt_summary(attempts: Iterable[dict[str, Any]]) -> dict[str, dict[
         "uncertain_correct": False, "unknown": False,
     })
     for item in sorted((dict(value) for value in attempts), key=_attempt_time):
-        node = canonicalize_knowledge_node_id(str(item.get("knowledge_node_id") or ""))
+        raw_question_id = str(item.get("question_id") or "")
+        node = canonicalize_question_evidence_node(
+            raw_question_id,
+            str(item.get("knowledge_node_id") or ""),
+        )
         if not node:
             continue
-        question_id = str(item.get("question_id") or "")
-        summary = summaries[node]
+        question_id = canonicalize_question_evidence_id(raw_question_id)
+        summary = summaries[str(node)]
         is_unknown = item.get("answer_status") == "unknown"
         is_correct = False if is_unknown else item.get("is_correct") is True
         if is_correct:
@@ -124,36 +131,47 @@ def select_node_adaptive_questions(
     state_records = {item["canonical_node_id"]: item for item in derive_all_user_node_states(attempts, as_of=as_of)}
     states = {node: item["state"] for node, item in state_records.items()}
     summaries = _node_attempt_summary(attempts)
-    seen_question_ids = {str(item.get("question_id") or "") for item in attempts}
+    seen_question_ids = {
+        canonicalize_question_evidence_id(str(item.get("question_id") or ""))
+        for item in attempts
+        if item.get("question_id")
+    }
     recent_attempts = sorted(attempts, key=_attempt_time, reverse=True)[:30]
     recent_question_ids = {
-        str(item.get("question_id") or "")
+        canonicalize_question_evidence_id(str(item.get("question_id") or ""))
         for item in recent_attempts
         if item.get("question_id")
     }
-    excluded = {str(value) for value in (exclude_ids or ())}
+    excluded = {
+        canonicalize_question_evidence_id(str(value))
+        for value in (exclude_ids or ())
+    }
     candidates = []
     for question_id in question_ids():
-        if question_id in excluded:
+        evidence_question_id = canonicalize_question_evidence_id(question_id)
+        if evidence_question_id in excluded:
             continue
         if category_small is not None and get_category_small(question_id) != category_small:
             continue
         tag = get_question_tag(question_id)
-        node = canonicalize_knowledge_node_id(tag["knowledge_node_id"])
-        state = states.get(node, "unseen")
-        summary = summaries.get(node, {
+        node = canonicalize_question_evidence_node(
+            question_id,
+            str(tag["knowledge_node_id"]),
+        )
+        state = states.get(str(node), "unseen")
+        summary = summaries.get(str(node), {
             "wrong_questions": set(), "evaluable_wrong_questions": set(),
             "correct_questions": set(), "confident_wrong": False,
             "uncertain_correct": False, "unknown": False,
         })
         score, reason, group = _priority(state, summary, str(tag.get("safety", "none")))
         if state == "recheck_due":
-            score += min(int(state_records.get(node, {}).get("due_overdue_days", 0)), 30)
+            score += min(int(state_records.get(str(node), {}).get("due_overdue_days", 0)), 30)
         evidence_strengths = {
             classify_repair_confirmation(wrong_id, question_id)
             for wrong_id in summary["wrong_questions"]
         }
-        is_same_q_repeat = question_id in summary["wrong_questions"]
+        is_same_q_repeat = evidence_question_id in summary["wrong_questions"]
         strong_confirmation = DIFFERENT_QUESTION_STRONG in evidence_strengths
         if is_same_q_repeat:
             repair_evidence_quality = SAME_QUESTION
@@ -169,11 +187,12 @@ def select_node_adaptive_questions(
             score += 80
         elif summary["wrong_questions"]:
             score += 20
-        if question_id not in seen_question_ids:
+        if evidence_question_id not in seen_question_ids:
             score += 10
         candidates.append({
             "question_id": question_id,
-            "canonical_node_id": node,
+            "evidence_question_id": evidence_question_id,
+            "canonical_node_id": str(node),
             "state": state,
             "priority_reason": reason,
             "priority_group": group,
@@ -181,7 +200,7 @@ def select_node_adaptive_questions(
             "previous_wrong_count": len(summary["wrong_questions"]),
             "previous_correct_count": len(summary["correct_questions"]),
             "same_question_repeat": is_same_q_repeat,
-            "recent_question_repeat": question_id in recent_question_ids,
+            "recent_question_repeat": evidence_question_id in recent_question_ids,
             "recent_cooldown_bypassed": False,
             "strong_repair_confirmation": strong_confirmation,
             "repair_evidence_quality": repair_evidence_quality,
@@ -207,7 +226,6 @@ def select_node_adaptive_questions(
     ]
     recent_candidates = [item for item in candidates if item["recent_question_repeat"]]
 
-    # Soft composition targets: repair half, checking about a third, exploration remainder.
     targets = {
         "repair": (question_count + 1) // 2,
         "checking": question_count // 3,
@@ -215,6 +233,7 @@ def select_node_adaptive_questions(
     }
     selected: list[dict[str, Any]] = []
     selected_ids: set[str] = set()
+    selected_evidence_ids: set[str] = set()
     node_counts: Counter[str] = Counter()
 
     def append_item(item: dict[str, Any]):
@@ -224,42 +243,45 @@ def select_node_adaptive_questions(
         )
         selected.append(selected_item)
         selected_ids.add(selected_item["question_id"])
+        selected_evidence_ids.add(selected_item["evidence_question_id"])
         node_counts[selected_item["canonical_node_id"]] += 1
+
+    def available(item: dict[str, Any], node_cap: int) -> bool:
+        return (
+            item["question_id"] not in selected_ids
+            and item["evidence_question_id"] not in selected_evidence_ids
+            and node_counts[item["canonical_node_id"]] < node_cap
+        )
 
     def take(pool, group: str, limit: int, node_cap: int):
         for item in pool:
             if len([value for value in selected if value["priority_group"] == group]) >= limit:
                 break
-            if item["priority_group"] != group or item["question_id"] in selected_ids:
-                continue
-            if node_counts[item["canonical_node_id"]] >= node_cap:
+            if item["priority_group"] != group or not available(item, node_cap):
                 continue
             append_item(item)
 
-    # Prefer one representative question per canonical Node. Only use a second
-    # question when a bucket cannot otherwise reach its existing composition target.
     for group, limit in targets.items():
         take(normal_candidates, group, limit, node_cap=1)
         take(normal_candidates, group, limit, node_cap=2)
 
-    # Maintenance and unused groups fill natural shortages with the same two-pass rule.
     for cap in (1, 2, 3, question_count):
         for item in normal_candidates:
             if len(selected) >= question_count:
                 break
-            if item["question_id"] in selected_ids or node_counts[item["canonical_node_id"]] >= cap:
+            if not available(item, cap):
                 continue
             append_item(item)
         if len(selected) >= question_count:
             break
 
     # Controlled final fallback: only a real bank shortage can bypass cooldown.
-    # Explicit exclude_ids never entered candidates and therefore cannot return.
+    # Equivalent official repeats remain one evidence identity even in fallback.
     for cap in (1, 2, 3, question_count):
         for item in recent_candidates:
             if len(selected) >= question_count:
                 break
-            if item["question_id"] in selected_ids or node_counts[item["canonical_node_id"]] >= cap:
+            if not available(item, cap):
                 continue
             append_item(item)
         if len(selected) >= question_count:

--- a/data/question_bank/question_equivalence_groups.json
+++ b/data/question_bank/question_equivalence_groups.json
@@ -1,0 +1,38 @@
+[
+  {
+    "equivalence_id": "QEQ0001",
+    "canonical_question_id": "Q972",
+    "canonical_knowledge_node_id": "KN0962",
+    "question_ids": ["Q972", "Q1354"],
+    "equivalence_type": "official_exact_repeat",
+    "review_status": "reviewed",
+    "reason": "MHLW official items from different exam years have the same normalized stem, ordered choices, and keyed answer. Preserve both provenance records but treat them as one learning-evidence identity."
+  },
+  {
+    "equivalence_id": "QEQ0002",
+    "canonical_question_id": "Q1067",
+    "canonical_knowledge_node_id": "KN1057",
+    "question_ids": ["Q1067", "Q1391"],
+    "equivalence_type": "official_exact_repeat",
+    "review_status": "reviewed",
+    "reason": "MHLW official items from different exam years have the same normalized stem, ordered choices, and keyed answer. Preserve both provenance records but treat them as one learning-evidence identity."
+  },
+  {
+    "equivalence_id": "QEQ0003",
+    "canonical_question_id": "Q1230",
+    "canonical_knowledge_node_id": "KN1215",
+    "question_ids": ["Q1230", "Q1526"],
+    "equivalence_type": "official_exact_repeat",
+    "review_status": "reviewed",
+    "reason": "MHLW official items from different exam years have the same normalized stem, ordered choices, and keyed answer. Preserve both provenance records but treat them as one learning-evidence identity."
+  },
+  {
+    "equivalence_id": "QEQ0004",
+    "canonical_question_id": "Q1411",
+    "canonical_knowledge_node_id": "KN1387",
+    "question_ids": ["Q1411", "Q1585"],
+    "equivalence_type": "official_exact_repeat_cross_node",
+    "review_status": "reviewed",
+    "reason": "The two MHLW official items are identical. Q1585 was historically stored under the narrower ADH Node KN0659; for derived learning evidence this exact item belongs with Q1411 under the posterior-pituitary-hormone Node KN1387. Raw attempts remain unchanged."
+  }
+]

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -28,30 +28,54 @@ Do not mark something complete only because code exists. Completion requires the
 # 1. Question Bank / Q2000
 
 ## Done / working now
-- Formal Question Bank has reached Q2000 in the post-Q2000 working branch.
+- Formal Question Bank has reached Q2000, bank version `2026-09-b20`.
 - Question delivery uses saved Question Bank data rather than generating each normal-learning question through OpenAI.
-- Q-number remains the stable question ID.
+- Q-number remains the stable immutable question ID.
 - Question, answer/explanation, tags, Knowledge Node relationships, and validators are separated into structured data/contracts.
 - Strong different-question repair pairs exist and are used by repair logic.
+- Final cross-sectional audit refined duplicate identity from generic stem equality to item-level equality (`normalized stem + ordered choices`).
+- The 33 same-stem groups resolve to **29 legitimate same-stem/different-choice official items plus 4 exact official provenance-repeat groups**.
+- On review branch `work/q2000-question-equivalence-v01`, the four exact official repeats are formally registered as one derived learning-evidence identity while preserving both raw Q IDs/provenance:
+  - Q972 / Q1354
+  - Q1067 / Q1391
+  - Q1230 / Q1526
+  - Q1411 / Q1585
+- Equivalent official repeats cannot masquerade as STRONG different-question repair evidence, cannot create artificial cross-question weakness, and cannot bypass Recent Cooldown merely by using the alternate raw Q ID.
+- Q1411/Q1585 are identical official content historically attached to different raw Nodes; review-branch logic reconciles them only for **derived evidence** under KN1387. Raw Production rows are not rewritten.
+- Primary learner impact check found only Q1585 among the eight exact-repeat Q IDs had prior attempts (4/4 correct); the other seven had no attempts at review time.
+- High-similarity non-exact sampling found no evidence supporting bulk rewriting of official items. Examples reviewed include AFO settings, fracture-name mappings, ASIA key muscles, prosthetic alignment, reproductive physiology, muscle action, metabolism and pathology.
+- 14 short-stem heuristic candidates were reviewed as ordinary national-exam prompts with sufficiently specific options/explanations.
+- 3 short global-explanation candidates were reviewed; all contain useful option-by-option rationales, so short summary length alone is not a blocker.
+- Duplicate raw Node label `交感神経の作用` for KN0597/KN0807 was already formally resolved by reviewed canonical alias `KNC0001` (KN0807 -> KN0597). The audit now distinguishes raw duplicate labels already resolved by canonicalization from genuinely unresolved same-label Nodes.
+- Duplicate raw label `筋と作用の組合せ` for KN1142/KN1252 was medically reviewed as **different content** (facial/masticatory muscles vs lower-limb muscles); do not merge. The generic labels may be refined later for learner-facing clarity.
+- Review-branch full CI has already produced green runs including **1207 passed, 6 skipped, 1 deselected, 125 subtests passed** before the latest audit-report refinements.
+- Detailed review record: `reports/q2000_final_quality_review_20260909.md`.
 
 ## Not finished yet
-- Final medical/editorial quality audit for all Q2000 content is not closed.
-- Exact duplicates / hard-near duplicates and any medically questionable items found by the final audit still need explicit disposition.
-- Final release-grade evidence for the Q2000 bank should be consolidated into one reproducible acceptance record.
+- Latest review-branch audit/canonical-label refinements still need their final CI result recorded before the final-quality audit is formally closed.
+- Final zero-blocker audit output and final regression evidence must be captured in the durable record.
+- Review PR #277 must be merged only into the safe post-Q2000 working branch after final green verification; it is not a `main`/Production promotion.
+- Diagnostic PR #276 must be closed without merge after its evidence is fully captured.
 
 ## Known problems / risks
-- A green structural validator does not by itself prove every item is medically ideal.
-- Similarity audits can identify pairs requiring human/editorial judgment rather than automatic deletion.
-- Q2000 must not be treated as a marketing claim if the final medical/editorial acceptance is not complete.
+- A green structural validator does not by itself prove every item is medically ideal; similarity and editorial heuristics still require human/medical interpretation.
+- Official exam provenance repeats must remain traceable, but counting them as independent learning evidence would falsely strengthen repair/weakness signals.
+- Generic Knowledge Node labels can be educationally unhelpful even when the underlying Node separation is correct; label quality and Node identity are separate concerns.
+- Temporary diagnostic PR #276 intentionally fails probes and must never be mistaken for a product regression.
 
 ## Target state / how it should be
-- 2000 questions are structurally valid, medically defensible, non-duplicative enough for learning value, correctly tagged, and usable by adaptive selection.
-- Every final-bank change is followed by validator + relevant Knowledge Node / selector / full regression checks.
+- 2000 questions are structurally valid, medically defensible, correctly tagged, and usable by adaptive selection.
+- Official duplicate provenance is preserved without double-counting learning evidence.
+- Similarity review is conservative: official items are not cosmetically rewritten merely to be unique.
+- Knowledge Node identity reflects the minimum meaningful repair target; labels should become specific enough for useful learner-facing weakness explanations.
+- Every final-bank change is followed by validator + affected Node/selector/repair checks + full regression.
 
 ## Next concrete work
-1. Close final Q2000 quality findings one by one.
-2. Re-run full Question Bank validation and affected selector/Node tests.
-3. Record final acceptance evidence here.
+1. Confirm latest PR #277 CI remains green after canonical-label audit refinement/report update.
+2. Record final zero-blocker audit result and CI evidence.
+3. Merge PR #277 into `work/pt-finalization-post-q2000` only if green.
+4. Close diagnostic PR #276 without merge.
+5. Then move the active completion focus to formal-vs-legacy dashboard source consolidation while Phase11 OPEN gates continue collecting natural evidence.
 
 ---
 
@@ -277,7 +301,7 @@ The seven automatic gates are necessary but not sufficient. The Phase11 ship che
 
 # 9. Current priority order
 
-1. Final Q2000 quality findings and acceptance evidence.
+1. Final Q2000 quality audit closure and safe-branch integration.
 2. Phase11 promotion-gate re-evaluation when new natural retention/recheck/comparison evidence appears.
 3. Formal-vs-legacy dashboard source map and consolidation plan.
 4. Longitudinal companion-record design and implementation.

--- a/knowledge_node_repair_evidence.py
+++ b/knowledge_node_repair_evidence.py
@@ -3,8 +3,11 @@
 import json
 from pathlib import Path
 
-from knowledge_node_canonical import canonicalize_knowledge_node_id
 from question_bank import QuestionBankError, get_question_tag
+from question_equivalence import (
+    are_equivalent_questions,
+    canonicalize_question_evidence_node,
+)
 
 
 SAME_QUESTION = "same_question"
@@ -43,24 +46,26 @@ _FORMAL_STRONG_PAIRS = _load_formal_strong_pairs()
 def classify_repair_confirmation(previous_question_id: str, candidate_question_id: str) -> str:
     """Classify conservatively using existing reviewed metadata only.
 
-    Strong evidence requires two different questions in the same canonical Node.
-    Different task or primary ability then demonstrates a materially different
-    demand. When metadata cannot prove either condition, fail closed as weak.
+    Strong evidence requires two materially different questions in the same
+    derived evidence Node. Reviewed exact official repeats are same-question
+    evidence even when their raw Q IDs or historical raw Nodes differ.
     """
     previous = str(previous_question_id or "")
     candidate = str(candidate_question_id or "")
-    if not previous or not candidate or previous == candidate:
+    if not previous or not candidate or are_equivalent_questions(previous, candidate):
         return SAME_QUESTION
     try:
         previous_tag = get_question_tag(previous)
         candidate_tag = get_question_tag(candidate)
     except (KeyError, ValueError, QuestionBankError):
         return DIFFERENT_QUESTION_WEAK
-    previous_node = canonicalize_knowledge_node_id(
-        str(previous_tag.get("knowledge_node_id") or "")
+    previous_node = canonicalize_question_evidence_node(
+        previous,
+        str(previous_tag.get("knowledge_node_id") or ""),
     )
-    candidate_node = canonicalize_knowledge_node_id(
-        str(candidate_tag.get("knowledge_node_id") or "")
+    candidate_node = canonicalize_question_evidence_node(
+        candidate,
+        str(candidate_tag.get("knowledge_node_id") or ""),
     )
     if not previous_node or not candidate_node or previous_node != candidate_node:
         return DIFFERENT_QUESTION_WEAK

--- a/knowledge_node_state_transition.py
+++ b/knowledge_node_state_transition.py
@@ -6,12 +6,12 @@ from collections import defaultdict
 from datetime import datetime, timedelta, timezone
 from typing import Any, Iterable
 
-from knowledge_node_canonical import canonicalize_knowledge_node_id
 from knowledge_node_weakness_evidence import derive_repeated_weakness_evidence
 from knowledge_node_repair_evidence import (
     DIFFERENT_QUESTION_STRONG,
     classify_repair_confirmation,
 )
+from question_equivalence import canonicalize_question_evidence_node
 
 
 STATES = ("unseen", "checking", "repairing", "repaired", "stable", "recheck_due")
@@ -25,6 +25,16 @@ def _sort_key(attempt: dict[str, Any]) -> tuple[str, str, int, int]:
         str(attempt.get("event_key") or ""),
         int(attempt.get("attempt_position") or 0),
         int(attempt.get("id") or 0),
+    )
+
+
+def _evidence_node(item: dict[str, Any]) -> str:
+    return str(
+        canonicalize_question_evidence_node(
+            str(item.get("question_id") or ""),
+            str(item.get("knowledge_node_id") or ""),
+        )
+        or ""
     )
 
 
@@ -104,15 +114,12 @@ def derive_knowledge_node_state(
     canonical_node_id: str | None = None,
     as_of: datetime | None = None,
 ) -> dict[str, Any]:
-    """Derive the final state for one user's one canonical Node history."""
+    """Derive the final state for one user's one canonical evidence-Node history."""
     ordered = sorted((dict(item) for item in attempts), key=_sort_key)
     if not ordered:
         return _result(str(canonical_node_id or ""), "unseen", "", [], 0)
 
-    canonical_ids = {
-        canonicalize_knowledge_node_id(str(item.get("knowledge_node_id") or ""))
-        for item in ordered
-    }
+    canonical_ids = {_evidence_node(item) for item in ordered}
     user_ids = {str(item.get("user_id") or "") for item in ordered}
     if len(canonical_ids) != 1 or len(user_ids) != 1:
         raise ValueError("attempts must belong to one user and one canonical Node")
@@ -213,11 +220,11 @@ def derive_knowledge_node_state(
 def derive_all_user_node_states(
     attempts: Iterable[dict[str, Any]], as_of: datetime | None = None
 ) -> list[dict[str, Any]]:
-    """Group by user and canonical Node without returning user identifiers."""
+    """Group by user and canonical evidence Node without returning user identifiers."""
     grouped: dict[tuple[str, str], list[dict[str, Any]]] = defaultdict(list)
     for source in attempts:
         item = dict(source)
-        canonical = canonicalize_knowledge_node_id(str(item.get("knowledge_node_id") or ""))
+        canonical = _evidence_node(item)
         grouped[(str(item.get("user_id") or ""), canonical)].append(item)
     return [
         derive_knowledge_node_state(history, canonical, as_of=as_of)

--- a/knowledge_node_weakness_evidence.py
+++ b/knowledge_node_weakness_evidence.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 from collections import defaultdict
 from typing import Any, Iterable
 
-from knowledge_node_canonical import canonicalize_knowledge_node_id
+from question_equivalence import (
+    canonicalize_question_evidence_id,
+    canonicalize_question_evidence_node,
+)
 
 
 NO_WRONG_EVIDENCE = "NO_WRONG_EVIDENCE"
@@ -25,10 +28,14 @@ def _sort_key(attempt: dict[str, Any]) -> tuple[str, str, int, int]:
     )
 
 
+def _evidence_question_id(item: dict[str, Any]) -> str:
+    return canonicalize_question_evidence_id(str(item.get("question_id") or ""))
+
+
 def _classify(history: list[dict[str, Any]]) -> tuple[str, str]:
     wrong = [item for item in history if item.get("is_correct") is False]
     correct = [item for item in history if item.get("is_correct") is True]
-    wrong_questions = {str(item["question_id"]) for item in wrong}
+    wrong_questions = {_evidence_question_id(item) for item in wrong}
 
     if not wrong:
         return NO_WRONG_EVIDENCE, "No wrong answer is recorded for this canonical Node."
@@ -47,7 +54,7 @@ def _classify(history: list[dict[str, Any]]) -> tuple[str, str]:
     if len(wrong) >= 2:
         return (
             REPEATED_SAME_QUESTION_WRONG,
-            "The same question was answered incorrectly more than once; this is not cross-question evidence.",
+            "The same evidence-equivalent question was answered incorrectly more than once; this is not cross-question evidence.",
         )
     return SINGLE_WRONG, "Only one wrong question is recorded; weakness is not confirmed."
 
@@ -58,8 +65,8 @@ def derive_repeated_weakness_evidence(
     """Return anonymous user/canonical-Node evidence records.
 
     User identifiers are used only as internal grouping keys and never included
-    in returned records. Histories are sorted before classification so callers
-    may provide attempts in any order.
+    in returned records. Exact reviewed official repeats are canonicalized only
+    for derived evidence; raw stored Q/Node IDs remain untouched.
     """
     grouped: dict[tuple[str, str], list[dict[str, Any]]] = defaultdict(list)
     for source in attempts:
@@ -68,24 +75,28 @@ def derive_repeated_weakness_evidence(
         raw_node_id = str(item.get("knowledge_node_id") or "")
         if not question_id or not raw_node_id:
             continue
-        canonical = canonicalize_knowledge_node_id(raw_node_id)
-        grouped[(str(item.get("user_id") or ""), canonical)].append(item)
+        canonical = canonicalize_question_evidence_node(question_id, raw_node_id)
+        grouped[(str(item.get("user_id") or ""), str(canonical or ""))].append(item)
 
     result: list[dict[str, Any]] = []
     for (_user_key, canonical), history in sorted(grouped.items()):
         ordered = sorted(history, key=_sort_key)
-        question_ids = {str(item["question_id"]) for item in ordered}
+        question_ids = {_evidence_question_id(item) for item in ordered}
         wrong = [item for item in ordered if item.get("is_correct") is False]
         correct = [item for item in ordered if item.get("is_correct") is True]
         level, reason = _classify(ordered)
         result.append({
             "canonical_node_id": canonical,
             "distinct_question_count": len(question_ids),
-            "wrong_question_count": len({str(item["question_id"]) for item in wrong}),
-            "correct_question_count": len({str(item["question_id"]) for item in correct}),
+            "wrong_question_count": len({_evidence_question_id(item) for item in wrong}),
+            "correct_question_count": len({_evidence_question_id(item) for item in correct}),
             "confident_wrong_count": sum(item.get("confidence") == 1 for item in wrong),
-            "first_wrong_question_id": str(wrong[0]["question_id"]) if wrong else None,
-            "last_wrong_question_id": str(wrong[-1]["question_id"]) if wrong else None,
+            "first_wrong_question_id": (
+                canonicalize_question_evidence_id(str(wrong[0]["question_id"])) if wrong else None
+            ),
+            "last_wrong_question_id": (
+                canonicalize_question_evidence_id(str(wrong[-1]["question_id"])) if wrong else None
+            ),
             "evidence_level": level,
             "evidence_reason": reason,
         })

--- a/question_equivalence.py
+++ b/question_equivalence.py
@@ -1,0 +1,122 @@
+"""Reviewed question-level equivalence for learning evidence without rewriting raw Q IDs."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from knowledge_node_canonical import canonicalize_knowledge_node_id
+
+
+BANK_DIR = Path(__file__).resolve().parent / "data" / "question_bank"
+EQUIVALENCE_PATH = BANK_DIR / "question_equivalence_groups.json"
+
+
+class QuestionEquivalenceValidationError(ValueError):
+    """Raised when reviewed question-equivalence master data is inconsistent."""
+
+
+def _load_records(path: Path = EQUIVALENCE_PATH) -> list[dict[str, Any]]:
+    raw = json.loads(path.read_text(encoding="utf-8-sig"))
+    if not isinstance(raw, list):
+        raise QuestionEquivalenceValidationError("question equivalence data must be an array")
+    return raw
+
+
+def load_and_validate_question_equivalence(
+    path: Path = EQUIVALENCE_PATH,
+) -> tuple[list[dict[str, Any]], dict[str, str], dict[str, str], dict[str, frozenset[str]]]:
+    records = _load_records(path)
+    canonical_by_question: dict[str, str] = {}
+    node_by_question: dict[str, str] = {}
+    group_by_question: dict[str, frozenset[str]] = {}
+    seen_equivalence_ids: set[str] = set()
+
+    for index, record in enumerate(records):
+        label = f"question_equivalence[{index}]"
+        required = {
+            "equivalence_id",
+            "canonical_question_id",
+            "canonical_knowledge_node_id",
+            "question_ids",
+            "equivalence_type",
+            "review_status",
+            "reason",
+        }
+        missing = required - record.keys()
+        if missing:
+            raise QuestionEquivalenceValidationError(f"{label} missing {sorted(missing)}")
+        equivalence_id = str(record["equivalence_id"])
+        if not equivalence_id or equivalence_id in seen_equivalence_ids:
+            raise QuestionEquivalenceValidationError(f"{label} duplicate/empty equivalence_id")
+        seen_equivalence_ids.add(equivalence_id)
+        if record.get("review_status") != "reviewed":
+            raise QuestionEquivalenceValidationError(f"{label} must be reviewed")
+        question_ids = [str(value) for value in record.get("question_ids") or []]
+        if len(question_ids) < 2 or len(question_ids) != len(set(question_ids)):
+            raise QuestionEquivalenceValidationError(f"{label} needs at least two unique question IDs")
+        canonical_question = str(record.get("canonical_question_id") or "")
+        if canonical_question not in question_ids:
+            raise QuestionEquivalenceValidationError(f"{label} canonical question must be a member")
+        canonical_node = str(record.get("canonical_knowledge_node_id") or "")
+        if not canonical_node:
+            raise QuestionEquivalenceValidationError(f"{label} canonical Node is empty")
+        members = frozenset(question_ids)
+        for question_id in question_ids:
+            if question_id in canonical_by_question:
+                raise QuestionEquivalenceValidationError(
+                    f"question appears in multiple equivalence groups: {question_id}"
+                )
+            canonical_by_question[question_id] = canonical_question
+            node_by_question[question_id] = canonical_node
+            group_by_question[question_id] = members
+
+    return records, canonical_by_question, node_by_question, group_by_question
+
+
+_RECORDS, _CANONICAL_BY_QUESTION, _NODE_BY_QUESTION, _GROUP_BY_QUESTION = (
+    load_and_validate_question_equivalence()
+)
+
+
+def get_question_equivalence_groups() -> list[dict[str, Any]]:
+    """Return a copy-safe representation of reviewed equivalence groups."""
+    return [dict(record) for record in _RECORDS]
+
+
+def canonicalize_question_evidence_id(question_id: str | None) -> str:
+    """Resolve exact provenance repeats to one stable evidence identity."""
+    text = str(question_id or "")
+    return _CANONICAL_BY_QUESTION.get(text, text)
+
+
+def equivalent_question_ids(question_id: str | None) -> frozenset[str]:
+    """Return every raw Q ID in the reviewed equivalence group, or the Q itself."""
+    text = str(question_id or "")
+    if not text:
+        return frozenset()
+    return _GROUP_BY_QUESTION.get(text, frozenset({text}))
+
+
+def are_equivalent_questions(first_question_id: str | None, second_question_id: str | None) -> bool:
+    first = str(first_question_id or "")
+    second = str(second_question_id or "")
+    return bool(first and second and canonicalize_question_evidence_id(first) == canonicalize_question_evidence_id(second))
+
+
+def canonicalize_question_evidence_node(
+    question_id: str | None,
+    raw_node_id: str | None,
+) -> str | None:
+    """Return the reviewed evidence Node for an exact repeat, else normal Node canonicalization.
+
+    Raw persisted attempt Node IDs are never rewritten. This function only controls
+    derived learning evidence so an identical official item cannot become independent
+    evidence merely because it was imported under a different historical Node.
+    """
+    question = str(question_id or "")
+    reviewed_node = _NODE_BY_QUESTION.get(question)
+    if reviewed_node:
+        return canonicalize_knowledge_node_id(reviewed_node)
+    return canonicalize_knowledge_node_id(raw_node_id)

--- a/reports/q2000_final_quality_review_20260909.md
+++ b/reports/q2000_final_quality_review_20260909.md
@@ -2,141 +2,130 @@
 
 Scope: formal PT Question Bank `Q1-Q2000`, bank version `2026-09-b20`.
 
-Status: **OPEN — count/structure is complete; final quality acceptance has been narrowed to four true duplicate-item dispositions plus editorial/Node review candidates.**
+Status: **NEAR-CLOSE — structural blockers are resolved on the review branch; remaining work is acceptance sampling/documentation and final regression evidence.**
 
-This record is based on read-only CI audits against `qb2000-finish` plus read-only Production attempt-history cross-checks. No Production DB write, Render change, LINE change, or `main` mutation was performed.
+No Production DB write, Render change, LINE change, or `main` mutation was performed.
 
-## CI evidence
+## 1. Audit progression
 
-Temporary draft PR #276 runs a read-only final-quality probe against `qb2000-finish`. It is diagnostic only and must not be merged.
+The first read-only audit found:
+- 2000 questions / bank version `2026-09-b20`
+- 33 normalized same-stem groups
+- 72 near-duplicate candidates at normalized similarity >= 0.90 within the same category
+- 14 short-stem heuristic candidates
+- 3 short-explanation heuristic candidates
+- 2 duplicate raw Knowledge Node label groups
 
-### First pass — stem-only duplicate detector
+The original stem-only duplicate detector was too coarse because official MHLW exams reuse generic stems with different choice sets. The permanent audit was therefore refined so a true item-level duplicate requires:
 
-Run `34309025255`:
-- existing suite apart from the intentionally failing audit probe: **1198 passed, 6 skipped, 1 deselected, 125 subtests passed**
-- question count: 2000
-- bank version: `2026-09-b20`
-- normalized same-stem groups: 33
-- near-duplicate candidates (same category, normalized similarity >= 0.90): 72
-- duplicate normalized Knowledge Node label candidates: 2
-- editorial heuristics: stem-length candidates 14, explanation-length candidates 3
+`same normalized stem + same normalized ordered choices`
 
-Review of the 33 groups showed that all are MHLW past-exam records from different exam years. A repeated generic exam stem is not, by itself, a duplicate learning item when the choices test different facts. Therefore the original stem-only blocker semantics were too coarse.
+That reduced the real exact-item repeat set from 33 stem groups to four groups.
 
-### Refined pass — item-level duplicate detector
+## 2. Four exact official provenance repeats — RESOLVED on review branch
 
-Run `34309589005` refined duplicate identity to:
+All four groups are MHLW official items repeated in different exam years. They are preserved as immutable raw Q records but registered as one **derived learning-evidence identity**.
 
-`same normalized stem + same normalized ordered choice set`
+1. Q972 / Q1354 -> canonical evidence Q972 / `KN0962`
+2. Q1067 / Q1391 -> canonical evidence Q1067 / `KN1057`
+3. Q1230 / Q1526 -> canonical evidence Q1230 / `KN1215`
+4. Q1411 / Q1585 -> canonical evidence Q1411 / `KN1387`
 
-Result:
-- same-stem groups: **33**
-- same-stem but different-choice groups: **29** -> review-only, not blockers
-- true exact duplicate item groups: **4** -> blockers pending explicit disposition
-- existing suite apart from the intentionally failing audit probe: **1198 passed, 6 skipped, 1 deselected, 125 subtests passed**
+Formal master: `data/question_bank/question_equivalence_groups.json`.
 
-The permanent audit implementation on `work/pt-finalization-post-q2000` was updated to the same item-level semantics in commit `2a4403d188ddd0ea82572abbb1bcfba79ebcacfd`.
+Implemented semantics:
+- equivalent Q IDs can never become STRONG different-question repair evidence;
+- weakness evidence counts equivalent Q IDs as one question identity;
+- Recent Cooldown / exclude / same-session selection applies to the whole equivalence group;
+- raw Q IDs, official provenance, and Production attempt rows remain unchanged;
+- Q1411/Q1585 are reconciled only in **derived learning evidence**, because identical content was historically assigned to different raw Nodes.
 
-## Four true exact duplicate official-item groups
+Primary learner impact check:
+- Q972/Q1354/Q1067/Q1391/Q1230/Q1526/Q1411: no recorded attempts at review time;
+- Q1585: 4 attempts, all correct;
+- Q1585's historical raw Node `KN0659` also has Q667 attempts, but no raw history is rewritten.
 
-All four are repeated MHLW official items from different exam years. They must not be mechanically rewritten merely to make text unique.
+This avoids treating a repeated official item as independent understanding evidence while preserving historical identity.
 
-### 1. Q972 / Q1354
-- identical stem and identical five choices
-- identical official answer: `3・4`
-- Q972: 第56回 午前86
-- Q1354: 第59回 午後49
-- same canonical learning Node: `KN0962`
-- primary learner attempts: Q972=0, Q1354=0
+## 3. Same-stem / different-choice groups — REVIEWED AS NON-BLOCKERS
 
-### 2. Q1067 / Q1391
-- identical stem and identical five choices
-- identical official answer: `3`
-- Q1067: 第57回 午前41
-- Q1391: 第60回 午前27
-- same Node: `KN1057`
-- primary learner attempts: Q1067=0, Q1391=0
+The other 29 same-stem groups have materially different choice sets and are legitimate distinct official exam records. They must not be deleted merely because the exam stem is reused.
 
-### 3. Q1230 / Q1526
-- identical stem and identical five choices
-- identical official answer: `4`
-- Q1230: 第58回 午前91
-- Q1526: 第61回 午後42
-- same Node: `KN1215`
-- primary learner attempts: Q1230=0, Q1526=0
+Examples include recurring generic stems for SIAS, GMFM, ASIA, sympathetic actions, endocrine physiology, anatomy and pathology. Their distinct options test different facts.
 
-### 4. Q1411 / Q1585
-- identical stem and identical five choices
-- identical official answer: `3・4`
-- Q1411: 第60回 午前56
-- Q1585: 第49回 午前68
-- **currently assigned to different raw Nodes**:
-  - Q1411 -> `KN1387`: 下垂体後葉からはオキシトシンとバソプレシンが放出される
-  - Q1585 -> `KN0659`: バソプレシン（ADH）は視床下部で合成され、下垂体後葉から放出される
-- primary learner attempts: Q1411=0, Q1585=4/4 correct
+Disposition: **retain raw questions; review-only, not duplicate blockers.**
 
-The fourth pair is the highest-priority semantic issue because identical evidence can currently be represented as two different Node concepts.
+## 4. Near-duplicate sampling — no bulk rewrite justified
 
-## Same-stem / different-choice groups
+The highest-similarity non-exact sample was reviewed with stems, choices, answers, tags and explanations.
 
-The other 29 groups are **not automatically duplicates**. They preserve distinct official exam items whose generic stems recur while the choice sets test different facts. Many of these Q IDs have already been used in the primary learner's real history, so preserving Q-number/provenance is especially important.
+### Highly similar but acceptably distinct
+- Q1306 / Q855 — same AFO concept and same Node; very similar official questions. Retain. Same task/ability means they are not promoted to independent STRONG repair evidence merely from wording difference.
+- Q1575 / Q694 — same fracture-name knowledge and same Node; near-redundant official questions. Retain as provenance-distinct records.
+- Q949 / Q734 — same template but eye-muscle vs lower-limb nerve knowledge; clearly different content.
+- Q688 / Q1098 — both ASIA key muscles, but one is factual mapping while the other is broader assessment selection; different learning demand.
+- Q517/Q936 vs Q1192 — inner-foot lift vs outer-foot lift prosthetic alignment; opposite findings/causes, not duplicates.
+- Q1540 / Q891 — male reproductive system, but different facts and answer structures.
+- Q553 / Q611 — hip vs shoulder muscle action; template similarity only.
+- Q1489 / Q1392 — different basal-metabolism facts.
+- Q750 / Q616 — different disease/pathology combinations.
 
-Examples with both/all members already attempted include:
-- Q542 / Q1412 / Q1591: 7 attempts total
-- Q605 / Q815: 10 attempts total
-- Q617 / Q1225: 9 attempts total
-- Q1153 / Q1263: 8 attempts total
-- Q1261 / Q1358 / Q1535: 10 attempts total
+Disposition: **similarity >=0.90 remains a sampling trigger, not an automatic rewrite rule.** Current high-risk sample does not support bulk rewriting official items.
 
-These groups remain editorial/semantic review targets, not blocker-class duplicates.
+## 5. Editorial heuristics — sampled and accepted
 
-## Duplicate Knowledge Node label candidates
+### 14 short stems
+Examples such as `血液凝固因子はどれか。`, `発達評価はどれか。`, `錐体路徴候はどれか。`, `排便中枢はどれか。` are short because they are ordinary national-exam fact prompts. The options and explanations provide sufficient specificity.
 
-Two normalized label collisions remain:
+Q2000 itself (`排便中枢はどれか。`) has a substantive explanation identifying S2-S4 and the pelvic-nerve parasympathetic pathway.
+
+Disposition: **short stem alone is not a quality defect.**
+
+### 3 short global explanations
+- Q1434: 加齢で骨塩量は低下する。
+- Q1532: 三叉神経は橋外側から出る。
+- Q1576: 腸骨筋は大腿神経支配である。
+
+Each also has useful option-by-option rationale covering the distractors. Therefore the short summary explanation alone is not a blocker.
+
+Disposition: **accepted under the current explanation contract because option rationales are present and informative.**
+
+## 6. Duplicate Knowledge Node label review
 
 ### KN0597 / KN0807 — `交感神経の作用`
-Q605 and Q815 use the same generic stem with different choices and strongly overlapping concepts. This pair needs canonical/semantic review; simple label equality should not by itself decide the merge.
+This was already formally resolved before the Q2000 audit:
+- `KNC0001` is reviewed;
+- `KN0807` aliases to canonical `KN0597` in `knowledge_node_canonical_map.json`.
+
+Q605/Q815 are overlapping sympathetic-action fact questions; Q1960 extends the canonical concept into critical safety judgment. The raw duplicate labels are therefore **already one formal canonical Node**, not an unresolved duplicate.
+
+The audit has been corrected to report same-label raw Nodes that already canonicalize to one Node as informational rather than unresolved candidates.
 
 ### KN1142 / KN1252 — `筋と作用の組合せ`
-Q1155 tests facial/masticatory muscle actions while Q1268 tests lower-limb muscle actions. The identical label is too generic, but the concepts are not the same Node. Preferred disposition is more specific labeling, **not** an automatic merge.
+These are **not the same Node** despite identical generic labels:
+- Q1155 tests facial/masticatory muscle actions (e.g. frontalis, temporalis);
+- Q1268 tests lower-limb muscle actions (e.g. fibularis brevis, gracilis).
 
-## Learner-history preservation rule
+Disposition: **do not merge**. The label is overly generic and may be refined later for learner-facing clarity, but this is not evidence duplication and is not a structural blocker.
 
-Read-only Production inspection confirms that many repeated-stem Q IDs already have real attempt history. Therefore:
+## 7. CI evidence on the question-equivalence review branch
 
-1. Q-number remains immutable historical identity.
-2. Existing official past-exam records are not silently deleted or rewritten.
-3. A provenance repeat must not be counted as independent learning evidence merely because it has a different Q number.
-4. Any equivalence handling must preserve raw attempt history while canonicalizing only the evidence/selection interpretation.
+Draft PR #277 targets `work/pt-finalization-post-q2000` and remains non-Production.
 
-## Duplicate/equivalence implementation target
+Confirmed green full-suite runs include:
+- run `34310188257`: success
+- run `34310333706`: success
+- observed full-suite result: **1207 passed, 6 skipped, 1 deselected, 125 subtests passed**
 
-The preferred design is to retain all official exam records and formally register the four exact official provenance-repeat groups as **question-equivalence groups**.
+The temporary diagnostic PR #276 intentionally contains failing probes and must never be interpreted as an application regression or merged.
 
-Required semantics:
-- selector/cooldown treats equivalent Qs as the same evidence identity for recent/seen logic;
-- weakness evidence does not count two equivalent Q IDs as cross-question confirmation;
-- repair confirmation treats equivalent Q IDs as same-question evidence, never STRONG different-question evidence;
-- exact duplicate records remain traceable to both official exam years;
-- Q1411/Q1585 also requires Node-semantic reconciliation so identical content cannot independently influence two unrelated Node states.
+## 8. Completion contract remaining
 
-This is preferable to rewriting an official MHLW item or inventing replacement wording under an official Q ID.
+Before calling the Q2000 final-quality audit fully closed:
+1. confirm the latest audit/Node-canonicalization changes remain green in PR #277;
+2. record the final zero-blocker audit output;
+3. update `docs/CURRENT_STATE.md` with the accepted dispositions and final CI evidence;
+4. merge PR #277 only into the safe post-Q2000 working branch after green verification;
+5. close diagnostic PR #276 without merge.
 
-## Other review candidates
-
-- near-duplicate candidates at >=0.90 similarity: 72
-- stem-length heuristic candidates: 14
-- explanation-length heuristic candidates: 3
-
-These are sampling/review targets rather than automatic failures. Medical correctness and learning value decide disposition.
-
-## Current completion judgment
-
-`Q1-Q2000 / 2000` is a valid **count milestone**. The final bank is not yet accepted under the current completion contract because four true exact official-item repeats still need formal equivalence/Node disposition and the remaining review candidates need sampled closure.
-
-Next concrete work:
-1. formalize question-equivalence semantics for the four exact groups without changing Q identity;
-2. resolve Q1411/Q1585 Node semantics and the two duplicate-label Node candidates;
-3. inspect the highest-value near-duplicate/editorial candidates;
-4. re-run Question Bank validator, Node/selector/repair tests, final quality audit, and full regression suite;
-5. close temporary PR #276 after its evidence is fully captured; never merge it.
+No `main`, Render, LINE, or Production DB promotion is part of this closure step.

--- a/reports/question_bank_q2000_final_quality_audit.py
+++ b/reports/question_bank_q2000_final_quality_audit.py
@@ -1,8 +1,9 @@
 """Cross-sectional final quality audit for the formal Q1-Q2000 PT Question Bank.
 
 Read-only with respect to formal bank data. The script writes one JSON report under reports/.
-It is intentionally conservative: structural/data-integrity failures are blockers; editorial
-heuristics are review candidates, not automatic failures.
+Structural/data-integrity failures are blockers; editorial heuristics are review candidates.
+Reviewed exact official provenance repeats may remain as raw Q records only when a formal
+question-equivalence group makes them one derived learning-evidence identity.
 """
 from __future__ import annotations
 
@@ -11,6 +12,8 @@ import re
 from collections import Counter, defaultdict
 from difflib import SequenceMatcher
 from pathlib import Path
+
+from question_equivalence import get_question_equivalence_groups
 
 ROOT = Path(__file__).resolve().parents[1]
 BANK = ROOT / "data" / "question_bank"
@@ -49,12 +52,6 @@ def choice_keys(q: dict) -> set[str]:
 
 
 def choice_signature(q: dict) -> tuple[str, ...]:
-    """Normalized ordered choice text for true item-level duplicate detection.
-
-    Repeated generic past-exam stems are not duplicates when their choice sets test
-    materially different facts. A blocker requires the same normalized stem and the
-    same normalized ordered choices.
-    """
     choices = q.get("choices") or q.get("options") or []
     if isinstance(choices, dict):
         def order_key(item):
@@ -94,6 +91,7 @@ def main() -> int:
     tags = load("question_tags.json")
     nodes = load("knowledge_nodes.json")
     manifest = load("bank_manifest.json")
+    equivalence_groups = get_question_equivalence_groups()
 
     stores = {
         "questions": questions,
@@ -142,14 +140,17 @@ def main() -> int:
 
     normalized_to_ids = defaultdict(list)
     item_signature_to_ids = defaultdict(list)
+    item_signature_by_qid: dict[str, tuple[str, tuple[str, ...]]] = {}
     for qid in expected:
         q = qmap[qid]
         a = amap[qid]
         e = emap[qid]
         stem = get_stem(q).strip()
         norm = norm_text(stem)
+        signature = (norm, choice_signature(q))
         normalized_to_ids[norm].append(qid)
-        item_signature_to_ids[(norm, choice_signature(q))].append(qid)
+        item_signature_to_ids[signature].append(qid)
+        item_signature_by_qid[qid] = signature
         keys = choice_keys(q)
         sets = accepted_sets(a)
         if not stem:
@@ -190,8 +191,51 @@ def main() -> int:
         if stem and choices and len(v) > 1
     ]
     true_item_duplicates.sort(key=lambda group: int(group[0][1:]))
-    if true_item_duplicates:
-        blockers.append({"type": "exact_duplicate_items", "groups": true_item_duplicates})
+
+    reviewed_equivalence = {
+        frozenset(str(qid) for qid in record.get("question_ids") or []): record
+        for record in equivalence_groups
+        if record.get("review_status") == "reviewed"
+    }
+    registered_exact_repeats = []
+    unregistered_exact_duplicates = []
+    true_duplicate_sets = {frozenset(group) for group in true_item_duplicates}
+    for group in true_item_duplicates:
+        record = reviewed_equivalence.get(frozenset(group))
+        if record is None:
+            unregistered_exact_duplicates.append(group)
+        else:
+            registered_exact_repeats.append({
+                "equivalence_id": record.get("equivalence_id"),
+                "canonical_question_id": record.get("canonical_question_id"),
+                "canonical_knowledge_node_id": record.get("canonical_knowledge_node_id"),
+                "question_ids": group,
+                "equivalence_type": record.get("equivalence_type"),
+            })
+    if unregistered_exact_duplicates:
+        blockers.append({"type": "unregistered_exact_duplicate_items", "groups": unregistered_exact_duplicates})
+
+    invalid_equivalence_groups = []
+    for member_set, record in reviewed_equivalence.items():
+        if member_set not in true_duplicate_sets:
+            invalid_equivalence_groups.append({
+                "equivalence_id": record.get("equivalence_id"),
+                "question_ids": sorted(member_set, key=lambda value: int(value[1:])),
+                "reason": "reviewed equivalence group does not exactly match one item-level duplicate signature",
+            })
+        answer_signatures = {
+            tuple(tuple(values) for values in accepted_sets(amap[qid]))
+            for qid in member_set
+            if qid in amap
+        }
+        if len(answer_signatures) != 1:
+            invalid_equivalence_groups.append({
+                "equivalence_id": record.get("equivalence_id"),
+                "question_ids": sorted(member_set, key=lambda value: int(value[1:])),
+                "reason": "equivalent item records do not share the same accepted answer sets",
+            })
+    if invalid_equivalence_groups:
+        blockers.append({"type": "invalid_question_equivalence", "items": invalid_equivalence_groups})
 
     same_stem_different_choices = []
     for group in same_stem_groups:
@@ -266,6 +310,7 @@ def main() -> int:
         "question_count": len(questions),
         "blocker_count": len(blockers),
         "blockers": blockers,
+        "registered_exact_provenance_repeats": registered_exact_repeats,
         "distributions": distributions,
         "knowledge_nodes": node_summary,
         "review_candidate_counts": {k: len(v) for k, v in review.items()},
@@ -273,7 +318,9 @@ def main() -> int:
         "interpretation": {
             "blockers": "must be zero before PT bank is treated as structurally final",
             "review_candidates": "heuristic sampling targets; human/medical review decides whether changes are required",
-            "duplicate_policy": "same normalized past-exam stem is review-only when choices differ; same normalized stem plus same ordered choices is an item-level duplicate blocker",
+            "duplicate_policy": (
+                "same normalized past-exam stem is review-only when choices differ; exact item repeats are blockers unless a reviewed equivalence group preserves provenance while collapsing derived learning evidence"
+            ),
         },
     }
     OUT.write_text(json.dumps(report, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
@@ -283,6 +330,7 @@ def main() -> int:
         "question_count": report["question_count"],
         "blocker_count": report["blocker_count"],
         "blockers": report["blockers"],
+        "registered_exact_provenance_repeat_count": len(registered_exact_repeats),
         "distributions": report["distributions"],
         "knowledge_nodes": report["knowledge_nodes"],
         "review_candidate_counts": report["review_candidate_counts"],

--- a/reports/question_bank_q2000_final_quality_audit.py
+++ b/reports/question_bank_q2000_final_quality_audit.py
@@ -13,6 +13,7 @@ from collections import Counter, defaultdict
 from difflib import SequenceMatcher
 from pathlib import Path
 
+from knowledge_node_canonical import canonicalize_knowledge_node_id
 from question_equivalence import get_question_equivalence_groups
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -140,17 +141,14 @@ def main() -> int:
 
     normalized_to_ids = defaultdict(list)
     item_signature_to_ids = defaultdict(list)
-    item_signature_by_qid: dict[str, tuple[str, tuple[str, ...]]] = {}
     for qid in expected:
         q = qmap[qid]
         a = amap[qid]
         e = emap[qid]
         stem = get_stem(q).strip()
         norm = norm_text(stem)
-        signature = (norm, choice_signature(q))
         normalized_to_ids[norm].append(qid)
-        item_signature_to_ids[signature].append(qid)
-        item_signature_by_qid[qid] = signature
+        item_signature_to_ids[(norm, choice_signature(q))].append(qid)
         keys = choice_keys(q)
         sets = accepted_sets(a)
         if not stem:
@@ -290,9 +288,23 @@ def main() -> int:
             duplicate_node_labels[label_norm].append(nid)
     if bad_node_qrefs:
         blockers.append({"type": "node_question_reference_missing", "items": bad_node_qrefs})
-    same_label_nodes = [v for v in duplicate_node_labels.values() if len(v) > 1]
-    if same_label_nodes:
-        review["duplicate_node_label_candidates"] = same_label_nodes[:100]
+
+    unresolved_same_label_nodes = []
+    canonicalized_same_label_nodes = []
+    for raw_group in (v for v in duplicate_node_labels.values() if len(v) > 1):
+        canonical_ids = {str(canonicalize_knowledge_node_id(node_id)) for node_id in raw_group}
+        item = {
+            "raw_node_ids": raw_group,
+            "canonical_node_ids": sorted(canonical_ids),
+        }
+        if len(canonical_ids) == 1:
+            canonicalized_same_label_nodes.append(item)
+        else:
+            unresolved_same_label_nodes.append(item)
+    if unresolved_same_label_nodes:
+        review["duplicate_node_label_candidates"] = unresolved_same_label_nodes[:100]
+    if canonicalized_same_label_nodes:
+        review["duplicate_node_labels_already_canonicalized"] = canonicalized_same_label_nodes[:100]
 
     node_summary = {
         "registry_nodes": len(nodes),
@@ -320,6 +332,9 @@ def main() -> int:
             "review_candidates": "heuristic sampling targets; human/medical review decides whether changes are required",
             "duplicate_policy": (
                 "same normalized past-exam stem is review-only when choices differ; exact item repeats are blockers unless a reviewed equivalence group preserves provenance while collapsing derived learning evidence"
+            ),
+            "node_label_policy": (
+                "raw Nodes sharing a label are informational when they already resolve to one reviewed canonical Node; only labels spanning different canonical Nodes remain review candidates"
             ),
         },
     }

--- a/tests/test_q2000_final_quality_audit.py
+++ b/tests/test_q2000_final_quality_audit.py
@@ -1,0 +1,26 @@
+import json
+from pathlib import Path
+
+from reports.question_bank_q2000_final_quality_audit import main
+
+
+ROOT = Path(__file__).resolve().parents[1]
+REPORT = ROOT / "reports" / "question_bank_q2000_final_quality_audit.json"
+
+
+def test_q2000_final_quality_audit_has_no_structural_blockers():
+    assert main() == 0
+    report = json.loads(REPORT.read_text(encoding="utf-8"))
+    assert report["scope"] == "Q1-Q2000"
+    assert report["question_count"] == 2000
+    assert report["blocker_count"] == 0
+    assert len(report["registered_exact_provenance_repeats"]) == 4
+    assert {
+        frozenset(item["question_ids"])
+        for item in report["registered_exact_provenance_repeats"]
+    } == {
+        frozenset(("Q972", "Q1354")),
+        frozenset(("Q1067", "Q1391")),
+        frozenset(("Q1230", "Q1526")),
+        frozenset(("Q1411", "Q1585")),
+    }

--- a/tests/test_q2000_final_quality_audit.py
+++ b/tests/test_q2000_final_quality_audit.py
@@ -24,3 +24,18 @@ def test_q2000_final_quality_audit_has_no_structural_blockers():
         frozenset(("Q1230", "Q1526")),
         frozenset(("Q1411", "Q1585")),
     }
+
+    canonicalized = report["review_candidates"].get(
+        "duplicate_node_labels_already_canonicalized", []
+    )
+    assert any(
+        set(item["raw_node_ids"]) == {"KN0597", "KN0807"}
+        and item["canonical_node_ids"] == ["KN0597"]
+        for item in canonicalized
+    )
+
+    unresolved = report["review_candidates"].get("duplicate_node_label_candidates", [])
+    assert all(
+        set(item["raw_node_ids"]) != {"KN0597", "KN0807"}
+        for item in unresolved
+    )

--- a/tests/test_question_equivalence.py
+++ b/tests/test_question_equivalence.py
@@ -1,0 +1,128 @@
+from datetime import datetime, timezone
+import random
+
+from adaptive_question_selector import select_node_adaptive_questions
+from knowledge_node_repair_evidence import SAME_QUESTION, classify_repair_confirmation
+from knowledge_node_state_transition import derive_all_user_node_states, derive_knowledge_node_state
+from knowledge_node_weakness_evidence import (
+    REPEATED_SAME_QUESTION_WRONG,
+    derive_repeated_weakness_evidence,
+)
+from question_equivalence import (
+    are_equivalent_questions,
+    canonicalize_question_evidence_id,
+    canonicalize_question_evidence_node,
+    equivalent_question_ids,
+    get_question_equivalence_groups,
+)
+
+
+def _attempt(q, node, *, correct, confidence=1, at="2026-09-01T00:00:00+00:00"):
+    return {
+        "user_id": "u1",
+        "question_id": q,
+        "knowledge_node_id": node,
+        "is_correct": correct,
+        "confidence": confidence,
+        "answered_at": at,
+    }
+
+
+def test_reviewed_exact_official_repeat_groups_are_registered():
+    groups = get_question_equivalence_groups()
+    assert len(groups) == 4
+    assert {frozenset(item["question_ids"]) for item in groups} == {
+        frozenset(("Q972", "Q1354")),
+        frozenset(("Q1067", "Q1391")),
+        frozenset(("Q1230", "Q1526")),
+        frozenset(("Q1411", "Q1585")),
+    }
+
+
+def test_equivalent_questions_share_one_evidence_identity():
+    assert canonicalize_question_evidence_id("Q1354") == "Q972"
+    assert canonicalize_question_evidence_id("Q1585") == "Q1411"
+    assert equivalent_question_ids("Q1411") == frozenset(("Q1411", "Q1585"))
+    assert are_equivalent_questions("Q1411", "Q1585") is True
+    assert are_equivalent_questions("Q1411", "Q667") is False
+
+
+def test_cross_node_exact_repeat_uses_reviewed_evidence_node_without_mutating_raw_id():
+    assert canonicalize_question_evidence_node("Q1411", "KN1387") == "KN1387"
+    assert canonicalize_question_evidence_node("Q1585", "KN0659") == "KN1387"
+
+
+def test_exact_repeat_can_never_be_strong_repair_confirmation():
+    for first, second in (
+        ("Q972", "Q1354"),
+        ("Q1067", "Q1391"),
+        ("Q1230", "Q1526"),
+        ("Q1411", "Q1585"),
+    ):
+        assert classify_repair_confirmation(first, second) == SAME_QUESTION
+        assert classify_repair_confirmation(second, first) == SAME_QUESTION
+
+
+def test_equivalent_wrong_ids_do_not_create_cross_question_weakness():
+    attempts = [
+        _attempt("Q972", "KN0962", correct=False, at="2026-09-01T00:00:00+00:00"),
+        _attempt("Q1354", "KN0962", correct=False, at="2026-09-02T00:00:00+00:00"),
+    ]
+    evidence = derive_repeated_weakness_evidence(attempts)[0]
+    assert evidence["distinct_question_count"] == 1
+    assert evidence["wrong_question_count"] == 1
+    assert evidence["evidence_level"] == REPEATED_SAME_QUESTION_WRONG
+
+
+def test_cross_node_exact_repeat_is_one_derived_node_and_one_question():
+    attempts = [
+        _attempt("Q1585", "KN0659", correct=True, at="2026-09-01T00:00:00+00:00"),
+        _attempt("Q1411", "KN1387", correct=True, at="2026-09-02T00:00:00+00:00"),
+    ]
+    states = derive_all_user_node_states(
+        attempts,
+        as_of=datetime(2026, 9, 3, tzinfo=timezone.utc),
+    )
+    assert len(states) == 1
+    assert states[0]["canonical_node_id"] == "KN1387"
+    assert states[0]["distinct_question_count"] == 1
+    assert states[0]["state"] == "checking"
+
+
+def test_cross_node_exact_repeat_correct_does_not_confirm_prior_wrong():
+    attempts = [
+        _attempt("Q1411", "KN1387", correct=False, at="2026-09-01T00:00:00+00:00"),
+        _attempt("Q1585", "KN0659", correct=True, confidence=1, at="2026-09-02T00:00:00+00:00"),
+    ]
+    state = derive_knowledge_node_state(attempts, as_of=datetime(2026, 9, 2, tzinfo=timezone.utc))
+    assert state["canonical_node_id"] == "KN1387"
+    assert state["state"] == "repairing"
+    assert state["confident_correct_after_wrong_count"] == 0
+
+
+def test_selector_exclude_applies_to_entire_equivalence_group():
+    records = select_node_adaptive_questions(
+        [],
+        question_count=30,
+        exclude_ids=("Q1585",),
+        rng=random.Random(7),
+        as_of=datetime(2026, 9, 9, tzinfo=timezone.utc),
+    )
+    selected = {item["question_id"] for item in records}
+    assert "Q1585" not in selected
+    assert "Q1411" not in selected
+
+
+def test_recent_equivalent_member_applies_cooldown_to_whole_group():
+    attempts = [
+        _attempt("Q1585", "KN0659", correct=True, at="2026-09-09T00:00:00+00:00"),
+    ]
+    records = select_node_adaptive_questions(
+        attempts,
+        question_count=30,
+        rng=random.Random(11),
+        as_of=datetime(2026, 9, 9, 1, tzinfo=timezone.utc),
+    )
+    selected = {item["question_id"] for item in records}
+    assert "Q1585" not in selected
+    assert "Q1411" not in selected


### PR DESCRIPTION
Draft review PR for Q2000 final-quality closure. Preserves raw official Q IDs and Production history while treating four reviewed exact MHLW provenance repeats as one derived learning-evidence identity. Includes cross-node reconciliation for Q1411/Q1585 at derivation time only. No Production DB write, Render/LINE change, or main merge. Do not merge until tests and learner-history impact audit are reviewed.