### PR TITLE
chore: remove legacy Search Console verification token

### DIFF
--- a/site_seo_foundation.py
+++ b/site_seo_foundation.py
@@ -14,7 +14,6 @@ NOINDEX_PREFIXES = (
 )
 
 GSC_VERIFICATION_FILES = (
-    "google5328e7e8be120ade.html",
     "googlef6f9c91620140fb4.html",
 )
 


### PR DESCRIPTION
Goal: complete the Search Console ownership migration to licensetown.support@gmail.com.

Changes:
- Remove the old myforest2022 verification file route google5328e7e8be120ade.html
- Keep the confirmed support-account verification file googlef6f9c91620140fb4.html
- No visible UI changes

Completion condition: CI green, merge to main, Render live, then verify the support-account token remains reachable and the legacy token no longer is.