### PR TITLE
Consolidate learner dashboard onto formal evidence

### DIFF
--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -1,317 +1,212 @@
 # LicenseTown Current State
 
 Last updated: 2026-09-09
-Active safe branch: `work/pt-finalization-post-q2000`
+Active implementation branch: `work/dashboard-formal-consolidation-v01`
+Safe integration base: `work/pt-finalization-post-q2000`
 
-## Purpose
-
-This file is the durable source of truth for **what is working, what is not finished, known problems/risks, the intended target state, and the next concrete work**.
-
+## How to resume
 On every new LicenseTown development/chat session:
 1. read `AGENTS.md`;
 2. read this file;
-3. verify only facts affected by newer changes;
-4. continue from the open work instead of rediscovering the repository.
+3. verify only facts affected by newer commits/data;
+4. continue from the current open work instead of rediscovering the repository.
 
-Whenever implementation status, validation evidence, design decisions, production behavior, data contracts, risks, or next work change, update this file in the same development cycle.
+Update this file in the same development cycle whenever implementation status, validation evidence, design decisions, production behavior, data contracts, risks or next work change.
 
-Distinguish these states explicitly:
-- code exists;
-- tests pass;
-- real data observed;
-- production/product behavior accepted.
+Distinguish: **code exists / tests pass / real data observed / product accepted**.
 
 ---
 
-# 1. Question Bank / Q2000
+# 1. Question Bank / Q2000 — CLOSED
 
-## Status: CLOSED for final-quality audit on the safe post-Q2000 branch
-
-## Done / working now
-- Formal PT Question Bank: **Q1-Q2000 / 2000 questions**.
-- Bank version: **`2026-09-b20`**.
-- Normal learning uses stored Question Bank data; it does not generate each ordinary question through OpenAI.
-- Q-number remains immutable historical identity.
-- Questions, answers, explanations, tags, Knowledge Nodes and related contracts are structured data.
-- Q2000 final cross-sectional audit has been completed with automatic audit plus targeted human/medical sampling.
-
-### Duplicate audit disposition
-- 33 normalized same-stem groups were initially detected.
-- After refining identity to `normalized stem + ordered choices`, the result was:
-  - **29 legitimate same-stem / different-choice MHLW items**;
-  - **4 exact official provenance-repeat groups**.
-- The four exact official repeats are:
+- Formal PT Question Bank: **Q1-Q2000 / 2000**, bank version **`2026-09-b20`**.
+- Final cross-sectional quality audit is closed on the safe post-Q2000 branch.
+- 33 same-stem groups were reduced to:
+  - 29 legitimate same-stem/different-choice official items;
+  - 4 exact official provenance repeats.
+- Exact-repeat groups:
   - Q972 / Q1354
   - Q1067 / Q1391
   - Q1230 / Q1526
   - Q1411 / Q1585
-- These official records are preserved, not rewritten or deleted.
-- They are registered in `data/question_bank/question_equivalence_groups.json` as one **derived learning-evidence identity** per group.
-- Equivalent Q IDs cannot:
-  - count as independent cross-question weakness evidence;
-  - become STRONG different-question repair confirmation;
-  - bypass Recent Question Cooldown merely by switching to the equivalent raw Q ID.
-- Raw Q IDs, provenance and persisted learner attempts remain unchanged.
+- Exact official repeats remain separate raw Q/provenance records but are one derived learning-evidence identity via `question_equivalence_groups.json`.
+- They cannot inflate cross-question weakness, STRONG repair confirmation, or Recent Cooldown behavior.
+- Q1411/Q1585 identical cross-Node content is reconciled only in derived evidence under KN1387; Production history is not rewritten.
+- 72 near-duplicate candidates were sampling targets; high-risk samples did not justify bulk rewriting official questions.
+- 14 short-stem and 3 short-summary-explanation candidates were sampled and accepted under the current explanation/option-rationale contract.
+- KN0597/KN0807 duplicate raw label was already formally canonicalized by KNC0001.
+- KN1142/KN1252 share a generic label but test different muscle regions; do not merge.
+- PR #277 merged only to `work/pt-finalization-post-q2000` at **`8792e5f542d726286f5420085d7964f648500548`**.
+- Final pre-merge full CI: **1208 passed, 6 skipped, 1 deselected, 125 subtests passed**.
+- Diagnostic PR #276 closed without merge.
+- No `main`, Render, LINE or Production DB promotion occurred.
 
