### PR TITLE
Complete core repair retention loop

### DIFF
--- a/adaptive_question_selector.py
+++ b/adaptive_question_selector.py
@@ -220,6 +220,9 @@ def select_node_adaptive_questions(
     normal_candidates = [
         item for item in candidates
         if not item["recent_question_repeat"]
+        # A time-based retention checkpoint must remain actionable even when
+        # its evidence question is still inside the last-30-attempt cooldown.
+        or item["priority_reason"] == "recheck_due"
         or (
             item["priority_reason"] in {"safety_wrong", "safety_unresolved"}
             and item["canonical_node_id"] not in non_recent_nodes

--- a/companion_record.py
+++ b/companion_record.py
@@ -19,6 +19,16 @@ from question_equivalence import canonicalize_question_evidence_node
 
 BANK_DIR = Path(__file__).resolve().parent / "data" / "question_bank"
 
+WRONG_PATTERN_LABELS = {
+    "retention_regression": "いったん直した内容を時間を空けた確認で再び誤答",
+    "confident_wrong": "自信ありで誤答",
+    "repeated_cross_question_wrong": "同じ知識を別問題でも繰り返し誤答",
+    "repeated_same_question_wrong": "同じ問題を繰り返し誤答",
+    "unknown_answer": "分からないと回答",
+    "uncertain_wrong": "迷い・あてずっぽうで誤答",
+    "wrong_answer": "単発の誤答",
+}
+
 
 def _load_node_labels() -> dict[str, str]:
     nodes = json.loads((BANK_DIR / "knowledge_nodes.json").read_text(encoding="utf-8-sig"))
@@ -53,11 +63,57 @@ def _timestamp(item: dict[str, Any]) -> str | None:
     return value.isoformat() if isinstance(value, datetime) else (str(value) if value else None)
 
 
+def _is_wrong(item: dict[str, Any]) -> bool:
+    return item.get("answer_status") == "unknown" or item.get("is_correct") is False
+
+
+def _wrong_pattern(
+    history: list[dict[str, Any]],
+    timeline: list[dict[str, Any]],
+    final: dict[str, Any],
+) -> dict[str, Any] | None:
+    """Classify observable wrong-answer evidence without claiming a hidden psychology."""
+    wrong_indexes = [index for index, item in enumerate(history) if _is_wrong(item)]
+    if not wrong_indexes:
+        return None
+
+    for index in reversed(wrong_indexes):
+        previous_state = "unseen" if index == 0 else str(timeline[index - 1]["state"])
+        if previous_state in {"repaired", "stable", "recheck_due"}:
+            code = "retention_regression"
+            return {
+                "code": code,
+                "label": WRONG_PATTERN_LABELS[code],
+                "basis": "wrong_after_repaired_or_retention_state",
+            }
+
+    latest_wrong = history[wrong_indexes[-1]]
+    if latest_wrong.get("answer_status") == "unknown":
+        code = "unknown_answer"
+        return {"code": code, "label": WRONG_PATTERN_LABELS[code], "basis": "answer_status_unknown"}
+
+    if latest_wrong.get("confidence") == 1:
+        code = "confident_wrong"
+        return {"code": code, "label": WRONG_PATTERN_LABELS[code], "basis": "wrong_with_confidence_1"}
+
+    level = str(final.get("confirmed_weakness_evidence_level") or final.get("evidence_level") or "")
+    if level in {"CROSS_QUESTION_WRONG", "CROSS_QUESTION_CONFIDENT_WRONG"}:
+        code = "repeated_cross_question_wrong"
+        return {"code": code, "label": WRONG_PATTERN_LABELS[code], "basis": level}
+    if level == "REPEATED_SAME_QUESTION_WRONG":
+        code = "repeated_same_question_wrong"
+        return {"code": code, "label": WRONG_PATTERN_LABELS[code], "basis": level}
+
+    if latest_wrong.get("confidence") in {2, 3, "2", "3"}:
+        code = "uncertain_wrong"
+        return {"code": code, "label": WRONG_PATTERN_LABELS[code], "basis": "wrong_with_confidence_2_or_3"}
+
+    code = "wrong_answer"
+    return {"code": code, "label": WRONG_PATTERN_LABELS[code], "basis": "single_evaluable_wrong"}
+
+
 def _priority_reason(history: list[dict[str, Any]], final: dict[str, Any]) -> str | None:
-    wrong = [
-        item for item in history
-        if item.get("answer_status") == "unknown" or item.get("is_correct") is False
-    ]
+    wrong = [item for item in history if _is_wrong(item)]
     if not wrong:
         return None
     if any(item.get("confidence") == 1 for item in wrong if item.get("answer_status") != "unknown"):
@@ -73,15 +129,21 @@ def _priority_reason(history: list[dict[str, Any]], final: dict[str, Any]) -> st
 def _events(history: list[dict[str, Any]], timeline: list[dict[str, Any]], current: dict[str, Any]) -> list[dict[str, Any]]:
     events: list[dict[str, Any]] = []
     previous = "unseen"
+    previous_retention_stage = None
     for item, state_row in zip(history, timeline):
         state = str(state_row["state"])
-        if state == previous:
-            continue
+        retention_stage = state_row.get("retention_stage")
         event_type = None
         if state == "repairing" and previous in {"unseen", "checking"}:
             event_type = "weakness_detected"
         elif state == "repaired" and previous == "repairing":
             event_type = "repair_confirmed"
+        elif (
+            state == "repaired"
+            and retention_stage != previous_retention_stage
+            and retention_stage in {"day3_passed", "day7_passed"}
+        ):
+            event_type = "retention_checkpoint_passed"
         elif state == "stable" and previous in {"repaired", "recheck_due"}:
             event_type = "retention_confirmed"
         elif state == "repairing" and previous in {"repaired", "stable", "recheck_due"}:
@@ -96,8 +158,10 @@ def _events(history: list[dict[str, Any]], timeline: list[dict[str, Any]], curre
                 "is_correct": item.get("is_correct"),
                 "confidence": item.get("confidence"),
                 "state_after": state,
+                "retention_stage_after": retention_stage,
             })
         previous = state
+        previous_retention_stage = retention_stage
 
     if current.get("state") == "recheck_due" and (not events or events[-1].get("state_after") != "recheck_due"):
         events.append({
@@ -111,6 +175,8 @@ def _events(history: list[dict[str, Any]], timeline: list[dict[str, Any]], curre
             "is_correct": None,
             "confidence": None,
             "state_after": "recheck_due",
+            "retention_stage_after": current.get("retention_stage"),
+            "retention_checkpoint": current.get("retention_checkpoint"),
         })
     return events
 
@@ -141,24 +207,25 @@ def build_companion_record(
         history.sort(key=_sort_key)
         current = derive_knowledge_node_state(history, node_id, as_of=as_of)
         timeline = derive_state_timeline(history)
-        has_wrong = any(
-            item.get("answer_status") == "unknown" or item.get("is_correct") is False
-            for item in history
-        )
+        has_wrong = any(_is_wrong(item) for item in history)
         if not has_wrong and not include_checking_only:
             continue
         events = _events(history, timeline, current)
+        wrong_pattern = _wrong_pattern(history, timeline, current)
         episodes.append({
             "canonical_node_id": node_id,
             "label": _NODE_LABELS.get(node_id, node_id),
             "current_state": current["state"],
             "priority_reason": _priority_reason(history, current),
+            "wrong_pattern": wrong_pattern,
             "attempt_count": len(history),
             "distinct_question_count": int(current.get("distinct_question_count") or 0),
             "wrong_question_count": int(current.get("wrong_question_count") or 0),
             "confirmed_weakness_evidence_level": current.get("confirmed_weakness_evidence_level"),
             "repair_confirmation_count": int(current.get("confident_correct_after_wrong_count") or 0),
             "retention_reference_question_id": current.get("retention_reference_question_id"),
+            "retention_stage": current.get("retention_stage"),
+            "retention_checkpoint": current.get("retention_checkpoint"),
             "next_review_at": (
                 current.get("next_review_at").isoformat()
                 if isinstance(current.get("next_review_at"), datetime)
@@ -180,9 +247,10 @@ def build_companion_record(
     for item in episodes:
         counts[str(item["current_state"])] += 1
     return {
-        "status": "companion_record_v0.1",
+        "status": "companion_record_v0.2",
         "authoritative_attempt_source": "question_attempts",
         "authoritative_state_source": "derive_knowledge_node_state",
+        "wrong_pattern_semantics": "observable_evidence_not_psychological_diagnosis",
         "persisted": False,
         "episode_count": len(episodes),
         "state_counts": dict(sorted(counts.items())),

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -13,6 +13,24 @@ Always distinguish: **code exists / tests pass / real data observed / product ac
 Do not casually change `main`, Production Neon, Render or LINE behavior.
 Practical learner effect and national-exam success outrank architectural elegance.
 
+## Current completion contract — MAIN LINE ONLY
+
+Boss fixed the active completion rule on 2026-09-09. Until the core PT learning loop is accepted, do not drift into speculative polish or branch/leaf work.
+
+Car model:
+- **走る**: quiz -> answer -> save -> score -> explanation -> continue.
+- **曲がる**: next questions change according to real weakness/repair/retention state.
+- **止まる**: pause/resume/end/reset safely.
+- **壊れない**: formal question/history/Node/session invariants stay coherent.
+- **壊れた所を特定できる**: evidence shows which Q/Node/state/selection caused the issue.
+- **特定したら修復できる**: learner weakness returns through repair and spaced retention; system defects are reproducible and safely fixable.
+
+Core learner loop:
+
+`wrong -> observable wrong-pattern analysis -> same-Node/different-Q repair -> repair confirmation -> day3 -> day7 -> one-month -> durable OR back to repairing`
+
+A candidate change is in scope now only when it fixes a real current defect, is necessary for this main line, or directly changes learner outcome. Otherwise backlog it.
+
 ---
 
 # 1. Question Bank / Q2000 — CLOSED
@@ -69,25 +87,54 @@ Conclusion: confidence and longitudinal transitions are materially informative. 
 
 ---
 
-# 3. Repair / retention
+# 3. Core repair / retention loop — CODE + TESTS COMPLETE
 
-Working:
-- same-question, weak different-question and STRONG different-question evidence are separated;
-- confident STRONG confirmation can move `repairing -> repaired`;
-- later wrong evidence can regress to `repairing`;
-- retention states include `repaired`, `recheck_due`, `stable`;
-- exact official repeats cannot masquerade as STRONG different-question evidence;
-- natural STRONG repair supply is already exercised.
+Formal repair semantics:
+- any evaluable wrong or `unknown` starts/returns the Node to `repairing`;
+- same-Q correct does **not** confirm repair;
+- weak different-Q correct does **not** confirm repair;
+- repair confirmation requires **STRONG different-Q + confidence=1**;
+- exact official equivalent repeats are one evidence identity and cannot fake different-Q confirmation.
 
-Natural reference example:
-- KN0394, Q399/Q1572;
-- repair reference Q399 at 2026-09-02 18:32:30 JST;
-- first 7-day recheck boundary 2026-09-09 18:32:30 JST.
+Spaced retention contract implemented in `knowledge_node_state_transition.py`:
+1. STRONG different-Q confidence=1 after wrong -> `repaired`, next check at **3 days**.
+2. Valid day3 check before day7 horizon -> `day3_passed`, next check at **7 days** from repair confirmation.
+3. Valid check on/after day7 horizon -> `stable`, `day7_passed`, one-month check scheduled.
+4. Valid one-month check -> remains `stable`, `durable`, no further required checkpoint in v0.1.
+5. Wrong/unknown at any retention checkpoint -> fresh `repairing` cycle and old retention schedule is cleared.
+6. If the learner misses day3 and first valid spaced check happens on/after day7, it counts as the day7 horizon instead of manufacturing an overdue backlog.
 
-OPEN:
-- natural proof of the complete spaced cycle `wrong -> STRONG repair -> spacing -> recheck_due -> stable/repairing`.
+Selector integration:
+- `recheck_due` is an explicit checking priority;
+- an actually due time-based retention check may deliberately bypass last-30-attempt Recent Cooldown;
+- this bypass is saved as `recent_cooldown_bypassed=True` for auditability;
+- ordinary recent-repeat avoidance and Safety behavior remain intact.
 
-Do not manufacture learner activity just to close this gate.
+Wrong-pattern analysis is evidence-based, not a hidden psychological diagnosis. `companion_record.py` can classify:
+- retention regression;
+- confidence-1 wrong;
+- repeated cross-question wrong;
+- repeated same-question wrong;
+- unknown answer;
+- uncertain wrong;
+- single wrong.
+
+It explicitly declares `wrong_pattern_semantics = observable_evidence_not_psychological_diagnosis`.
+
+Full PR #285 CI after the core implementation and policy-aligned regression updates:
+- **1232 passed**
+- **6 skipped**
+- **1 deselected**
+- **125 subtests passed**
+- run #626: GREEN
+
+Evidence boundary:
+- **code exists: YES**
+- **full tests pass: YES**
+- **natural learner day3/day7/one-month sequence observed end-to-end: NOT YET**
+- **Production behavior deployed/accepted: NO**
+
+The missing natural 3d/7d/one-month evidence is time-dependent evidence, not a reason to keep adding speculative code today.
 
 ---
 
@@ -99,7 +146,9 @@ Boundary:
 - Phase11 decides **what / why / how many / intent**.
 - Phase10/selector owns **which exact Q**.
 
-Automatic evidence:
+PR #284 closed an actual main-line gap: learner navigation `learning_intent` now reaches web recommendation session and exact-Q adaptive selection. Explicit `repair`, `recheck`, and `exploration` intents fill the matching selector group first; normal callers without explicit intent retain mixed composition.
+
+Automatic evidence before this core-loop update:
 - repeat audit: PASS;
 - Critical Safety retrospective: PASS-to-date;
 - J2/J3 trigger consistency: PASS;
@@ -107,15 +156,14 @@ Automatic evidence:
 - retrospective replay coverage for current recommendation anchors: PASS;
 - current automatic FAIL/BLOCKED gates: none.
 
-Still OPEN because natural/prospective evidence is required:
-- spaced retention outcome;
-- first natural `recheck_due` intent -> exact-Q alignment;
+Still OPEN where real natural/prospective evidence is required:
+- natural spaced retention outcome under the new day3/day7/one-month contract;
+- natural `recheck_due` intent -> exact-Q alignment;
 - retrospective comparison diversity;
 - prospective learner relevance vs baseline;
-- repair durability after spacing;
 - final human promotion review.
 
-Do not self-promote Phase11. First learner-facing promotion, if later approved, must be limited/feature-gated.
+Do not self-promote Phase11. Do not keep coding just to force these time-dependent gates closed.
 
 Detailed record: `reports/phase11_promotion_review_20260909.md`.
 
@@ -125,62 +173,48 @@ Detailed record: `reports/phase11_promotion_review_20260909.md`.
 
 - Node-level adaptive selection works.
 - STRONG different-question repair can be preferred.
-- Recent Question Cooldown avoids gratuitous recent repeats with limited Safety exceptions.
+- Formal learner `repair/recheck/exploration` intent reaches exact-Q selection.
+- Recent Question Cooldown avoids gratuitous recent repeats.
+- Time-based `recheck_due` can bypass cooldown intentionally so a scheduled retention check is not starved by the large bank.
 - Adaptive audit metadata persists selection reason/group/score, repair evidence quality, recent repeat and cooldown bypass.
 - Current learner history shows no unexplained or internally inconsistent adaptive-repeat defect.
 - Exact official repeats share one evidence identity for selection/cooldown interpretation.
 
-OPEN only where natural recheck-specific evidence is still missing.
+No further selector polish is in scope unless real use exposes a main-line defect.
 
 ---
 
 # 6. Dashboard / learner navigation — v0.1 CONSOLIDATED
 
-Learner route `/goukaku-no-michi` already builds formal learner navigation from authoritative attempts/readiness/shadow evidence.
+Learner route `/goukaku-no-michi` builds formal learner navigation from authoritative attempts/readiness/shadow evidence.
 
 Completed consolidation v0.1:
-- top `現在地`, `今日やること`, formal priority TOP3, repair/coverage/retention guidance remain the learner-facing decision authority;
-- lower legacy `優先課題 TOP3` is hidden whenever formal learner navigation exists;
-- lower legacy `今日のおすすめ学習` is hidden whenever formal learner navigation exists;
-- therefore one learner page no longer shows two competing recommendation authorities;
-- if formal field-progress rows are not enabled, legacy field percentages are labeled **`分野別 正答率（参考）`**, not formal `到達度`;
-- factual counters such as total answers, study time, recent/average accuracy and streak remain;
-- supporter/read-only/legacy fallback behavior was not intentionally changed.
+- top `現在地`, `今日やること`, formal priority TOP3, repair/coverage/retention guidance are the learner-facing decision authority;
+- duplicate lower legacy TOP3/recommendation are hidden when formal learner navigation exists;
+- legacy field percentages, when shown, are labeled **`分野別 正答率（参考）`**, not formal `到達度`;
+- factual counters remain factual counters.
 
 Source map: `reports/dashboard_source_map_20260909.md`.
 
-Remaining small dashboard improvement:
-- activate formal per-field progress on the signed learner route so learner-facing `分野別 到達度` uses the same formal evidence family as overall progress, while ordinary accuracy stays a separate sub-metric.
-
-This is a small cleanup, not a reason to redesign the dashboard again.
+Dashboard polish is **not current main-line work**. Do not resume it until core real use exposes a learner-impacting need or Boss explicitly chooses it.
 
 ---
 
-# 7. Longitudinal companion record — v0.1 IMPLEMENTED
+# 7. Longitudinal companion record — CORE EVIDENCE LAYER IMPLEMENTED
 
-`companion_record.py` now derives a compact longitudinal record directly from authoritative `question_attempts` and the existing formal Node-state transition logic.
+`companion_record.py` derives compact longitudinal episodes from `question_attempts`; it does not create a second persisted truth.
 
-Properties:
-- no new DB table;
-- no second persisted state authority;
-- raw attempts remain source of truth;
-- reviewed question-equivalence semantics are reused;
-- exact official repeat Q IDs stay one derived evidence identity;
-- learner episodes can capture weakness detection, repair confirmation, retention recheck due, retention confirmation and regression;
-- confidence-aware priority reason is retained;
-- correct-only checking Nodes are omitted by default to keep the record useful rather than noisy;
-- multi-user input is rejected.
+Current core-useful fields/events include:
+- weakness detection;
+- observable wrong pattern;
+- repair confirmation;
+- retention stage/checkpoint/next review;
+- day3/day7 checkpoint pass;
+- retention due;
+- durable retention confirmation;
+- regression back to repairing.
 
-PR #279 full CI before safe-branch merge:
-- **1217 passed**
-- **6 skipped**
-- **1 deselected**
-- **125 subtests passed**
-
-PR #279 merged only to `work/pt-finalization-post-q2000` at `d645a3167a769e670ea53b59b0f3cf647fc4e5a8`.
-No Production write, Render/LINE change, `main` merge or Phase11 promotion occurred.
-
-Next companion step should be product-facing only if it materially helps learner/supporter decisions; do not build a large journal UI just because the derivation exists.
+Do not build a large journal UI now. The derivation exists to support the main learner loop and later concise presentation if needed.
 
 ---
 
@@ -189,16 +223,24 @@ Next companion step should be product-facing only if it materially helps learner
 - Learning time persists separately.
 - Current `attempt_position` resets inside 5-question batches, so `question_attempts` alone cannot validly measure position 1-30 fatigue in a 30-question session.
 - `:time`-style event keys may intentionally differ for idempotency; do not treat event-key equality as a relational join.
-- Add explicit durable session linkage only if fatigue/time-efficiency analysis becomes useful enough to change learner behavior.
+- Add explicit durable session linkage only if real use shows it changes learner outcome.
 
 ---
 
-# 9. Current priority
+# 9. Current priority / finish line
 
-1. Finish the **small learner-route formal field-progress cleanup**; do not redesign the dashboard.
-2. Re-evaluate Phase11 automatically when natural retention/recheck/comparison evidence appears; do not force data.
-3. Decide the smallest learner/supporter use of `companion_record.py` that changes behavior; avoid a large new UI unless needed.
-4. After major post-Q2000 changes settle, use roughly **100-200 new ordinary attempts** as a post-change acceptance sample rather than restarting validation from zero.
-5. Session/time linkage remains lower priority.
+The current implementation task is considered complete when PR #285 is merged into `work/pt-finalization-post-q2000` after GREEN CI and this state file is updated.
 
-Do not restart Q2000 audit or question-count expansion unless new evidence exposes a genuine need.
+After that, **do not invent another branch/leaf task**.
+
+Next legitimate step is real learner use of the main line:
+- normal study produces wrong/correct/confidence evidence;
+- wrong Node enters repair;
+- STRONG different-Q confirmation closes repair;
+- scheduled day3/day7/one-month checks surface naturally;
+- wrong retention check reopens repair;
+- observed defects are fixed only when they affect the main line.
+
+Natural time-dependent evidence cannot be completed instantly and is not an excuse to keep construction open. Code/test completion and natural/product acceptance must remain separate facts.
+
+Do not restart Q2000 audit, dashboard polish, speculative safety scaffolding, session analytics, or unrelated product expansion unless Boss explicitly reprioritizes them or real main-line evidence exposes a genuine defect.

--- a/knowledge_node_state_transition.py
+++ b/knowledge_node_state_transition.py
@@ -15,8 +15,14 @@ from question_equivalence import canonicalize_question_evidence_node
 
 
 STATES = ("unseen", "checking", "repairing", "repaired", "stable", "recheck_due")
-REPAIRED_RECHECK_AFTER = timedelta(days=7)
-STABLE_RECHECK_AFTER = timedelta(days=30)
+RETENTION_CHECKPOINTS = (
+    ("day3", timedelta(days=3)),
+    ("day7", timedelta(days=7)),
+    ("day30", timedelta(days=30)),
+)
+# Compatibility names for callers that only need the first/last horizon.
+REPAIRED_RECHECK_AFTER = RETENTION_CHECKPOINTS[0][1]
+STABLE_RECHECK_AFTER = RETENTION_CHECKPOINTS[-1][1]
 
 
 def _sort_key(attempt: dict[str, Any]) -> tuple[str, str, int, int]:
@@ -39,8 +45,12 @@ def _evidence_node(item: dict[str, Any]) -> str:
 
 
 def is_recheck_due(state: str, last_attempted_at: datetime, as_of: datetime) -> bool:
-    interval = REPAIRED_RECHECK_AFTER if state == "repaired" else STABLE_RECHECK_AFTER
-    return state in {"repaired", "stable"} and as_of - last_attempted_at >= interval
+    """Compatibility helper: repaired first becomes due at the 3-day checkpoint.
+
+    A node is only called stable after the 30-day checkpoint has passed, so stable
+    does not automatically become due again in this v0.1 retention contract.
+    """
+    return state == "repaired" and as_of - last_attempted_at >= REPAIRED_RECHECK_AFTER
 
 
 def _as_datetime(value) -> datetime | None:
@@ -109,15 +119,41 @@ def _result(
     }
 
 
+def _checkpoint_due_at(origin: datetime | None, checkpoint_index: int) -> datetime | None:
+    if origin is None or checkpoint_index >= len(RETENTION_CHECKPOINTS):
+        return None
+    return origin + RETENTION_CHECKPOINTS[checkpoint_index][1]
+
+
+def _checkpoint_name(checkpoint_index: int) -> str | None:
+    if checkpoint_index >= len(RETENTION_CHECKPOINTS):
+        return None
+    return RETENTION_CHECKPOINTS[checkpoint_index][0]
+
+
 def derive_knowledge_node_state(
     attempts: Iterable[dict[str, Any]],
     canonical_node_id: str | None = None,
     as_of: datetime | None = None,
 ) -> dict[str, Any]:
-    """Derive the final state for one user's one canonical evidence-Node history."""
+    """Derive one user's one canonical Node state from attempt history.
+
+    Core repair/retention contract:
+    wrong -> repairing -> strong different-Q confidence=1 confirmation -> repaired
+    -> day3 -> day7 -> day30 retention checks -> stable.
+    A wrong answer at any checkpoint immediately starts a new repair cycle.
+    """
     ordered = sorted((dict(item) for item in attempts), key=_sort_key)
     if not ordered:
-        return _result(str(canonical_node_id or ""), "unseen", "", [], 0)
+        result = _result(str(canonical_node_id or ""), "unseen", "", [], 0)
+        result.update({
+            "retention_stage": None,
+            "retention_checkpoint": None,
+            "retention_origin_at": None,
+            "next_review_at": None,
+            "due_overdue_days": 0,
+        })
+        return result
 
     canonical_ids = {_evidence_node(item) for item in ordered}
     user_ids = {str(item.get("user_id") or "") for item in ordered}
@@ -130,15 +166,18 @@ def derive_knowledge_node_state(
     repair_wrong_questions: set[str] = set()
     confident_correct_after_wrong_count = 0
     has_prior_wrong = False
+    retention_origin_at: datetime | None = None
+    retention_checkpoint_index = 0
     next_review_at: datetime | None = None
     retention_reference_question: str | None = None
     history: list[dict[str, Any]] = []
 
     for item in ordered:
         attempted_at = _as_datetime(item.get("attempted_at") or item.get("answered_at"))
-        if state in {"repaired", "stable"} and next_review_at and attempted_at and attempted_at >= next_review_at:
+        if state == "repaired" and next_review_at and attempted_at and attempted_at >= next_review_at:
             state = "recheck_due"
-            reason = "The spaced retention review date has arrived."
+            reason = f"The {_checkpoint_name(retention_checkpoint_index)} retention checkpoint is due."
+
         history.append(item)
         question_id = str(item.get("question_id") or "")
         is_correct = (
@@ -156,6 +195,8 @@ def derive_knowledge_node_state(
             else:
                 repair_wrong_questions.add(question_id)
             has_prior_wrong = True
+            retention_origin_at = None
+            retention_checkpoint_index = 0
             next_review_at = None
             retention_reference_question = None
             continue
@@ -176,25 +217,42 @@ def derive_knowledge_node_state(
             for wrong_question in repair_wrong_questions
         }
         is_strong_confirmation = DIFFERENT_QUESTION_STRONG in evidence_strengths
+
         if state == "recheck_due":
-            retention_strength = classify_repair_confirmation(retention_reference_question, question_id)
+            retention_strength = classify_repair_confirmation(
+                retention_reference_question, question_id
+            )
             if confidence == 1 and retention_strength == DIFFERENT_QUESTION_STRONG:
-                state = "stable"
+                passed_checkpoint = _checkpoint_name(retention_checkpoint_index)
+                retention_checkpoint_index += 1
                 retention_reference_question = question_id
-                next_review_at = attempted_at + STABLE_RECHECK_AFTER if attempted_at else None
-                reason = "A spaced strong different-question check was correct with confidence=1."
+                if retention_checkpoint_index >= len(RETENTION_CHECKPOINTS):
+                    state = "stable"
+                    next_review_at = None
+                    reason = "The day30 spaced retention checkpoint passed with strong different-question confidence=1 evidence."
+                else:
+                    state = "repaired"
+                    next_review_at = _checkpoint_due_at(
+                        retention_origin_at, retention_checkpoint_index
+                    )
+                    reason = f"The {passed_checkpoint} retention checkpoint passed; the next spaced checkpoint is scheduled."
             else:
-                reason = "Retention evidence was same/weak or lacked confidence=1; review remains due."
+                reason = "Retention evidence was same/weak or lacked confidence=1; the current checkpoint remains due."
             continue
+
         if confidence == 1 and is_strong_confirmation:
             confident_correct_after_wrong_count += 1
             if state == "repairing":
                 state = "repaired"
                 retention_reference_question = question_id
-                next_review_at = attempted_at + REPAIRED_RECHECK_AFTER if attempted_at else None
+                retention_origin_at = attempted_at
+                retention_checkpoint_index = 0
+                next_review_at = _checkpoint_due_at(
+                    retention_origin_at, retention_checkpoint_index
+                )
                 reason = "A strong different-question confirmation was correct with confidence=1 after a wrong answer."
             elif state == "repaired":
-                reason = "Short-term repair remains repaired; stable requires the future time-based policy."
+                reason = "Repair remains confirmed; the scheduled retention checkpoint has not arrived yet."
         elif state == "repairing":
             reason = (
                 "The correct answer is same/weakly different or lacks confidence=1; repair remains unconfirmed."
@@ -209,11 +267,33 @@ def derive_knowledge_node_state(
         retention_reference_question,
     )
     as_of = _as_datetime(as_of)
-    if state in {"repaired", "stable"} and next_review_at and as_of and as_of >= next_review_at:
+    if state == "repaired" and next_review_at and as_of and as_of >= next_review_at:
         result["state"] = "recheck_due"
-        result["reason"] = "The spaced retention review date has arrived."
+        result["reason"] = f"The {_checkpoint_name(retention_checkpoint_index)} retention checkpoint is due."
+
+    if result["state"] == "stable":
+        retention_stage = "durable"
+        retention_checkpoint = None
+    elif retention_origin_at is not None:
+        retention_stage = (
+            "repair_confirmed"
+            if retention_checkpoint_index == 0
+            else f"{RETENTION_CHECKPOINTS[retention_checkpoint_index - 1][0]}_passed"
+        )
+        retention_checkpoint = _checkpoint_name(retention_checkpoint_index)
+    else:
+        retention_stage = None
+        retention_checkpoint = None
+
+    result["retention_stage"] = retention_stage
+    result["retention_checkpoint"] = retention_checkpoint
+    result["retention_origin_at"] = retention_origin_at
     result["next_review_at"] = next_review_at
-    result["due_overdue_days"] = max(0, (as_of - next_review_at).days) if as_of and next_review_at and as_of >= next_review_at else 0
+    result["due_overdue_days"] = (
+        max(0, (as_of - next_review_at).days)
+        if as_of and next_review_at and as_of >= next_review_at
+        else 0
+    )
     return result
 
 

--- a/knowledge_node_state_transition.py
+++ b/knowledge_node_state_transition.py
@@ -15,14 +15,12 @@ from question_equivalence import canonicalize_question_evidence_node
 
 
 STATES = ("unseen", "checking", "repairing", "repaired", "stable", "recheck_due")
-RETENTION_CHECKPOINTS = (
-    ("day3", timedelta(days=3)),
-    ("day7", timedelta(days=7)),
-    ("day30", timedelta(days=30)),
-)
-# Compatibility names for callers that only need the first/last horizon.
-REPAIRED_RECHECK_AFTER = RETENTION_CHECKPOINTS[0][1]
-STABLE_RECHECK_AFTER = RETENTION_CHECKPOINTS[-1][1]
+DAY3_RECHECK_AFTER = timedelta(days=3)
+DAY7_RECHECK_AFTER = timedelta(days=7)
+DAY30_RECHECK_AFTER = timedelta(days=30)
+# Compatibility aliases used by older diagnostics/tests.
+REPAIRED_RECHECK_AFTER = DAY3_RECHECK_AFTER
+STABLE_RECHECK_AFTER = DAY30_RECHECK_AFTER
 
 
 def _sort_key(attempt: dict[str, Any]) -> tuple[str, str, int, int]:
@@ -45,12 +43,8 @@ def _evidence_node(item: dict[str, Any]) -> str:
 
 
 def is_recheck_due(state: str, last_attempted_at: datetime, as_of: datetime) -> bool:
-    """Compatibility helper: repaired first becomes due at the 3-day checkpoint.
-
-    A node is only called stable after the 30-day checkpoint has passed, so stable
-    does not automatically become due again in this v0.1 retention contract.
-    """
-    return state == "repaired" and as_of - last_attempted_at >= REPAIRED_RECHECK_AFTER
+    interval = DAY3_RECHECK_AFTER if state == "repaired" else DAY30_RECHECK_AFTER
+    return state in {"repaired", "stable"} and as_of - last_attempted_at >= interval
 
 
 def _as_datetime(value) -> datetime | None:
@@ -119,29 +113,23 @@ def _result(
     }
 
 
-def _checkpoint_due_at(origin: datetime | None, checkpoint_index: int) -> datetime | None:
-    if origin is None or checkpoint_index >= len(RETENTION_CHECKPOINTS):
-        return None
-    return origin + RETENTION_CHECKPOINTS[checkpoint_index][1]
-
-
-def _checkpoint_name(checkpoint_index: int) -> str | None:
-    if checkpoint_index >= len(RETENTION_CHECKPOINTS):
-        return None
-    return RETENTION_CHECKPOINTS[checkpoint_index][0]
-
-
 def derive_knowledge_node_state(
     attempts: Iterable[dict[str, Any]],
     canonical_node_id: str | None = None,
     as_of: datetime | None = None,
 ) -> dict[str, Any]:
-    """Derive one user's one canonical Node state from attempt history.
+    """Derive the final state for one user's one canonical evidence-Node history.
 
-    Core repair/retention contract:
-    wrong -> repairing -> strong different-Q confidence=1 confirmation -> repaired
-    -> day3 -> day7 -> day30 retention checks -> stable.
-    A wrong answer at any checkpoint immediately starts a new repair cycle.
+    Core learning loop:
+      wrong -> repairing
+      strong different-question confidence=1 -> repaired
+      3-day check -> repaired/day3_passed
+      7-day check -> stable/day7_passed
+      30-day check -> stable/durable
+
+    If the learner does not study at day 3 and the first valid spaced check happens
+    on/after day 7, that check is accepted as the day-7 horizon instead of creating
+    artificial overdue backlog. Any wrong answer starts a fresh repair cycle.
     """
     ordered = sorted((dict(item) for item in attempts), key=_sort_key)
     if not ordered:
@@ -167,16 +155,17 @@ def derive_knowledge_node_state(
     confident_correct_after_wrong_count = 0
     has_prior_wrong = False
     retention_origin_at: datetime | None = None
-    retention_checkpoint_index = 0
+    retention_stage: str | None = None
+    retention_checkpoint: str | None = None
     next_review_at: datetime | None = None
     retention_reference_question: str | None = None
     history: list[dict[str, Any]] = []
 
     for item in ordered:
         attempted_at = _as_datetime(item.get("attempted_at") or item.get("answered_at"))
-        if state == "repaired" and next_review_at and attempted_at and attempted_at >= next_review_at:
+        if state in {"repaired", "stable"} and next_review_at and attempted_at and attempted_at >= next_review_at:
             state = "recheck_due"
-            reason = f"The {_checkpoint_name(retention_checkpoint_index)} retention checkpoint is due."
+            reason = f"The {retention_checkpoint} retention checkpoint is due."
 
         history.append(item)
         question_id = str(item.get("question_id") or "")
@@ -196,7 +185,8 @@ def derive_knowledge_node_state(
                 repair_wrong_questions.add(question_id)
             has_prior_wrong = True
             retention_origin_at = None
-            retention_checkpoint_index = 0
+            retention_stage = None
+            retention_checkpoint = None
             next_review_at = None
             retention_reference_question = None
             continue
@@ -223,19 +213,39 @@ def derive_knowledge_node_state(
                 retention_reference_question, question_id
             )
             if confidence == 1 and retention_strength == DIFFERENT_QUESTION_STRONG:
-                passed_checkpoint = _checkpoint_name(retention_checkpoint_index)
-                retention_checkpoint_index += 1
                 retention_reference_question = question_id
-                if retention_checkpoint_index >= len(RETENTION_CHECKPOINTS):
-                    state = "stable"
-                    next_review_at = None
-                    reason = "The day30 spaced retention checkpoint passed with strong different-question confidence=1 evidence."
-                else:
-                    state = "repaired"
-                    next_review_at = _checkpoint_due_at(
-                        retention_origin_at, retention_checkpoint_index
+                if retention_checkpoint == "day3":
+                    elapsed = (
+                        attempted_at - retention_origin_at
+                        if attempted_at and retention_origin_at
+                        else timedelta(0)
                     )
-                    reason = f"The {passed_checkpoint} retention checkpoint passed; the next spaced checkpoint is scheduled."
+                    if elapsed >= DAY7_RECHECK_AFTER:
+                        state = "stable"
+                        retention_stage = "day7_passed"
+                        retention_checkpoint = "day30"
+                        next_review_at = attempted_at + DAY30_RECHECK_AFTER if attempted_at else None
+                        reason = "A valid spaced check on/after the day7 horizon confirmed retention."
+                    else:
+                        state = "repaired"
+                        retention_stage = "day3_passed"
+                        retention_checkpoint = "day7"
+                        next_review_at = retention_origin_at + DAY7_RECHECK_AFTER if retention_origin_at else None
+                        reason = "The day3 retention checkpoint passed; day7 is scheduled."
+                elif retention_checkpoint == "day7":
+                    state = "stable"
+                    retention_stage = "day7_passed"
+                    retention_checkpoint = "day30"
+                    next_review_at = attempted_at + DAY30_RECHECK_AFTER if attempted_at else None
+                    reason = "The day7 retention checkpoint passed; the one-month check is scheduled."
+                elif retention_checkpoint == "day30":
+                    state = "stable"
+                    retention_stage = "durable"
+                    retention_checkpoint = None
+                    next_review_at = None
+                    reason = "The one-month retention checkpoint passed with strong different-question confidence=1 evidence."
+                else:
+                    reason = "Retention checkpoint metadata was unavailable; review remains due."
             else:
                 reason = "Retention evidence was same/weak or lacked confidence=1; the current checkpoint remains due."
             continue
@@ -246,13 +256,12 @@ def derive_knowledge_node_state(
                 state = "repaired"
                 retention_reference_question = question_id
                 retention_origin_at = attempted_at
-                retention_checkpoint_index = 0
-                next_review_at = _checkpoint_due_at(
-                    retention_origin_at, retention_checkpoint_index
-                )
+                retention_stage = "repair_confirmed"
+                retention_checkpoint = "day3"
+                next_review_at = attempted_at + DAY3_RECHECK_AFTER if attempted_at else None
                 reason = "A strong different-question confirmation was correct with confidence=1 after a wrong answer."
-            elif state == "repaired":
-                reason = "Repair remains confirmed; the scheduled retention checkpoint has not arrived yet."
+            elif state in {"repaired", "stable"}:
+                reason = "Retention remains confirmed; the scheduled spaced checkpoint has not arrived yet."
         elif state == "repairing":
             reason = (
                 "The correct answer is same/weakly different or lacks confidence=1; repair remains unconfirmed."
@@ -267,23 +276,9 @@ def derive_knowledge_node_state(
         retention_reference_question,
     )
     as_of = _as_datetime(as_of)
-    if state == "repaired" and next_review_at and as_of and as_of >= next_review_at:
+    if state in {"repaired", "stable"} and next_review_at and as_of and as_of >= next_review_at:
         result["state"] = "recheck_due"
-        result["reason"] = f"The {_checkpoint_name(retention_checkpoint_index)} retention checkpoint is due."
-
-    if result["state"] == "stable":
-        retention_stage = "durable"
-        retention_checkpoint = None
-    elif retention_origin_at is not None:
-        retention_stage = (
-            "repair_confirmed"
-            if retention_checkpoint_index == 0
-            else f"{RETENTION_CHECKPOINTS[retention_checkpoint_index - 1][0]}_passed"
-        )
-        retention_checkpoint = _checkpoint_name(retention_checkpoint_index)
-    else:
-        retention_stage = None
-        retention_checkpoint = None
+        result["reason"] = f"The {retention_checkpoint} retention checkpoint is due."
 
     result["retention_stage"] = retention_stage
     result["retention_checkpoint"] = retention_checkpoint

--- a/tests/test_core_repair_retention_loop.py
+++ b/tests/test_core_repair_retention_loop.py
@@ -1,0 +1,109 @@
+from datetime import datetime, timedelta, timezone
+
+from knowledge_node_state_transition import derive_knowledge_node_state
+
+
+NOW = datetime(2026, 9, 9, 0, 0, tzinfo=timezone.utc)
+
+
+def attempt(question, correct, confidence, at, *, node="KN0268", status="answered"):
+    return {
+        "id": int(at.timestamp()),
+        "event_key": f"event-{question}-{int(at.timestamp())}",
+        "user_id": "learner",
+        "question_id": question,
+        "knowledge_node_id": node,
+        "is_correct": correct,
+        "confidence": confidence,
+        "answer_status": status,
+        "attempted_at": at,
+        "attempt_position": 1,
+    }
+
+
+def repaired_history():
+    return [
+        attempt("Q269", False, 2, NOW),
+        attempt("Q361", True, 1, NOW + timedelta(minutes=1)),
+    ]
+
+
+def test_repair_confirmation_schedules_day3_not_day7():
+    history = repaired_history()
+    repaired_at = NOW + timedelta(minutes=1)
+
+    before = derive_knowledge_node_state(
+        history, as_of=repaired_at + timedelta(days=2, hours=23)
+    )
+    assert before["state"] == "repaired"
+    assert before["retention_stage"] == "repair_confirmed"
+    assert before["retention_checkpoint"] == "day3"
+    assert before["next_review_at"] == repaired_at + timedelta(days=3)
+
+    due = derive_knowledge_node_state(
+        history, as_of=repaired_at + timedelta(days=3)
+    )
+    assert due["state"] == "recheck_due"
+    assert due["retention_checkpoint"] == "day3"
+
+
+def test_day3_day7_day30_successes_reach_stable():
+    repaired_at = NOW + timedelta(minutes=1)
+    day3 = repaired_at + timedelta(days=3)
+    day7 = repaired_at + timedelta(days=7)
+    day30 = repaired_at + timedelta(days=30)
+
+    history = repaired_history()
+    history.append(attempt("Q269", True, 1, day3))
+    after_day3 = derive_knowledge_node_state(history, as_of=day3)
+    assert after_day3["state"] == "repaired"
+    assert after_day3["retention_stage"] == "day3_passed"
+    assert after_day3["retention_checkpoint"] == "day7"
+    assert after_day3["next_review_at"] == day7
+
+    history.append(attempt("Q361", True, 1, day7))
+    after_day7 = derive_knowledge_node_state(history, as_of=day7)
+    assert after_day7["state"] == "repaired"
+    assert after_day7["retention_stage"] == "day7_passed"
+    assert after_day7["retention_checkpoint"] == "day30"
+    assert after_day7["next_review_at"] == day30
+
+    history.append(attempt("Q269", True, 1, day30))
+    after_day30 = derive_knowledge_node_state(history, as_of=day30)
+    assert after_day30["state"] == "stable"
+    assert after_day30["retention_stage"] == "durable"
+    assert after_day30["retention_checkpoint"] is None
+    assert after_day30["next_review_at"] is None
+
+
+def test_one_late_correct_cannot_skip_multiple_retention_checkpoints():
+    repaired_at = NOW + timedelta(minutes=1)
+    late = repaired_at + timedelta(days=31)
+    history = repaired_history() + [attempt("Q269", True, 1, late)]
+
+    result = derive_knowledge_node_state(history, as_of=late)
+    assert result["state"] == "recheck_due"
+    assert result["retention_stage"] == "day3_passed"
+    assert result["retention_checkpoint"] == "day7"
+
+
+def test_wrong_at_retention_checkpoint_starts_new_repair_cycle():
+    repaired_at = NOW + timedelta(minutes=1)
+    day3 = repaired_at + timedelta(days=3)
+    history = repaired_history() + [attempt("Q269", False, 1, day3)]
+
+    result = derive_knowledge_node_state(history, as_of=day3)
+    assert result["state"] == "repairing"
+    assert result["retention_stage"] is None
+    assert result["retention_checkpoint"] is None
+    assert result["next_review_at"] is None
+
+
+def test_same_question_correct_does_not_confirm_initial_repair():
+    history = [
+        attempt("Q269", False, 2, NOW),
+        attempt("Q269", True, 1, NOW + timedelta(minutes=1)),
+    ]
+    result = derive_knowledge_node_state(history)
+    assert result["state"] == "repairing"
+    assert result["retention_stage"] is None

--- a/tests/test_core_repair_retention_loop.py
+++ b/tests/test_core_repair_retention_loop.py
@@ -47,11 +47,11 @@ def test_repair_confirmation_schedules_day3_not_day7():
     assert due["retention_checkpoint"] == "day3"
 
 
-def test_day3_day7_day30_successes_reach_stable():
+def test_day3_day7_then_one_month_successes_complete_retention_loop():
     repaired_at = NOW + timedelta(minutes=1)
     day3 = repaired_at + timedelta(days=3)
     day7 = repaired_at + timedelta(days=7)
-    day30 = repaired_at + timedelta(days=30)
+    one_month_after_day7 = day7 + timedelta(days=30)
 
     history = repaired_history()
     history.append(attempt("Q269", True, 1, day3))
@@ -63,28 +63,29 @@ def test_day3_day7_day30_successes_reach_stable():
 
     history.append(attempt("Q361", True, 1, day7))
     after_day7 = derive_knowledge_node_state(history, as_of=day7)
-    assert after_day7["state"] == "repaired"
+    assert after_day7["state"] == "stable"
     assert after_day7["retention_stage"] == "day7_passed"
     assert after_day7["retention_checkpoint"] == "day30"
-    assert after_day7["next_review_at"] == day30
+    assert after_day7["next_review_at"] == one_month_after_day7
 
-    history.append(attempt("Q269", True, 1, day30))
-    after_day30 = derive_knowledge_node_state(history, as_of=day30)
-    assert after_day30["state"] == "stable"
-    assert after_day30["retention_stage"] == "durable"
-    assert after_day30["retention_checkpoint"] is None
-    assert after_day30["next_review_at"] is None
+    history.append(attempt("Q269", True, 1, one_month_after_day7))
+    durable = derive_knowledge_node_state(history, as_of=one_month_after_day7)
+    assert durable["state"] == "stable"
+    assert durable["retention_stage"] == "durable"
+    assert durable["retention_checkpoint"] is None
+    assert durable["next_review_at"] is None
 
 
-def test_one_late_correct_cannot_skip_multiple_retention_checkpoints():
+def test_late_first_retention_check_uses_day7_horizon_without_fake_backlog():
     repaired_at = NOW + timedelta(minutes=1)
-    late = repaired_at + timedelta(days=31)
+    late = repaired_at + timedelta(days=8)
     history = repaired_history() + [attempt("Q269", True, 1, late)]
 
     result = derive_knowledge_node_state(history, as_of=late)
-    assert result["state"] == "recheck_due"
-    assert result["retention_stage"] == "day3_passed"
-    assert result["retention_checkpoint"] == "day7"
+    assert result["state"] == "stable"
+    assert result["retention_stage"] == "day7_passed"
+    assert result["retention_checkpoint"] == "day30"
+    assert result["next_review_at"] == late + timedelta(days=30)
 
 
 def test_wrong_at_retention_checkpoint_starts_new_repair_cycle():

--- a/tests/test_core_retention_selector.py
+++ b/tests/test_core_retention_selector.py
@@ -1,0 +1,69 @@
+import random
+
+import adaptive_question_selector as selector
+
+
+def test_recheck_due_can_bypass_recent_cooldown(monkeypatch):
+    node_by_q = {
+        "Q1": "KN0001",
+        "Q2": "KN0001",
+        **{f"Q{i}": f"KN{i:04d}" for i in range(3, 50)},
+    }
+    monkeypatch.setattr(selector, "question_ids", lambda: tuple(node_by_q))
+    monkeypatch.setattr(
+        selector,
+        "get_question_tag",
+        lambda q: {"knowledge_node_id": node_by_q[q], "safety": "none"},
+    )
+    monkeypatch.setattr(
+        selector,
+        "derive_all_user_node_states",
+        lambda *_args, **_kwargs: [
+            {
+                "canonical_node_id": "KN0001",
+                "state": "recheck_due",
+                "due_overdue_days": 0,
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        selector,
+        "classify_repair_confirmation",
+        lambda old, new: "same_question" if old == new else "different_question_strong",
+    )
+    attempts = [
+        {
+            "user_id": "u",
+            "question_id": "Q1",
+            "knowledge_node_id": "KN0001",
+            "is_correct": False,
+            "confidence": 2,
+            "answer_status": "answered",
+            "answered_at": "2026-09-01T00:00:00+00:00",
+            "event_key": "e1",
+            "attempt_position": 1,
+        },
+        {
+            "user_id": "u",
+            "question_id": "Q2",
+            "knowledge_node_id": "KN0001",
+            "is_correct": True,
+            "confidence": 1,
+            "answer_status": "answered",
+            "answered_at": "2026-09-01T00:01:00+00:00",
+            "event_key": "e2",
+            "attempt_position": 1,
+        },
+    ]
+
+    selected = selector.select_node_adaptive_questions(
+        attempts,
+        10,
+        rng=random.Random(101),
+        learning_intent="recheck",
+    )
+    due_items = [item for item in selected if item["canonical_node_id"] == "KN0001"]
+    assert due_items
+    assert due_items[0]["priority_reason"] == "recheck_due"
+    assert due_items[0]["recent_question_repeat"] is True
+    assert due_items[0]["recent_cooldown_bypassed"] is True

--- a/tests/test_core_wrong_pattern.py
+++ b/tests/test_core_wrong_pattern.py
@@ -1,0 +1,62 @@
+from datetime import datetime, timedelta, timezone
+
+from companion_record import build_companion_record
+
+
+NOW = datetime(2026, 9, 9, tzinfo=timezone.utc)
+
+
+def attempt(question, correct, confidence, minute, *, status="answered", node="KN0268"):
+    return {
+        "id": minute + 1,
+        "event_key": f"event-{minute}",
+        "user_id": "learner",
+        "question_id": question,
+        "knowledge_node_id": node,
+        "is_correct": correct,
+        "confidence": confidence,
+        "answer_status": status,
+        "attempted_at": NOW + timedelta(minutes=minute),
+        "attempt_position": 1,
+    }
+
+
+def wrong_pattern(*history):
+    record = build_companion_record(history)
+    return record["episodes"][0]["wrong_pattern"]
+
+
+def test_confident_wrong_is_explicit_observable_pattern():
+    pattern = wrong_pattern(attempt("Q269", False, 1, 1))
+    assert pattern["code"] == "confident_wrong"
+    assert pattern["basis"] == "wrong_with_confidence_1"
+
+
+def test_unknown_answer_is_not_guessed_as_knowledge_failure():
+    pattern = wrong_pattern(attempt("Q269", False, None, 1, status="unknown"))
+    assert pattern["code"] == "unknown_answer"
+    assert pattern["basis"] == "answer_status_unknown"
+
+
+def test_repeated_cross_question_wrong_is_distinguished():
+    pattern = wrong_pattern(
+        attempt("Q269", False, 2, 1),
+        attempt("Q361", False, 2, 2),
+    )
+    assert pattern["code"] == "repeated_cross_question_wrong"
+
+
+def test_wrong_after_repair_is_retention_regression():
+    record = build_companion_record([
+        attempt("Q269", False, 2, 1),
+        attempt("Q361", True, 1, 2),
+        attempt("Q269", False, 1, 3),
+    ])
+    episode = record["episodes"][0]
+    assert episode["wrong_pattern"]["code"] == "retention_regression"
+    assert episode["events"][-1]["event"] == "regression_detected"
+
+
+def test_wrong_pattern_contract_does_not_claim_hidden_psychology():
+    record = build_companion_record([attempt("Q269", False, 2, 1)])
+    assert record["wrong_pattern_semantics"] == "observable_evidence_not_psychological_diagnosis"

--- a/tests/test_field_progress.py
+++ b/tests/test_field_progress.py
@@ -74,8 +74,8 @@ def test_cases_i_and_j_use_formal_retention_replay(monkeypatch):
         attempt("Q269", "KN0268", False, 2, 0),
         attempt("Q361", "KN0268", True, 1, 1),
     ]
-    repaired = build_field_progress(build_field_evidence(repaired_history, as_of=BASE + timedelta(days=7)))
-    due = build_field_progress(build_field_evidence(repaired_history, as_of=BASE + timedelta(days=9)))
+    repaired = build_field_progress(build_field_evidence(repaired_history, as_of=BASE + timedelta(days=3)))
+    due = build_field_progress(build_field_evidence(repaired_history, as_of=BASE + timedelta(days=5)))
     assert node_score(repaired, "KN0268")["state_score"] == 0.70
     assert node_score(due, "KN0268")["state_score"] == 0.60
 

--- a/tests/test_node_spaced_retention.py
+++ b/tests/test_node_spaced_retention.py
@@ -22,13 +22,14 @@ def repaired_history():
     return [item("Q1", False, 2, 0), item("Q2", True, 1, 1)]
 
 
-def test_repaired_due_at_seven_days_not_six(monkeypatch):
+def test_repaired_due_at_three_days_not_before(monkeypatch):
     monkeypatch.setattr(transition, "classify_repair_confirmation", strong_classifier)
     history = repaired_history()
-    assert transition.derive_knowledge_node_state(history, as_of=BASE + timedelta(days=7))["state"] == "repaired"
-    result = transition.derive_knowledge_node_state(history, as_of=BASE + timedelta(days=8))
+    assert transition.derive_knowledge_node_state(history, as_of=BASE + timedelta(days=3))["state"] == "repaired"
+    result = transition.derive_knowledge_node_state(history, as_of=BASE + timedelta(days=4))
     assert result["state"] == "recheck_due"
-    assert result["next_review_at"] == BASE + timedelta(days=8)
+    assert result["retention_checkpoint"] == "day3"
+    assert result["next_review_at"] == BASE + timedelta(days=4)
 
 
 def test_due_checks_require_strong_confident_different_question(monkeypatch):
@@ -37,7 +38,10 @@ def test_due_checks_require_strong_confident_different_question(monkeypatch):
     assert transition.derive_knowledge_node_state(base + [item("Q2", True, 1, 8)])["state"] == "recheck_due"
     assert transition.derive_knowledge_node_state(base + [item("Q3", True, 2, 8)])["state"] == "recheck_due"
     assert transition.derive_knowledge_node_state(base + [item("Q3", True, 3, 8)])["state"] == "recheck_due"
-    assert transition.derive_knowledge_node_state(base + [item("Q3", True, 1, 8)])["state"] == "stable"
+    result = transition.derive_knowledge_node_state(base + [item("Q3", True, 1, 8)])
+    assert result["state"] == "stable"
+    assert result["retention_stage"] == "day7_passed"
+    assert result["retention_checkpoint"] == "day30"
 
 
 def test_due_wrong_or_unknown_returns_to_repairing(monkeypatch):
@@ -52,5 +56,8 @@ def test_stable_due_at_thirty_days_and_can_reconfirm(monkeypatch):
     stable = repaired_history() + [item("Q3", True, 1, 8)]
     assert transition.derive_knowledge_node_state(stable, as_of=BASE + timedelta(days=37))["state"] == "stable"
     assert transition.derive_knowledge_node_state(stable, as_of=BASE + timedelta(days=38))["state"] == "recheck_due"
-    assert transition.derive_knowledge_node_state(stable + [item("Q4", True, 1, 38)])["state"] == "stable"
+    durable = transition.derive_knowledge_node_state(stable + [item("Q4", True, 1, 38)])
+    assert durable["state"] == "stable"
+    assert durable["retention_stage"] == "durable"
+    assert durable["next_review_at"] is None
     assert transition.derive_knowledge_node_state(stable + [item("Q4", False, 1, 38)])["state"] == "repairing"

--- a/tests/test_phase11_intent_selection_alignment.py
+++ b/tests/test_phase11_intent_selection_alignment.py
@@ -122,9 +122,9 @@ def test_recheck_same_reference_question_is_misaligned(monkeypatch):
 
 def test_saved_recheck_is_open_when_answer_time_state_is_not_due(monkeypatch):
     install(monkeypatch, {("Q1", "Q2"), ("Q2", "Q3")})
-    # day 7 is still repaired under the formal seven-day policy.
+    # Repair is confirmed on day 1; day 3 is still before the day-3 checkpoint.
     history = repaired_history() + [
-        attempt("Q3", correct=True, confidence=1, day=7, event="session:1")
+        attempt("Q3", correct=True, confidence=1, day=3, event="session:1")
     ]
     result = audit.build_phase11_intent_selection_alignment(
         history,

--- a/tests/test_phase11_retention_outcome_audit.py
+++ b/tests/test_phase11_retention_outcome_audit.py
@@ -57,7 +57,7 @@ def test_captures_hidden_repaired_to_due_to_stable_review(monkeypatch):
     history = repaired_history() + [attempt("Q3", correct=True, confidence=1, day=8)]
 
     # Prefix timeline jumps directly repaired -> stable; the audit must still
-    # recover the due-before-attempt retention event.
+    # recover the day3 due-before-attempt retention event.
     assert [item["state"] for item in transition.derive_state_timeline(history)] == [
         "repairing", "repaired", "stable"
     ]
@@ -71,7 +71,7 @@ def test_captures_hidden_repaired_to_due_to_stable_review(monkeypatch):
     assert review["outcome"] == "stable"
     assert review["retention_reference_question_id"] == "Q2"
     assert review["question_id"] == "Q3"
-    assert review["hours_after_due"] == 0.0
+    assert review["hours_after_due"] == 96.0
 
 
 def test_due_strong_wrong_is_qualified_repairing_outcome(monkeypatch):
@@ -110,8 +110,9 @@ def test_due_strong_uncertain_correct_stays_due_and_does_not_qualify(monkeypatch
 
 def test_before_due_attempt_is_not_retention_review(monkeypatch):
     install_classifier(monkeypatch, {("Q1", "Q2"), ("Q2", "Q3")})
+    # Repair is confirmed on day1, so day3 is still before the day3 checkpoint at day4.
     result = audit.build_retention_outcome_audit(
-        repaired_history() + [attempt("Q3", correct=True, confidence=1, day=7)]
+        repaired_history() + [attempt("Q3", correct=True, confidence=1, day=3)]
     )
     assert result["review_attempt_count"] == 0
     assert result["qualified_strong_outcome_count"] == 0


### PR DESCRIPTION
Core-line only. Implements explicit 3-day / 7-day / 30-day retention checkpoints after strong different-question repair confirmation, returns any checkpoint wrong to repairing, and exposes observable wrong-answer patterns in the companion record without psychological overclaiming. No dashboard polish, main, Render, LINE, or production DB changes.