### PR TITLE
Add longitudinal learner companion record

### DIFF
--- a/companion_record.py
+++ b/companion_record.py
@@ -1,0 +1,190 @@
+"""Pure longitudinal companion-record derivation from authoritative attempt history.
+
+The record summarizes meaningful learner-state episodes without persisting a second
+state authority. Raw attempts remain the source of truth; Knowledge Node state and
+question-equivalence semantics are reused from the formal derivation modules.
+"""
+
+from __future__ import annotations
+
+import json
+from collections import defaultdict
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Iterable
+
+from knowledge_node_state_transition import derive_knowledge_node_state, derive_state_timeline
+from question_equivalence import canonicalize_question_evidence_node
+
+
+BANK_DIR = Path(__file__).resolve().parent / "data" / "question_bank"
+
+
+def _load_node_labels() -> dict[str, str]:
+    nodes = json.loads((BANK_DIR / "knowledge_nodes.json").read_text(encoding="utf-8-sig"))
+    labels = {
+        str(item.get("knowledge_node_id")): str(item.get("label") or item.get("knowledge_node_id"))
+        for item in nodes
+    }
+    canonical = json.loads(
+        (BANK_DIR / "knowledge_node_canonical_map.json").read_text(encoding="utf-8-sig")
+    )
+    for item in canonical:
+        node_id = str(item.get("canonical_node_id") or "")
+        if node_id:
+            labels[node_id] = str(item.get("canonical_label") or labels.get(node_id) or node_id)
+    return labels
+
+
+_NODE_LABELS = _load_node_labels()
+
+
+def _sort_key(item: dict[str, Any]) -> tuple[str, str, int, int]:
+    return (
+        str(item.get("attempted_at") or item.get("answered_at") or ""),
+        str(item.get("event_key") or ""),
+        int(item.get("attempt_position") or 0),
+        int(item.get("id") or 0),
+    )
+
+
+def _timestamp(item: dict[str, Any]) -> str | None:
+    value = item.get("attempted_at") or item.get("answered_at")
+    return value.isoformat() if isinstance(value, datetime) else (str(value) if value else None)
+
+
+def _priority_reason(history: list[dict[str, Any]], final: dict[str, Any]) -> str | None:
+    wrong = [
+        item for item in history
+        if item.get("answer_status") == "unknown" or item.get("is_correct") is False
+    ]
+    if not wrong:
+        return None
+    if any(item.get("confidence") == 1 for item in wrong if item.get("answer_status") != "unknown"):
+        return "confident_wrong"
+    level = str(final.get("confirmed_weakness_evidence_level") or final.get("evidence_level") or "")
+    if level in {"CROSS_QUESTION_WRONG", "CROSS_QUESTION_CONFIDENT_WRONG", "REPEATED_SAME_QUESTION_WRONG"}:
+        return "repeated_wrong"
+    if any(item.get("answer_status") == "unknown" for item in wrong):
+        return "unknown_answer"
+    return "wrong_answer"
+
+
+def _events(history: list[dict[str, Any]], timeline: list[dict[str, Any]], current: dict[str, Any]) -> list[dict[str, Any]]:
+    events: list[dict[str, Any]] = []
+    previous = "unseen"
+    for item, state_row in zip(history, timeline):
+        state = str(state_row["state"])
+        if state == previous:
+            continue
+        event_type = None
+        if state == "repairing" and previous in {"unseen", "checking"}:
+            event_type = "weakness_detected"
+        elif state == "repaired" and previous == "repairing":
+            event_type = "repair_confirmed"
+        elif state == "stable" and previous in {"repaired", "recheck_due"}:
+            event_type = "retention_confirmed"
+        elif state == "repairing" and previous in {"repaired", "stable", "recheck_due"}:
+            event_type = "regression_detected"
+        elif state == "checking" and previous == "unseen":
+            event_type = "checking_started"
+        if event_type:
+            events.append({
+                "event": event_type,
+                "at": _timestamp(item),
+                "question_id": str(item.get("question_id") or ""),
+                "is_correct": item.get("is_correct"),
+                "confidence": item.get("confidence"),
+                "state_after": state,
+            })
+        previous = state
+
+    if current.get("state") == "recheck_due" and (not events or events[-1].get("state_after") != "recheck_due"):
+        events.append({
+            "event": "retention_recheck_due",
+            "at": (
+                current.get("next_review_at").isoformat()
+                if isinstance(current.get("next_review_at"), datetime)
+                else current.get("next_review_at")
+            ),
+            "question_id": current.get("retention_reference_question_id"),
+            "is_correct": None,
+            "confidence": None,
+            "state_after": "recheck_due",
+        })
+    return events
+
+
+def build_companion_record(
+    attempts: Iterable[dict[str, Any]],
+    *,
+    as_of: datetime | None = None,
+    include_checking_only: bool = False,
+) -> dict[str, Any]:
+    """Build compact longitudinal episodes without creating another state authority."""
+    rows = [dict(item) for item in attempts]
+    user_ids = {str(item.get("user_id") or "") for item in rows}
+    if len(user_ids) > 1:
+        raise ValueError("attempts must belong to one user")
+
+    grouped: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for item in rows:
+        node_id = canonicalize_question_evidence_node(
+            str(item.get("question_id") or ""),
+            str(item.get("knowledge_node_id") or ""),
+        )
+        if node_id:
+            grouped[str(node_id)].append(item)
+
+    episodes = []
+    for node_id, history in sorted(grouped.items()):
+        history.sort(key=_sort_key)
+        current = derive_knowledge_node_state(history, node_id, as_of=as_of)
+        timeline = derive_state_timeline(history)
+        has_wrong = any(
+            item.get("answer_status") == "unknown" or item.get("is_correct") is False
+            for item in history
+        )
+        if not has_wrong and not include_checking_only:
+            continue
+        events = _events(history, timeline, current)
+        episodes.append({
+            "canonical_node_id": node_id,
+            "label": _NODE_LABELS.get(node_id, node_id),
+            "current_state": current["state"],
+            "priority_reason": _priority_reason(history, current),
+            "attempt_count": len(history),
+            "distinct_question_count": int(current.get("distinct_question_count") or 0),
+            "wrong_question_count": int(current.get("wrong_question_count") or 0),
+            "confirmed_weakness_evidence_level": current.get("confirmed_weakness_evidence_level"),
+            "repair_confirmation_count": int(current.get("confident_correct_after_wrong_count") or 0),
+            "retention_reference_question_id": current.get("retention_reference_question_id"),
+            "next_review_at": (
+                current.get("next_review_at").isoformat()
+                if isinstance(current.get("next_review_at"), datetime)
+                else current.get("next_review_at")
+            ),
+            "events": events,
+        })
+
+    state_rank = {"repairing": 0, "recheck_due": 1, "repaired": 2, "stable": 3, "checking": 4, "unseen": 5}
+    episodes.sort(
+        key=lambda item: (
+            state_rank.get(str(item["current_state"]), 9),
+            0 if item.get("priority_reason") == "confident_wrong" else 1,
+            -int(item.get("wrong_question_count") or 0),
+            str(item["canonical_node_id"]),
+        )
+    )
+    counts: dict[str, int] = defaultdict(int)
+    for item in episodes:
+        counts[str(item["current_state"])] += 1
+    return {
+        "status": "companion_record_v0.1",
+        "authoritative_attempt_source": "question_attempts",
+        "authoritative_state_source": "derive_knowledge_node_state",
+        "persisted": False,
+        "episode_count": len(episodes),
+        "state_counts": dict(sorted(counts.items())),
+        "episodes": episodes,
+    }