-### Cross-Node exact repeat
-- Q1411/Q1585 are identical official content but historically had different raw Knowledge Nodes.
-- Derived learning evidence is reconciled under **KN1387** without rewriting Production history.
-- Primary learner impact check at review time:
-  - Q1585 had 4 attempts, all correct;
-  - the other seven exact-repeat Q IDs had no recorded attempts.
-
-### Near-duplicate / editorial sampling
-- 72 near-duplicate candidates (`>=0.90` normalized similarity in the same category) were audit targets, not automatic failures.
-- Highest-risk samples were inspected with stem, options, answers, tags and explanations.
-- Sampled high-similarity pairs were either legitimate official variants, opposite/related findings, different body regions, different facts, or different learning demands.
-- No evidence justified bulk rewriting official past-exam items.
-- 14 short-stem candidates were reviewed as ordinary national-exam fact prompts with sufficient options/explanations.
-- 3 short global-explanation candidates were reviewed; each had informative option-by-option rationales, so summary length alone was not a quality defect.
-
-### Knowledge Node label audit
-- KN0597 / KN0807 (`交感神経の作用`) were already formally canonicalized by reviewed `KNC0001`: KN0807 -> KN0597. This is not an unresolved duplicate Node.
-- KN1142 / KN1252 (`筋と作用の組合せ`) test different concepts (facial/masticatory vs lower-limb muscle actions). **Do not merge.** Their generic labels may be refined later for learner-facing clarity.
-
-### Final integration / CI
-- Review PR #277 was promoted out of draft only after green CI and merged **only into `work/pt-finalization-post-q2000`**.
-- Safe-branch merge commit: **`8792e5f542d726286f5420085d7964f648500548`**.
-- Latest pre-merge head: `9691404dee87026e7f928d3c6641957685e34809`.
-- Latest full CI on that head: **SUCCESS**.
-- Full suite evidence immediately before merge: **1208 passed, 6 skipped, 1 deselected, 125 subtests passed**.
-- Diagnostic PR #276 was closed **without merge** after evidence capture.
-- No `main`, Render, LINE or Production Neon mutation was part of this Q2000 audit closure.
-
-## Remaining non-blocking improvement
-- Knowledge Node labels can still be improved for learner-facing clarity where technically correct labels are too generic.
-- Future medical/editorial issues discovered through real use remain eligible for normal correction; “audit closed” does not mean the bank can never change.
-
-## Target state
-- Preserve official provenance while preventing duplicate evidence from inflating learning-state confidence.
-- Keep medical validity and learning value above cosmetic uniqueness.
-- Any future bank change must rerun affected validator / Node / repair / selector tests and regression checks.
+Detailed record: `reports/q2000_final_quality_review_20260909.md`.
 
 ---
 
-# 2. Formal data authority / learning evidence
+# 2. Formal learning-data authority
 
-## Done / working now
-- `question_attempts` is the authoritative durable attempt history for formal learner-state derivation.
-- Knowledge Node state is formally derived from attempt history with pure logic; `user_node_state` is not formal truth.
-- Formal path is:
+- `question_attempts` is the authoritative durable attempt history.
+- Formal Node state is pure-derived from attempts; `user_node_state` is not formal truth.
+- Authority path:
   `question_attempts -> derived Node state -> field/strategy/readiness -> selector/presentation`.
-- Unknown/unanswered-like evidence is distinguished from evaluable answers.
-- Primary learner snapshot measured on 2026-09-09:
+- Primary learner snapshot measured 2026-09-09:
   - **1525 attempts**
-  - **1103 correct (72.3%)**
+  - **1103 correct = 72.3%**
   - **740 unique questions**
   - **572 unique raw Knowledge Nodes**
 
-## Known risk
-- Reading legacy/supporting persisted state alone can produce false conclusions about repair/retention.
-
-## Target state
-- One explicit authority chain; any persisted derived state must be treated only as cache/supporting data unless formally promoted.
+Do not infer formal state from legacy persisted state alone.
 
 ---
 
 # 3. Repair / retention
 
-## Done / working now
-- Same-question, weak different-question and STRONG different-question evidence are separated.
-- A confident (`confidence=1`) STRONG different-question correct answer after wrong evidence can move a Node to `repaired`.
-- Later wrong evidence can regress it to `repairing`.
-- Retention states include `repaired`, `recheck_due`, `stable`.
-- Natural real use has exercised STRONG repair supply.
-- 2026-09-06 natural use included 35 STRONG different-question repairing attempts, 26 correct, including 13 confidence-1 formal-confirmation candidates.
-- Confirmed natural example: KN0394 using Q399 / Q1572.
-- Q399 repair reference: 2026-09-02 18:32:30 JST.
-- First 7-day recheck boundary: 2026-09-09 18:32:30 JST.
+Working:
+- same-question / weak different-question / STRONG different-question evidence are separated;
+- confident STRONG confirmation can move `repairing -> repaired`;
+- later wrong evidence can regress to `repairing`;
+- retention states include `repaired`, `recheck_due`, `stable`;
+- natural STRONG repair supply is already exercised.
 
