### PR TITLE
Fix dashboard summary row and route guidance

### DIFF
--- a/static/goukaku/dashboard-approved-layout-v01.css
+++ b/static/goukaku/dashboard-approved-layout-v01.css
@@ -135,6 +135,12 @@
 .dashboard-reference-source-only{
   display:none!important;
 }
+.lt-route-pace-note{
+  margin:8px 0 0;
+  color:#53625a;
+  font-size:10px;
+  line-height:1.45;
+}
 
 /* LOWER HALF: frozen to the already approved reference. */
 .dashboard-reference-lower{
@@ -210,5 +216,19 @@
       "footprints"
       "checkpoint";
     gap:12px;
+  }
+}
+
+@media (min-width:701px) and (max-width:1000px){
+  .dashboard-reference-top>.summary-grid{
+    grid-template-columns:repeat(5,minmax(0,1fr));
+    gap:10px;
+  }
+  .dashboard-reference-top>.summary-grid .mini-card{
+    padding-left:8px;
+    padding-right:8px;
+  }
+  .dashboard-reference-top>.summary-grid .mini-card strong{
+    font-size:29px;
   }
 }

--- a/static/goukaku/dashboard-product-copy-v01.js
+++ b/static/goukaku/dashboard-product-copy-v01.js
@@ -138,9 +138,9 @@ document.addEventListener('DOMContentLoaded', () => {
       </div>
       <p class="lt-route-lead">残り${Number.isFinite(countdownNumber) ? `${countdownNumber}日` : '日数'}を、今の現在地から逆算して進めます。学習結果に合わせてルートは更新されます。</p>
       <div class="lt-route-pace-panel">
-        <div><small>この時点の推奨</small><strong>${recommendedDisplay}</strong><span>LT学習到達指標</span></div>
-        <div><small>現在</small><strong>${currentDisplay}</strong><span>推奨との差 ${gapDisplay}</span></div>
-        <div class="lt-route-pace-result"><small>推奨ルートとの位置</small><strong>${scheduleDetail}</strong><span>${scheduleLabel}</span></div>
+        <div><small>この時点の推奨</small><strong>${recommendedDisplay}</strong><span>LT学習到達指標</span><p class="lt-route-pace-note">現在の学習記録から見た到達目安です</p></div>
+        <div><small>現在</small><strong>${currentDisplay}</strong><span>推奨との差 ${gapDisplay}</span><p class="lt-route-pace-note">いまの進み具合を毎日更新しています</p></div>
+        <div class="lt-route-pace-result"><small>推奨ルートとの位置</small><strong>${scheduleDetail}</strong><span>${scheduleLabel}</span><p class="lt-route-pace-note">推奨ペースと現在地の差を示しています</p></div>
       </div>
       <p class="lt-route-evidence">${activityCopy} <b>回答数だけではなく、修復・再確認・定着まで含めて現在地を判定します。</b></p>
       <div class="lt-route-now-grid">

--- a/tests/test_dashboard_approved_layout.py
+++ b/tests/test_dashboard_approved_layout.py
@@ -23,6 +23,9 @@ def test_top_half_matches_latest_boss_reference_exact_order():
     assert positions == sorted(positions)
     assert "grid-template-columns:minmax(0,58%) minmax(0,42%)" in css
     assert ".dashboard-reference-source-only" in css
+    assert "@media (min-width:701px) and (max-width:1000px)" in css
+    assert "grid-template-columns:repeat(5,minmax(0,1fr))" in css
+    assert ".lt-route-pace-note" in css
 
 
 def test_lower_half_remains_frozen_to_previous_approved_reference():

--- a/tests/test_dashboard_product_copy_v01.py
+++ b/tests/test_dashboard_product_copy_v01.py
@@ -38,5 +38,8 @@ def test_paid_route_compares_current_progress_with_recommended_pace():
     assert "equivalentDaysRemaining" in js
     assert "この時点の推奨" in js
     assert "推奨ルートとの位置" in js
+    assert "現在の学習記録から見た到達目安です" in js
+    assert "いまの進み具合を毎日更新しています" in js
+    assert "推奨ペースと現在地の差を示しています" in js
     assert "合格確率ではありません" in js
     assert "lt-route-pace-panel" in css


### PR DESCRIPTION
Boss指定の2点だけを反映します。

- サマリー5カードをPC/タブレット幅で横一列に固定
- 「合格までの推奨ルート」上段3カードの余白に短い説明文を追加

それ以外の配置・下半分・カード内容は変更しません。

Codex側で実装・検証・branch push済み。対象commit: 8403389258f8d5eca72ff96ce3228a58dbb8b841

追記: 実機で変更が反映されないことを確認。原因は5列CSSが701-1000pxに限定されていたことと、JS/CSSのキャッシュバージョン未更新。後続のfix branchで是正する。