--- a/reports/primary_learner_history_analysis_20260909.md
+++ b/reports/primary_learner_history_analysis_20260909.md
@@ -1,0 +1,125 @@
+# Primary learner history analysis — 2026-09-09
+
+Scope: read-only analysis of the primary learner's Production `question_attempts` history. No Production write, Render change, LINE change, or `main` mutation was performed.
+
+## Snapshot
+
+- Attempts: **1525**
+- Correct: **1103**
+- Overall accuracy: **72.3%**
+- Unique questions: **740**
+- Unique raw Knowledge Nodes: **572**
+- Observation window: 2026-08-17 through 2026-09-09 JST
+
+This is already large enough to use as the main retrospective real-use dataset for deciding what LicenseTown PT still needs. It should not be replaced by a small artificial beta dataset.
+
+## Confidence calibration
+
+| Confidence | Attempts | Correct | Accuracy |
+|---|---:|---:|---:|
+| 1 | 850 | 752 | 88.5% |
+| 2 | 623 | 338 | 54.3% |
+| 3 | 42 | 13 | 31.0% |
+| missing/unknown | 10 | 0 | 0.0% |
+
+### Interpretation
+
+Confidence is strongly informative. The learner clearly separates "I know this" from "I am unsure" in a way that correlates with actual performance.
+
+- Confidence-1 wrong answers: **98**. These are high-value misconception/repair candidates because the learner believed the answer was known.
+- Confidence-2/3 correct answers: **351**. These are not equivalent to stable mastery; they are useful checking/retention candidates.
+
+Therefore confidence should remain a first-class input to weakness/repair strategy. Removing or flattening confidence would discard valuable learner-state information.
+
+## Repeat behavior
+
+Across 740 unique questions:
+
+- Questions attempted at least twice: **344**
+- Repeat attempts beyond the first attempt: **785**
+- First wrong -> latest correct: **76 questions**
+- First correct -> latest wrong: **52 questions**
+- First wrong -> latest wrong: **37 questions**
+- First correct -> latest correct: **179 questions**
+
+### Interpretation
+
+A large part of actual use is already longitudinal rather than one-shot testing. This is useful evidence for repair and retention logic.
+
+However, raw repeat count must not be interpreted as a defect by itself. Existing adaptive-repeat audit work already distinguishes justified spaced repeats, cooldown bypasses, non-adaptive repeats and historical rows without audit metadata. The important metric is whether repeated evidence changes learner state appropriately and whether gratuitous repeats are avoided.
+
+The 37 still-wrong repeated questions and the 52 correct-to-wrong regressions are especially valuable for identifying persistent weakness and forgetting.
+
+## Daily use pattern
+
+The learner's ordinary use ranges from 5 to 200 answers per study day. Recent heavy-use days include 90, 105, 110, 130 and 200 attempts.
+
+Accuracy varies materially by day rather than simply improving with volume. Examples include:
+
+- 2026-08-24: 30 attempts, 46.7%
+- 2026-09-02: 90 attempts, 83.3%
+- 2026-09-05: 130 attempts, 63.8%
+- 2026-09-06: 200 attempts, 74.5%
+- 2026-09-08: 115 attempts, 83.5%
+
+This supports using learner-state and confidence evidence rather than a simplistic rule such as "more questions = stronger state".
+
+## Session/fatigue analysis limitation discovered
+
+`attempt_position` currently resets within the 5-question batch. All 1525 rows fall in positions 1-5, so the present table cannot independently measure accuracy deterioration across positions 1-30 of a 30-question session.
+
+Therefore a claimed "question 25-30 fatigue effect" cannot currently be derived from `question_attempts` alone.
+
+This confirms the existing lower-priority architecture note: if session-level time/fatigue analysis becomes important, an explicit durable session relationship (`session_id` / `learning_event_key`) is needed. Do not add it merely for architectural neatness; add it only if the analysis becomes useful enough to change learner behavior.
+
+## Product conclusions from the 1525-attempt history
+
+### 1. Do not expand the Question Bank above Q2000 merely to add volume
+
+The limiting issue is no longer raw question count. The learner has used only 740 unique questions while generating 1525 attempts. The higher-value work is deciding what to present, when to repair, when to recheck, and how to explain the next action.
+
+### 2. Confidence-aware repair is justified by real data
+
+The difference between confidence levels is large enough to support separate treatment:
+
+- confidence-1 wrong -> misconception/high-priority repair;
+- confidence-2/3 correct -> uncertain knowledge/checking rather than stable mastery;
+- confidence-2/3 wrong -> ordinary weak evidence, strengthened by repetition/cross-question confirmation.
+
+This matches the direction of the existing formal strategy/Node-state design.
+
+### 3. Longitudinal companion record has real value
+
+The dataset already contains transitions such as wrong -> correct, correct -> wrong and still wrong. A useful companion record should summarize these educational episodes rather than dump raw logs.
+
+Minimum useful episode shape:
+
+- Knowledge Node / learner-facing concept
+- first meaningful weakness evidence
+- why it was prioritized (confident wrong / repeated wrong / Safety etc.)
+- repair question/evidence
+- repair result
+- later retention/regression result
+- current state
+
+### 4. Phase11 should remain evidence-gated, not blocked by lack of historical data
+
+There is plenty of retrospective history for weak/repair/repeat analysis. The remaining OPEN Phase11 gates are specifically prospective/natural phenomena that cannot be manufactured from older data, especially spaced retention, first natural `recheck_due` execution, and comparison diversity.
+
+### 5. Dashboard decision authority should stay formal
+
+Because confidence and longitudinal transitions materially change interpretation, simple field accuracy cannot be the recommendation authority. Accuracy remains useful as a factual display, but the "what should I do next" decision should come from formal derived evidence.
+
+## Priority after this analysis
+
+1. Keep Phase11 Shadow-only while natural retention/recheck evidence accumulates.
+2. Build the smallest useful longitudinal companion-record derivation from existing `question_attempts`; no new DB table is required for the first version.
+3. Use the derived record to support learner/supporter summaries and to audit whether repair actually persists.
+4. Add session/time linkage only if a later decision genuinely requires fatigue/time-efficiency analysis.
+5. After the major product changes are integrated, use roughly 100-200 new ordinary attempts as a post-change acceptance sample rather than restarting validation from zero.
+
+## Completion judgment
+
+The 1525-attempt dataset is sufficient to stop treating "real-user validation" as an unknown. It already gives strong evidence about confidence calibration, repeat/repair behavior and the need for longitudinal state interpretation.
+
+The remaining validation gap is narrower: **does the final post-Q2000 system make better next-step decisions and preserve repaired knowledge over time?** That should be answered with targeted natural follow-up evidence, not another broad artificial beta.