-## Not finished yet
-- Natural evidence for the full cycle
-  `wrong -> STRONG repair -> spacing -> recheck_due -> stable/repairing`
-  is still insufficient.
-- Repair durability after spacing remains **OPEN**.
+Natural example:
+- KN0394, Q399 / Q1572;
+- repair reference Q399 at 2026-09-02 18:32:30 JST;
+- first 7-day recheck boundary 2026-09-09 18:32:30 JST.
 
-## Rule
-- Do not manufacture special learner activity just to close the retention gate.
+OPEN:
+- natural proof of the complete spaced cycle
+  `wrong -> STRONG repair -> spacing -> recheck_due -> stable/repairing`.
+
+Do not manufacture learner activity to close this gate.
 
 ---
 
-# 4. Phase11 learning-strategy judgment engine
+# 4. Phase11 strategy engine — HOLD / Shadow-only
 
-## Current rollout state: HOLD / Shadow-only
+Implemented intents include Safety repair, confident/repeated wrong repair, ongoing repairing, retention recheck, uncertain checking, coverage expansion and maintenance.
 
-The engine exists and is substantially implemented. The remaining issue is evidence for promotion, not a known blocking code defect.
+Phase11 decides **what/why/how many/intent**; Phase10/selector owns exact Q.
 
-## Strategy responsibilities already implemented
-Phase11 can distinguish major intents including:
-- Safety repair
-- confident-wrong repair
-- repeated/cross-question wrong repair
-- ongoing repairing
-- retention recheck
-- uncertain correct/checking
-- coverage expansion
-- maintenance
-
-Phase11 decides **what/why/how many/intent**. Phase10/selector owns the exact Q numbers.
-
-## Automatic promotion gates — current evidence
+Automatic gate status:
 - Repeat audit: **PASS**
-  - adaptive spaced repeat 293
-  - justified cooldown bypass 12
-  - non-adaptive repeat 237
-  - audit metadata unavailable 252
-  - adaptive unexplained repeat **0**
-  - metadata inconsistent **0**
 - Critical Safety retrospective: **PASS-to-date**
-- J2/J3 formal trigger consistency: **PASS**
-- Current profile consistency: **PASS**
-- Retrospective replay coverage: **PASS** for 9 recommendation-plan anchors
-  - missing attempts 0
-  - question-ID mismatch 0
+- J2/J3 trigger consistency: **PASS**
+- current profile consistency: **PASS**
+- retrospective replay coverage across 9 recommendation anchors: **PASS**
 - Retention: **OPEN**
-- recheck intent -> exact-Q alignment: **OPEN** because no natural persisted `recheck_due` selection existed at review time
+- recheck intent -> exact-Q alignment: **OPEN**
 - retrospective comparison diversity: **OPEN**
-- currently identified automatic BLOCKED/FAIL gates: **none**
+- current automatic FAIL/BLOCKED: **none**
 
-## Manual/product promotion criteria
-- architecture/ownership boundaries: **PASS**
-- Phase10 adaptive dependency: **PASS**
-- ordinary single-wrong overreaction: **PASS-to-date / monitor**
-- sparse-coverage conservatism: **PASS-to-date / monitor**
-- repair mechanics / STRONG supply: **PASS-to-date**
-- repair durability after spacing: **OPEN**
-- prospective recommendation relevance vs Baseline: **OPEN**
-- symmetric disagreement breadth: **OPEN**
-- final human learner-facing promotion review: **OPEN by design**
+Manual/product status:
+- architecture boundaries: PASS
+- Phase10 adaptive dependency: PASS
+- ordinary single-wrong overreaction: PASS-to-date / monitor
+- sparse coverage conservatism: PASS-to-date / monitor
+- STRONG repair mechanics: PASS-to-date
+- repair durability: OPEN
+- prospective recommendation relevance vs baseline: OPEN
+- symmetric disagreement breadth: OPEN
+- final human promotion review: OPEN by design
 
-One prospective 2026-09-02 disagreement favored the Baseline field (神経医学) over the Shadow field (心理学) for immediate learner-perceived priority, while the Shadow field was still rated important. This is useful mixed evidence and is not sufficient to tune or promote either policy.
+No promotion until natural evidence is sufficient. First promotion, if approved, must be limited/feature-gated.
 
-## Promotion rule
-- Automatic diagnostics never self-promote Phase11.
-- Do not convert OPEN into PASS using manufactured data.
-- First learner-facing promotion, if approved later, should be a limited feature-flagged pilot rather than a full replacement.
-
-## Next re-evaluation trigger
-Re-run Phase11 evidence when natural data supplies:
-- first qualified `recheck_due` execution/outcome;
-- exact-Q alignment evidence for that recheck;
-- additional retrospective comparison direction;
-- additional ordinary learner-relevance evidence.
+Detailed record: `reports/phase11_promotion_review_20260909.md`.
 
 ---
 
-# 5. Adaptive selector / Recent Question Cooldown
+# 5. Adaptive selector / cooldown
 
