### PR TITLE
chore: verify LicenseTown in Google Search Console

### DIFF
--- a/templates/site/home.html
+++ b/templates/site/home.html
@@ -3,6 +3,7 @@
 <title>理学療法士国家試験の勉強・問題演習ならLicenseTown | PT国試対策</title>
 <meta name="description" content="LicenseTownは、理学療法士国家試験（PT国試）の合格を目指す受験生向け学習サービスです。2000問の問題演習、弱点分析、学習提案で、今日やることから合格までを伴走します。">
 <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1">
+<meta name="google-site-verification" content="X0TjcNHijLqiVMmj0d6u_3mpqSHddyYOUxq_FXDf4ys" />
 <link rel="canonical" href="{{ request.url_root.rstrip('/') }}{{ url_for('site_ui.home') }}">
 <meta property="og:title" content="理学療法士国家試験の勉強・問題演習ならLicenseTown">
 <meta property="og:description" content="2000問の問題演習、弱点分析、学習提案でPT国試合格まで伴走。やれば出来る子を、やったから出来た子へ。">


### PR DESCRIPTION
Add the Google Search Console ownership verification meta tag to the public LicenseTown home page. No visual or learner-flow changes.