--- a/tests/test_companion_record.py
+++ b/tests/test_companion_record.py
@@ -1,0 +1,111 @@
+from datetime import datetime, timedelta, timezone
+
+from companion_record import build_companion_record
+
+
+NOW = datetime(2026, 9, 1, tzinfo=timezone.utc)
+
+
+def attempt(user, node, question, correct, confidence, minute, *, answer_status="answered"):
+    return {
+        "id": minute + 1,
+        "event_key": f"event-{user}-{minute}",
+        "user_id": user,
+        "question_id": question,
+        "knowledge_node_id": node,
+        "is_correct": correct,
+        "confidence": confidence,
+        "answer_status": answer_status,
+        "attempted_at": NOW + timedelta(minutes=minute),
+        "attempt_position": 1,
+    }
+
+
+def test_record_uses_formal_repair_transition_and_is_not_persisted():
+    record = build_companion_record([
+        attempt("u", "KN0268", "Q269", False, 2, 1),
+        attempt("u", "KN0268", "Q361", True, 1, 2),
+    ])
+    assert record["persisted"] is False
+    assert record["authoritative_attempt_source"] == "question_attempts"
+    assert record["episode_count"] == 1
+    episode = record["episodes"][0]
+    assert episode["current_state"] == "repaired"
+    assert [item["event"] for item in episode["events"]] == [
+        "weakness_detected",
+        "repair_confirmed",
+    ]
+
+
+def test_confident_wrong_is_high_priority_reason():
+    record = build_companion_record([
+        attempt("u", "KN0268", "Q269", False, 1, 1),
+    ])
+    assert record["episodes"][0]["priority_reason"] == "confident_wrong"
+
+
+def test_repeated_wrong_reason_uses_existing_formal_evidence():
+    record = build_companion_record([
+        attempt("u", "KN0268", "Q269", False, 2, 1),
+        attempt("u", "KN0268", "Q269", False, 2, 2),
+    ])
+    assert record["episodes"][0]["priority_reason"] == "repeated_wrong"
+    assert record["episodes"][0]["current_state"] == "repairing"
+
+
+def test_repaired_episode_becomes_recheck_due_from_as_of_without_fake_attempt():
+    history = [
+        attempt("u", "KN0268", "Q269", False, 2, 1),
+        attempt("u", "KN0268", "Q361", True, 1, 2),
+    ]
+    record = build_companion_record(history, as_of=NOW + timedelta(days=8))
+    episode = record["episodes"][0]
+    assert episode["current_state"] == "recheck_due"
+    assert episode["events"][-1]["event"] == "retention_recheck_due"
+    assert episode["events"][-1]["state_after"] == "recheck_due"
+
+
+def test_regression_after_repair_is_explicit_episode_event():
+    record = build_companion_record([
+        attempt("u", "KN0268", "Q269", False, 2, 1),
+        attempt("u", "KN0268", "Q361", True, 1, 2),
+        attempt("u", "KN0268", "Q269", False, 1, 3),
+    ])
+    episode = record["episodes"][0]
+    assert episode["current_state"] == "repairing"
+    assert episode["events"][-1]["event"] == "regression_detected"
+
+
+def test_correct_only_checking_nodes_are_omitted_by_default():
+    history = [attempt("u", "KN0268", "Q269", True, 1, 1)]
+    assert build_companion_record(history)["episode_count"] == 0
+    assert build_companion_record(history, include_checking_only=True)["episode_count"] == 1
+
+
+def test_multiple_users_are_rejected():
+    history = [
+        attempt("a", "KN0268", "Q269", False, 2, 1),
+        attempt("b", "KN0268", "Q269", False, 2, 2),
+    ]
+    try:
+        build_companion_record(history)
+    except ValueError as exc:
+        assert "one user" in str(exc)
+    else:
+        raise AssertionError("expected ValueError")
+
+
+def test_exact_official_repeat_cross_node_stays_one_episode():
+    # Q1411/Q1585 are reviewed exact official repeats and must share the same
+    # derived evidence Node even though their raw historical Nodes differ.
+    record = build_companion_record([
+        attempt("u", "KN1387", "Q1411", False, 2, 1),
+        attempt("u", "KN0659", "Q1585", True, 1, 2),
+    ])
+    assert record["episode_count"] == 1
+    episode = record["episodes"][0]
+    assert episode["canonical_node_id"] == "KN1387"
+    # Equivalent Q IDs are not strong different-question evidence, so this
+    # cannot falsely mark repair as confirmed.
+    assert episode["current_state"] == "repairing"
+    assert episode["repair_confirmation_count"] == 0


### PR DESCRIPTION
Read-only longitudinal companion-record derivation from authoritative question_attempts and existing formal Knowledge Node state transitions. Reuses reviewed question-equivalence semantics, creates no new DB authority/table, and summarizes weakness/repair/retention/regression episodes for later learner/supporter use. Includes the 1525-attempt retrospective analysis report. No Production DB write, Render/LINE change, main merge, or Phase11 promotion.