-## Done / working now
-- Adaptive selection works at Knowledge Node level.
-- STRONG different-question repair supply can be preferred.
-- Recent Question Cooldown avoids recent repeats when adequate non-recent supply exists, with limited Safety exceptions.
-- Adaptive audit metadata persists selection reason/group/score, repair evidence quality, repeat and bypass flags.
-- Current real data contains no unexplained or internally inconsistent adaptive-repeat defect.
-- Exact official provenance repeats are now collapsed to one evidence identity for cooldown/selection interpretation on the safe post-Q2000 branch.
+- Node-level adaptive selection works.
+- STRONG different-question repair can be preferred.
+- Recent Question Cooldown is active with limited Safety exception behavior.
+- Adaptive audit metadata persists selection reason/group/score, repair evidence quality, recent repeat and bypass flags.
+- Current real history has no unexplained/internally inconsistent adaptive-repeat defect.
+- Exact official provenance repeats now share one derived evidence identity for selection/cooldown interpretation on the safe branch.
 
-## Not finished yet
-- Continue natural validation under Q2000 supply.
-- recheck-specific intent/selection compatibility still waits for natural `recheck_due` evidence.
+OPEN: natural recheck-specific alignment evidence.
 
 ---
 
-# 6. Dashboard / learner navigation
+# 6. Dashboard / learner navigation — ACTIVE WORK
 
-## Done / working now
-- A formal real-data dashboard/shadow implementation exists.
-- It can compute Node coverage, mastery/state, field progress, weakness priorities, strategy intent, Safety/repair/recheck/coverage signals and learner navigation.
-- `/goukaku-no-michi` already constructs learner navigation from formal inputs.
-- Learner CTA carries field, count, learning intent and reason code.
-- Formal pass-readiness is an evidence-gated status machine, **not a pass probability**.
+## What already works
+- `/goukaku-no-michi` calls `build_dashboard(..., include_learner_navigation=True)`.
+- Formal learner-navigation is already built from authoritative attempts/readiness/shadow evidence.
+- Formal `現在地`, `今日やること`, formal priority items, repair/coverage/retention guidance are already visible.
+- Formal overall-progress presentation is already used on the learner page because learner navigation forces that calculation path.
+- Factual counters (answers, study time, recent/average accuracy, streak) come from saved dashboard aggregates and remain useful.
 
-## Not finished yet
-- Legacy aggregates and formal derived metrics still coexist in parts of the UI/code path.
-- Visible cards do not yet have one fully consolidated source-of-truth hierarchy.
+## Source map completed
+Detailed source map: `reports/dashboard_source_map_20260909.md`.
 
-## Known risk
-- Mixing legacy and formal metrics can confuse both learner and developer and can create apparently conflicting progress numbers.
+Main findings:
+1. **Two recommendation authorities are visible on the same learner page.**
+   - Top `今日やること` / formal TOP3 = formal learner navigation.
+   - Lower `優先課題 TOP3` and `今日のおすすめ学習` = legacy `build_learning_guidance`.
+   - These can disagree and must not remain independent authorities.
+2. **Field progress is semantically mixed.**
+   - Formal overall progress is shown.
+   - `分野別 到達度` remains legacy accuracy bars unless `ENABLE_FIELD_PROGRESS_UI` is enabled.
+   - Accuracy is useful, but it is not the same concept as formal field progress.
+3. `源さんの一言` still depends on legacy weak/recommendation inputs and is therefore mixed presentation.
+4. Factual counters and reward/milestone counts are not competing strategy authorities and should remain.
 
 ## Target state
-- One coherent learner-facing dashboard driven by formal evidence.
-- Clearly separate:
-  - ordinary accuracy
-  - coverage
-  - repair/stability
-  - readiness evidence
-  - recommended next action
-- No fake precision and no pass-guarantee wording.
+- One recommendation authority: formal learner navigation/derived evidence.
+- Formal per-field progress on the learner page; accuracy shown explicitly only as accuracy.
+- Legacy guidance remains fallback/compatibility until all supporter/read-only callers are mapped, but must not compete on the learner page.
+- Preserve auth, recommendation-start behavior and factual counters.
 
-## Next concrete work — ACTIVE
-1. Map every visible dashboard card to its actual data source.
-2. Classify each card as formal / legacy / mixed / demo.
-3. Decide retain / replace / demote / remove.
-4. Consolidate to one formal hierarchy without breaking current learner flow.
+## Next implementation — NOW
+1. Make formal field-progress presentation active whenever learner navigation is enabled.
+2. Make lower learner-page priority/recommendation mirror the formal learner-navigation source or remove the duplicate authority.
+3. Preserve legacy behavior for contexts that do not enable formal learner navigation.
+4. Add regression tests for learner-page source authority.
+5. Run targeted dashboard tests, then full CI before safe-branch integration.
 
 ---
 
 # 7. Weakness analysis / companion record
 
-## Done / working now
-- Formal active weakness derivation exists at Node and field level.
-- Confident wrong, repeated wrong, active repairing, Safety and recheck signals are available.
-- Learner/supporter summaries already cover substantial current-state information.
+Working:
+- formal active weakness at Node/field level;
+- confident wrong, repeated wrong, repairing, Safety and recheck signals;
+- current-state learner/supporter summaries.
 
-## Not finished yet
-- A true longitudinal companion record is not yet a finished first-class product feature.
+Not finished:
+- first-class longitudinal companion record.
 
-## Target state
-Record the learning story, not only the current snapshot:
-- important weakness episode
-- evidence that triggered it
-- what intervention/selection was tried
-- whether repair was confirmed
-- whether it remained repaired after spacing
-- major strategy changes
-- concise learner/supporter summary
-- references back to raw evidence for auditability
+Target record:
+- weakness episode and triggering evidence;
+- intervention/selection;
+- repair confirmation;
+- spaced retention outcome;
+- major strategy changes;
+- concise learner/supporter summary with raw evidence references.
 
-## Next concrete work
-- Design the minimum useful longitudinal schema after dashboard source consolidation.
+Start after dashboard authority consolidation.
 
 ---
 
 # 8. Learning-time linkage
 
-## Done / working now
-- Learning time is persisted separately.
-- Time-event keys may intentionally use suffixes such as `:time` for idempotency.
-
-## Not finished yet
-- There is no finalized explicit relational key tying a learning session/batch to all net learning-time events for higher-quality fatigue/time-efficiency analysis.
-
-## Rule / priority
-- Do not misuse raw event-key equality as a relational join.
-- Defer session/time-link redesign until higher-value dashboard/companion work is complete.
+- Learning time persists separately.
+- `:time`-style event keys may intentionally differ for idempotency.
+- Do not treat event-key equality as a relational join.
+- Explicit session/batch linkage for fatigue/time-efficiency analysis remains lower priority.
 
 ---
 
-# 9. Current priority order
+# 9. Current priority
 
-1. **Formal-vs-legacy dashboard source map and consolidation** — active now.
-2. Phase11 promotion-gate re-evaluation when new natural retention/recheck/comparison evidence appears.
-3. Longitudinal weakness/companion-record design and implementation.
-4. Lower-priority session/time linkage improvement.
+1. **Dashboard formal-vs-legacy consolidation** — active branch `work/dashboard-formal-consolidation-v01`.
+2. Re-evaluate Phase11 when new natural retention/recheck/comparison evidence appears.
+3. Longitudinal companion record.
+4. Session/time linkage later.
 
-Q2000 final-quality audit is closed on the safe post-Q2000 branch; do not restart it from zero unless new evidence reveals a genuine issue.
+Do not restart Q2000 audit from zero unless new evidence exposes a genuine issue.
 
-Practical effect for the learner and national-exam success take priority over architectural elegance.
-
----
-
-# 10. Working rules
-
-- Before proposing a change, check whether the capability already exists.
-- Do not rediscover the whole system every session; start from `AGENTS.md` + this file and verify only affected facts.
-- Distinguish **code exists / tests pass / real data observed / production behavior accepted**.
-- Do not casually change `main`, Render, LINE or Production DB.
-- Prefer small verified changes: hypothesis -> implementation -> real use -> result -> correction.
-- If a change alters any fact here, update this file in the same development cycle.
+Practical learner effect and national-exam success outrank architectural elegance.

--- a/reports/dashboard_source_map_20260909.md
+++ b/reports/dashboard_source_map_20260909.md
@@ -34,50 +34,66 @@ Legacy learning summary/activity data remains useful for factual counters such a
 | 平均正答率 | saved dashboard summary | FACTUAL AGGREGATE | RETAIN |
 | 連続学習日数 | saved activity aggregate | FACTUAL AGGREGATE | RETAIN |
 | 分野別 到達度 | formal only when `ENABLE_FIELD_PROGRESS_UI` is enabled; otherwise legacy field accuracy list | MIXED / FLAGGED | FORMALIZE |
-| lower-page 優先課題 TOP3 (`dashboard.weak_fields`) | `build_learning_guidance(...)` legacy path | LEGACY INTERPRETATION | REPLACE/DEMOTE; duplicates formal TOP3 |
-| lower-page 今日のおすすめ学習 (`dashboard.recommended_study`) | `build_learning_guidance(...)` legacy path | LEGACY INTERPRETATION | REPLACE with formal today action; currently duplicate authority |
+| lower-page 優先課題 TOP3 (`dashboard.weak_fields`) | `build_learning_guidance(...)` legacy path | LEGACY INTERPRETATION | HIDE on formal learner page; retain fallback data for legacy callers |
+| lower-page 今日のおすすめ学習 (`dashboard.recommended_study`) | `build_learning_guidance(...)` legacy path | LEGACY INTERPRETATION | HIDE on formal learner page; retain fallback data for legacy callers |
 | 源さんの一言 | `build_gensan_comment(...)` using legacy fields/weak/recommended inputs | LEGACY/MIXED PRESENTATION | KEEP temporarily; later make formal-input aware |
 | reward/milestone progress | saved answer-count reward calculation | FACTUAL/GAMIFICATION | RETAIN |
 
 ## Main inconsistency found
 
-The page currently contains **two recommendation systems at once**:
+The page originally contained **two recommendation systems at once**:
 
 1. top learner-navigation block: formal evidence and strategy intent;
 2. lower `優先課題 TOP3` + `今日のおすすめ学習`: legacy `build_learning_guidance` output.
 
-This can show different fields or different reasons on one page. The top formal CTA already carries field, question count, learning intent and reason code into the recommendation-start endpoint, so the lower legacy recommendation is no longer needed as an independent authority.
+This could show different fields or different reasons on one page. The top formal CTA already carries field, question count, learning intent and reason code into the recommendation-start endpoint, so the lower legacy recommendation is not needed as an independent authority.
+
+## Consolidation v0.1 implemented on `work/dashboard-formal-consolidation-v01`
+
+The learner-page layout now detects the formal `.learner-navigation` block and, only when that formal block exists:
+
+- removes the lower legacy `.weak-card`;
+- removes the lower legacy `.recommend-card`;
+- preserves factual counters, source data and legacy fallback structures in Python;
+- leaves supporter/read-only/legacy contexts unchanged because the DOM change is conditional on formal learner navigation;
+- if formal field-progress rows are not present yet, relabels the old subject percentage section from `分野別 到達度` to **`分野別 正答率（参考）`** so accuracy is not presented as formal attainment.
+
+This is deliberately a small source-authority fix rather than a dashboard redesign.
 
 ## Field-progress inconsistency
 
-`include_learner_navigation=True` forces formal overall-progress presentation, but **does not force formal field-progress UI**. Field-level display still depends on `ENABLE_FIELD_PROGRESS_UI`.
+`include_learner_navigation=True` forces formal overall-progress presentation, but **does not yet force formal field-progress UI**. Field-level display still depends on `ENABLE_FIELD_PROGRESS_UI`.
 
-Therefore a learner can currently see:
+Until that backend activation is completed, the learner page no longer calls legacy per-field accuracy `到達度`; it is explicitly shown as reference accuracy only.
+
+Target end state remains:
 - formal overall progress based on coverage/state evidence;
-- legacy per-field accuracy bars labeled as `分野別 到達度` when the field-progress flag is off.
+- formal per-field progress based on the same evidence;
+- accuracy shown separately as accuracy.
 
-That is semantically inconsistent. Accuracy is useful, but it is not the same thing as formal field progress.
+## Recommended minimal consolidation v0.2
 
-## Recommended minimal consolidation v0.1
+1. Make formal field-progress presentation active on the signed learner route without silently changing supporter/read-only legacy behavior.
+2. Keep ordinary accuracy visible as a sub-metric.
+3. Preserve factual counters (answers/time/accuracy/streak); they are not competing strategy authorities.
+4. Do not promote Phase11 merely because the dashboard uses formal navigation. Learner-facing strategy remains constrained by the existing promotion/feature-gate contract where applicable.
+5. Keep `build_learning_guidance` available for legacy/supporter compatibility until every caller is mapped; do not delete it yet.
 
-Do not redesign the whole dashboard at once.
+## Acceptance criteria
 
-1. When `learner_navigation_enabled=True`, make formal field-progress presentation active as well. Keep ordinary accuracy visible as a sub-metric.
-2. Replace the lower legacy `優先課題 TOP3` content with the same formal `attention_items` already used by learner navigation, or hide the duplicate lower block. Prefer one recommendation authority.
-3. Replace lower `今日のおすすめ学習` with `learner_navigation.today_action` when formal navigation exists. Legacy recommendation remains fallback only for non-formal/read-only legacy contexts.
-4. Preserve factual counters (answers/time/accuracy/streak); they are not competing strategy authorities.
-5. Do not promote Phase11 merely because the dashboard uses formal navigation. Learner-facing strategy remains constrained by the existing promotion/feature-gate contract where applicable.
-6. Keep `build_learning_guidance` available for legacy/supporter compatibility until every caller is mapped; do not delete it in this first change.
-
-## Acceptance criteria for consolidation change
-
+### v0.1
 - Learner page never displays two conflicting recommended fields from formal and legacy systems.
-- `分野別 到達度` on the learner page uses formal field-progress calculation, with accuracy clearly shown only as accuracy.
+- Legacy field accuracy is not mislabeled as formal attainment.
 - Existing factual counters remain unchanged.
 - Existing authentication and recommendation-start behavior remain unchanged.
-- Supporter/read-only pages are not silently changed unless explicitly covered by tests.
+- Supporter/read-only pages are not silently changed.
+- Full regression suite remains green.
+
+### final dashboard consolidation
+- `分野別 到達度` on the learner page uses formal field-progress calculation, with accuracy clearly shown only as accuracy.
+- One formal recommendation/priority authority remains learner-facing.
 - Full regression suite remains green.
 
 ## Next implementation step
 
-Create a small learner-page-only consolidation change on `work/dashboard-formal-consolidation-v01`, add regression tests for source authority, run targeted dashboard tests, then full CI before any safe-branch integration.
+After v0.1 CI is green, integrate it into `work/pt-finalization-post-q2000`, then complete the small backend learner-route-only formal field-progress activation as v0.2.

--- a/reports/dashboard_source_map_20260909.md
+++ b/reports/dashboard_source_map_20260909.md
@@ -1,0 +1,83 @@
+# Dashboard source map — 2026-09-09
+
+Scope: learner-facing `/goukaku-no-michi` on safe post-Q2000 branch.
+
+Purpose: identify which visible cards are driven by formal derived evidence, ordinary factual aggregates, legacy guidance, or mixed sources before any consolidation change.
+
+## Current rendering path
+
+`/goukaku-no-michi` calls:
+
+`build_dashboard(user_id, include_learner_navigation=True)`
+
+This means the current learner page always builds the formal learner-navigation path and formal overall-progress presentation, while several older cards are still populated from the legacy guidance path.
+
+Formal authority remains:
+
+`question_attempts -> build_field_evidence -> build_field_progress / derived Node state -> dashboard_real_data_shadow / pass_readiness -> learner presentation`
+
+Legacy learning summary/activity data remains useful for factual counters such as total answers, study time, streak and recent accuracy; the problem is not that all old data is invalid, but that **legacy recommendation/weakness interpretation still coexists with formal interpretation on the same page**.
+
+## Visible card source map
+
+| Visible area | Current source | Classification | Disposition |
+|---|---|---|---|
+| 現在地 | `learner_navigation` from formal attempts/readiness/shadow | FORMAL | RETAIN |
+| 今日やること | `learner_navigation.today_action` | FORMAL | RETAIN as recommendation authority |
+| 優先課題 TOP3 inside learner navigation | formal `attention_items` | FORMAL | RETAIN as priority authority |
+| できていること / 直していること / 未確認 / 次の確認 | formal learner navigation | FORMAL | RETAIN |
+| 試験日 / 残り日数 | dashboard settings | FACTUAL SETTINGS | RETAIN |
+| 合格への到達度 | formal `overall_progress_preview` when learner navigation is included | FORMAL | RETAIN |
+| 総回答数 | saved dashboard summary | FACTUAL AGGREGATE | RETAIN |
+| 累計学習時間 | saved activity/time aggregate | FACTUAL AGGREGATE | RETAIN, with known session-link analysis limitation |
+| 直近7日正答率 | saved dashboard summary | FACTUAL AGGREGATE | RETAIN |
+| 平均正答率 | saved dashboard summary | FACTUAL AGGREGATE | RETAIN |
+| 連続学習日数 | saved activity aggregate | FACTUAL AGGREGATE | RETAIN |
+| 分野別 到達度 | formal only when `ENABLE_FIELD_PROGRESS_UI` is enabled; otherwise legacy field accuracy list | MIXED / FLAGGED | FORMALIZE |
+| lower-page 優先課題 TOP3 (`dashboard.weak_fields`) | `build_learning_guidance(...)` legacy path | LEGACY INTERPRETATION | REPLACE/DEMOTE; duplicates formal TOP3 |
+| lower-page 今日のおすすめ学習 (`dashboard.recommended_study`) | `build_learning_guidance(...)` legacy path | LEGACY INTERPRETATION | REPLACE with formal today action; currently duplicate authority |
+| 源さんの一言 | `build_gensan_comment(...)` using legacy fields/weak/recommended inputs | LEGACY/MIXED PRESENTATION | KEEP temporarily; later make formal-input aware |
+| reward/milestone progress | saved answer-count reward calculation | FACTUAL/GAMIFICATION | RETAIN |
+
+## Main inconsistency found
+
+The page currently contains **two recommendation systems at once**:
+
+1. top learner-navigation block: formal evidence and strategy intent;
+2. lower `優先課題 TOP3` + `今日のおすすめ学習`: legacy `build_learning_guidance` output.
+
+This can show different fields or different reasons on one page. The top formal CTA already carries field, question count, learning intent and reason code into the recommendation-start endpoint, so the lower legacy recommendation is no longer needed as an independent authority.
+
+## Field-progress inconsistency
+
+`include_learner_navigation=True` forces formal overall-progress presentation, but **does not force formal field-progress UI**. Field-level display still depends on `ENABLE_FIELD_PROGRESS_UI`.
+
+Therefore a learner can currently see:
+- formal overall progress based on coverage/state evidence;
+- legacy per-field accuracy bars labeled as `分野別 到達度` when the field-progress flag is off.
+
+That is semantically inconsistent. Accuracy is useful, but it is not the same thing as formal field progress.
+
+## Recommended minimal consolidation v0.1
+
+Do not redesign the whole dashboard at once.
+
+1. When `learner_navigation_enabled=True`, make formal field-progress presentation active as well. Keep ordinary accuracy visible as a sub-metric.
+2. Replace the lower legacy `優先課題 TOP3` content with the same formal `attention_items` already used by learner navigation, or hide the duplicate lower block. Prefer one recommendation authority.
+3. Replace lower `今日のおすすめ学習` with `learner_navigation.today_action` when formal navigation exists. Legacy recommendation remains fallback only for non-formal/read-only legacy contexts.
+4. Preserve factual counters (answers/time/accuracy/streak); they are not competing strategy authorities.
+5. Do not promote Phase11 merely because the dashboard uses formal navigation. Learner-facing strategy remains constrained by the existing promotion/feature-gate contract where applicable.
+6. Keep `build_learning_guidance` available for legacy/supporter compatibility until every caller is mapped; do not delete it in this first change.
+
+## Acceptance criteria for consolidation change
+
+- Learner page never displays two conflicting recommended fields from formal and legacy systems.
+- `分野別 到達度` on the learner page uses formal field-progress calculation, with accuracy clearly shown only as accuracy.
+- Existing factual counters remain unchanged.
+- Existing authentication and recommendation-start behavior remain unchanged.
+- Supporter/read-only pages are not silently changed unless explicitly covered by tests.
+- Full regression suite remains green.
+
+## Next implementation step
+
+Create a small learner-page-only consolidation change on `work/dashboard-formal-consolidation-v01`, add regression tests for source authority, run targeted dashboard tests, then full CI before any safe-branch integration.

--- a/static/goukaku/dashboard-layout-v05.js
+++ b/static/goukaku/dashboard-layout-v05.js
@@ -12,6 +12,25 @@ document.addEventListener('DOMContentLoaded', () => {
 
   if (!grid || !subjectCard || !guidanceStack) return;
 
+  // The signed learner page already has a formal learner-navigation block built
+  // from question_attempts -> derived Node state. When that block exists, do
+  // not leave the legacy weakness/recommendation cards on screen as a second
+  // competing decision authority.
+  if (learnerNavigation) {
+    const legacyWeakCard = guidanceStack.querySelector('.weak-card');
+    const legacyRecommendCard = guidanceStack.querySelector('.recommend-card');
+    if (legacyWeakCard) legacyWeakCard.remove();
+    if (legacyRecommendCard) legacyRecommendCard.remove();
+
+    // Until the backend formally enables field-progress presentation on this
+    // route, the old subject rows are factual accuracy summaries only. Do not
+    // label them as formal attainment.
+    if (!subjectCard.querySelector('.field-progress-list')) {
+      const subjectHeading = subjectCard.querySelector('.section-title h2');
+      if (subjectHeading) subjectHeading.textContent = '分野別 正答率（参考）';
+    }
+  }
+
   const story = document.createElement('section');
   story.className = 'dashboard-story-layout';
 

--- a/tests/test_dashboard_layout_v05.py
+++ b/tests/test_dashboard_layout_v05.py
@@ -37,3 +37,16 @@ def test_paid_dashboard_v05_recomposes_story_into_balanced_columns():
 
     assert ".dashboard-story-layout{align-items:start}" in balance_css
     assert ".dashboard-story-left>.learning-position-card{margin-top:0!important}" in balance_css
+
+
+def test_formal_learner_navigation_removes_competing_legacy_guidance():
+    root = Path(__file__).resolve().parents[1]
+    js = (root / "static" / "goukaku" / "dashboard-layout-v05.js").read_text(encoding="utf-8")
+
+    assert "if (learnerNavigation)" in js
+    assert "guidanceStack.querySelector('.weak-card')" in js
+    assert "guidanceStack.querySelector('.recommend-card')" in js
+    assert "legacyWeakCard.remove()" in js
+    assert "legacyRecommendCard.remove()" in js
+    assert "分野別 正答率（参考）" in js
+    assert "subjectCard.querySelector('.field-progress-list')" in js


### PR DESCRIPTION
Working PR after Q2000 final-quality closure. Source map is recorded in reports/dashboard_source_map_20260909.md. Scope: learner-page-only consolidation of field progress and priority/recommendation authority while preserving factual counters, auth, supporter/read-only compatibility and Phase11 promotion boundaries. No main/Production deployment. Current implementation step removes duplicate legacy weak/recommendation cards whenever formal learner navigation is present, and relabels legacy field percentage display as factual reference accuracy rather than formal attainment.