### PR TITLE
fix: block short-term same-Q repeats across learner paths

### DIFF
--- a/app.py
+++ b/app.py
@@ -619,15 +619,21 @@ def load_question_master(path=None):
     return questions
 
 
-def select_random_questions(question_count):
+def select_random_questions(question_count, *, exclude_ids=()):
     """
     起動時ロード済みの正式問題バンクからランダムに取得する。
     """
+    if exclude_ids:
+        return select_formal_questions(question_count, exclude_ids=exclude_ids)
     return select_formal_questions(question_count)
 
 
-def select_category_questions(category_small, question_count):
+def select_category_questions(category_small, question_count, *, exclude_ids=()):
     """正式問題バンクから指定分野の問題だけを取得する。"""
+    if exclude_ids:
+        return select_formal_questions_by_category(
+            category_small, question_count, exclude_ids=exclude_ids
+        )
     return select_formal_questions_by_category(category_small, question_count)
 
 # 回答時に使用する自信度
@@ -928,7 +934,12 @@ def start_quiz(user_id, session_kind=None, question_count=None, exclude_ids=None
     adaptive_selection_audit = None
     if session_kind == "initial_assessment":
         all_questions = build_initial_assessment(total_question_count)
-    elif session_kind == "adaptive_daily":
+    else:
+        attempts = get_question_attempts(user_id)
+        from short_term_repeat_guard import blocked_short_term_evidence_ids
+        short_term_blocked = blocked_short_term_evidence_ids(attempts)
+        short_term_blocked.update(str(value) for value in (exclude_ids or ()))
+    if session_kind == "adaptive_daily":
         if is_node_adaptive_recommendation_enabled(
             ENABLE_NODE_ADAPTIVE_RECOMMENDATION,
             user_id,
@@ -936,19 +947,30 @@ def start_quiz(user_id, session_kind=None, question_count=None, exclude_ids=None
         ):
             adaptive_selection_audit = {}
             all_questions = build_node_adaptive_session(
-                get_question_attempts(user_id),
+                attempts,
                 total_question_count,
-                exclude_ids=exclude_ids,
+                exclude_ids=short_term_blocked,
                 audit_out=adaptive_selection_audit,
             )
         else:
             all_questions = build_daily_session(
-                get_question_history(user_id), total_question_count, exclude_ids=exclude_ids
+                attempts, total_question_count, exclude_ids=short_term_blocked
             )
-    elif category_small is None:
-        all_questions = select_random_questions(total_question_count)
-    else:
-        all_questions = select_category_questions(category_small, total_question_count)
+    elif session_kind != "initial_assessment":
+        if category_small is None:
+            all_questions = (
+                select_random_questions(total_question_count, exclude_ids=short_term_blocked)
+                if short_term_blocked
+                else select_random_questions(total_question_count)
+            )
+        else:
+            all_questions = (
+                select_category_questions(
+                    category_small, total_question_count, exclude_ids=short_term_blocked
+                )
+                if short_term_blocked
+                else select_category_questions(category_small, total_question_count)
+            )
     # Keep the import at the session boundary so isolated app test harnesses
     # cannot accidentally drop the guard from this function's module globals.
     from question_order_quality import arrange_five_question_sets
@@ -1962,6 +1984,14 @@ def queue_prerequisite_backtrack_for_next_set(user_id, session):
         get_reviewed_node_relations(),
         excluded_question_ids=excluded,
     )
+    if candidate:
+        from short_term_repeat_guard import (
+            blocked_short_term_evidence_ids,
+            is_short_term_repeat_blocked,
+        )
+        blocked = blocked_short_term_evidence_ids(attempts)
+        if is_short_term_repeat_blocked(candidate["question_id"], blocked):
+            candidate = None
     if candidate:
         session["pending_prerequisite_backtrack"] = candidate
     return candidate

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -6,7 +6,7 @@
 - Root cause: the PR #296 protection lived inside the adaptive/daily selectors; ordinary random/category session creation and prerequisite backtrack did not consistently apply the authoritative `question_attempts` history.
 - Fix branch: `fix/global-short-term-repeat-guard-v01`. All ordinary learner session paths now derive one shared blocked exact-evidence set from formal Node-state replay. Previously attempted evidence stays blocked until the formal state is `recheck_due`; same-Node different-Q repair remains eligible.
 - Random/category selection accepts that blocked set, category shortage fills from other non-recent evidence instead of immediately repeating a Q, and prerequisite backtrack cannot reinsert blocked evidence. Initial assessment remains unchanged.
-- Status: **real Production defect observed: YES / cause identified: YES / focused regression: GREEN / full local pytest: one unrelated Windows CRLF idempotence failure only; Linux CI pending / Production deployed: NO / real learner acceptance: PENDING**.
+- Status: **real Production defect observed: YES / cause identified: YES / focused regression: 173 passed plus 125 subtests / LF CI-equivalent full pytest: 1268 passed, 6 skipped, 1 deselected, 125 subtests passed / Production deployed: NO / real learner acceptance: PENDING**.
 
 Last updated: 2026-09-10
 Safe integration base: `work/pt-finalization-post-q2000`

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -1,6 +1,14 @@
 # LicenseTown Current State
 
-Last updated: 2026-09-09
+## 2026-09-10 Production blocker: global short-term same-Q repeats
+
+- Production attempts showed the same evidence question recurring within minutes through non-adaptive learner paths, despite the adaptive Recent Cooldown repair.
+- Root cause: the PR #296 protection lived inside the adaptive/daily selectors; ordinary random/category session creation and prerequisite backtrack did not consistently apply the authoritative `question_attempts` history.
+- Fix branch: `fix/global-short-term-repeat-guard-v01`. All ordinary learner session paths now derive one shared blocked exact-evidence set from formal Node-state replay. Previously attempted evidence stays blocked until the formal state is `recheck_due`; same-Node different-Q repair remains eligible.
+- Random/category selection accepts that blocked set, category shortage fills from other non-recent evidence instead of immediately repeating a Q, and prerequisite backtrack cannot reinsert blocked evidence. Initial assessment remains unchanged.
+- Status: **real Production defect observed: YES / cause identified: YES / focused regression: GREEN / full local pytest: one unrelated Windows CRLF idempotence failure only; Linux CI pending / Production deployed: NO / real learner acceptance: PENDING**.
+
+Last updated: 2026-09-10
 Safe integration base: `work/pt-finalization-post-q2000`
 
 ## How to resume
@@ -13,6 +21,14 @@ Safe integration base: `work/pt-finalization-post-q2000`
 Always distinguish: **code exists / tests pass / real data observed / product accepted**.
 Do not casually change `main`, Production Neon, Render or LINE behavior.
 Practical learner effect and national-exam success outrank architectural elegance.
+
+## 2026-09-10 Production blocker: global short-term same-Q repeats
+
+- Production evidence showed same raw questions recurring within minutes across ordinary learning sessions, including Q1702 at 17:34 / 17:39 / 17:45 and Q1595 at 19:16 / 19:24.
+- PR #296 protected the Node-adaptive and legacy daily builders, but ordinary random/category starts and prerequisite backtrack still had paths that did not apply the formal attempt-based guard.
+- Fix branch: `fix/global-short-term-repeat-guard-v01`. Every non-initial-assessment start reads `question_attempts` as formal truth, canonicalizes exact-repeat evidence identity, and blocks previously attempted evidence until the formal Node replay reaches `recheck_due`; same-Node different-Q repair remains eligible.
+- Random/category selection accepts the same evidence exclusions, and prerequisite backtrack cannot inject a blocked recent evidence question. Initial assessment remains on its fixed contract.
+- Status: **real Production defect observed: YES / code fix exists: YES / focused regression green / full CI pending / Production deployed: NO / real-device acceptance: PENDING**.
 
 ## Fixed PT v1.0 product finish line
 

--- a/question_bank.py
+++ b/question_bank.py
@@ -9,6 +9,8 @@ import random
 import re
 from pathlib import Path
 
+from question_equivalence import canonicalize_question_evidence_id
+
 
 logger = logging.getLogger(__name__)
 QUESTION_BANK_DIR = Path(__file__).resolve().parent / "data" / "question_bank"
@@ -343,16 +345,31 @@ def get_quiz_question(q_id) -> dict:
     }
 
 
-def select_random_questions(question_count: int) -> list[dict]:
+def select_random_questions(question_count: int, *, exclude_ids=()) -> list[dict]:
     _require_loaded()
-    if question_count > len(_QUESTIONS):
+    excluded = {
+        canonicalize_question_evidence_id(str(value))
+        for value in (exclude_ids or ())
+    }
+    eligible_by_evidence = {}
+    for q_id in _QUESTIONS:
+        evidence_id = canonicalize_question_evidence_id(q_id)
+        if evidence_id not in excluded:
+            eligible_by_evidence.setdefault(evidence_id, []).append(q_id)
+    eligible_ids = [random.choice(ids) for ids in eligible_by_evidence.values()]
+    if question_count > len(eligible_ids):
         raise QuestionBankError("Requested question count exceeds formal bank")
-    ids = random.sample(list(_QUESTIONS), question_count)
+    ids = random.sample(eligible_ids, question_count)
     return [get_quiz_question(q_id) for q_id in ids]
 
 
-def select_questions_by_category(category_small: int, question_count: int) -> list[dict]:
-    """正式JSONから指定分野だけを抽出する。少数分野は一巡後に再抽出する。"""
+def select_questions_by_category(
+    category_small: int,
+    question_count: int,
+    *,
+    exclude_ids=(),
+) -> list[dict]:
+    """正式JSONから指定分野だけを、同一evidenceの重複なしで抽出する。"""
     _require_loaded()
     try:
         category_number = int(category_small)
@@ -363,17 +380,45 @@ def select_questions_by_category(category_small: int, question_count: int) -> li
     if question_count < 1:
         raise QuestionBankError("Requested question count must be positive")
 
-    matching_ids = [
-        q_id for q_id, question in _QUESTIONS.items()
-        if int(question.get("category_small", 0)) == category_number
-    ]
+    excluded = {
+        canonicalize_question_evidence_id(str(value))
+        for value in (exclude_ids or ())
+    }
+    matching_by_evidence = {}
+    for q_id, question in _QUESTIONS.items():
+        evidence_id = canonicalize_question_evidence_id(q_id)
+        if (
+            int(question.get("category_small", 0)) == category_number
+            and evidence_id not in excluded
+        ):
+            matching_by_evidence.setdefault(evidence_id, []).append(q_id)
+    matching_ids = [random.choice(ids) for ids in matching_by_evidence.values()]
     if not matching_ids:
         raise QuestionBankError(f"No questions found for category_small={category_number}")
 
-    selected_ids = []
-    while len(selected_ids) < question_count:
-        shuffled_ids = random.sample(matching_ids, len(matching_ids))
-        selected_ids.extend(shuffled_ids[: question_count - len(selected_ids)])
+    if excluded:
+        selected_ids = random.sample(
+            matching_ids, min(question_count, len(matching_ids))
+        )
+        if len(selected_ids) < question_count:
+            selected_evidence = {
+                canonicalize_question_evidence_id(q_id) for q_id in selected_ids
+            }
+            fallback_by_evidence = {}
+            for q_id in _QUESTIONS:
+                evidence_id = canonicalize_question_evidence_id(q_id)
+                if evidence_id not in excluded and evidence_id not in selected_evidence:
+                    fallback_by_evidence.setdefault(evidence_id, []).append(q_id)
+            fallback_ids = [random.choice(ids) for ids in fallback_by_evidence.values()]
+            needed = question_count - len(selected_ids)
+            if needed > len(fallback_ids):
+                raise QuestionBankError("Requested question count exceeds formal bank")
+            selected_ids.extend(random.sample(fallback_ids, needed))
+    else:
+        selected_ids = []
+        while len(selected_ids) < question_count:
+            shuffled_ids = random.sample(matching_ids, len(matching_ids))
+            selected_ids.extend(shuffled_ids[: question_count - len(selected_ids)])
     return [get_quiz_question(q_id) for q_id in selected_ids]
 
 

--- a/short_term_repeat_guard.py
+++ b/short_term_repeat_guard.py
@@ -1,0 +1,62 @@
+"""Shared fail-closed guard for short-term same-evidence-question repeats."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Iterable
+
+from knowledge_node_state_transition import derive_all_user_node_states
+from question_bank import get_question_tag
+from question_equivalence import (
+    canonicalize_question_evidence_id,
+    canonicalize_question_evidence_node,
+)
+
+
+def blocked_short_term_evidence_ids(
+    attempts: Iterable[dict[str, Any]],
+    *,
+    as_of: datetime | None = None,
+) -> set[str]:
+    """Return attempted evidence IDs that have no formal retention check due."""
+    replay = []
+    evidence_node_by_id: dict[str, str] = {}
+    for value in attempts or ():
+        item = dict(value)
+        question_id = str(item.get("question_id") or "")
+        if not question_id:
+            continue
+        raw_node_id = item.get("knowledge_node_id")
+        if not raw_node_id:
+            raw_node_id = get_question_tag(question_id).get("knowledge_node_id")
+        node_id = canonicalize_question_evidence_node(question_id, raw_node_id)
+        evidence_id = canonicalize_question_evidence_id(question_id)
+        if not node_id or not evidence_id:
+            continue
+        item.setdefault("user_id", "short-term-repeat-guard")
+        item["knowledge_node_id"] = node_id
+        item.setdefault("answered_at", item.get("timestamp") or item.get("attempted_at"))
+        replay.append(item)
+        evidence_node_by_id[evidence_id] = str(node_id)
+
+    states = {
+        str(item["canonical_node_id"]): str(item["state"])
+        for item in derive_all_user_node_states(
+            replay,
+            as_of=as_of or datetime.now(timezone.utc),
+        )
+    }
+    return {
+        evidence_id
+        for evidence_id, node_id in evidence_node_by_id.items()
+        if states.get(node_id) != "recheck_due"
+    }
+
+
+def is_short_term_repeat_blocked(
+    question_id: str,
+    blocked_evidence_ids: Iterable[str],
+) -> bool:
+    """Check a raw Q ID against canonical exact-repeat evidence identities."""
+    blocked = {str(value) for value in blocked_evidence_ids}
+    return canonicalize_question_evidence_id(str(question_id)) in blocked

--- a/tests/test_adaptive_question_selector.py
+++ b/tests/test_adaptive_question_selector.py
@@ -544,17 +544,18 @@ def test_user_histories_cannot_be_mixed(monkeypatch):
         raise AssertionError("mixed users must be rejected")
 
 
-def test_flag_false_uses_legacy_without_attempt_db_read(monkeypatch):
+def test_flag_false_uses_legacy_with_one_formal_attempt_read(monkeypatch):
     legacy = [{"id": f"Q{i}"} for i in range(1, 31)]
     monkeypatch.setattr(app, "ENABLE_NODE_ADAPTIVE_RECOMMENDATION", False)
     monkeypatch.setattr(app, "NODE_ADAPTIVE_RECOMMENDATION_PILOT_USER_IDS", {"flag-off"})
-    monkeypatch.setattr(app, "get_question_history", lambda _u: [])
     monkeypatch.setattr(app, "build_daily_session", lambda *args, **kwargs: legacy)
     monkeypatch.setattr(app, "format_quiz_messages", lambda _questions: ["quiz"])
-    monkeypatch.setattr(app, "get_question_attempts", lambda _u: (_ for _ in ()).throw(AssertionError("extra DB read")))
+    reads = []
+    monkeypatch.setattr(app, "get_question_attempts", lambda user_id: reads.append(user_id) or [])
     app.user_modes["flag-off"] = "study"
     app.start_quiz("flag-off", session_kind="adaptive_daily")
     assert app.study_sessions["flag-off"]["all_questions"] == legacy
+    assert reads == ["flag-off"]
     app.study_sessions.pop("flag-off", None)
 
 
@@ -616,17 +617,18 @@ def test_node_adaptive_allowlist_is_fail_closed():
     assert enabled(True, "son", {"son", "other"})
 
 
-def test_flag_true_non_allowlisted_user_preserves_legacy_and_no_attempt_read(monkeypatch):
+def test_flag_true_non_allowlisted_user_preserves_legacy_with_formal_attempt_guard(monkeypatch):
     legacy = [{"id": f"Q{i}"} for i in range(1, 31)]
     monkeypatch.setattr(app, "ENABLE_NODE_ADAPTIVE_RECOMMENDATION", True)
     monkeypatch.setattr(app, "NODE_ADAPTIVE_RECOMMENDATION_PILOT_USER_IDS", {"son"})
-    monkeypatch.setattr(app, "get_question_history", lambda _u: [])
     monkeypatch.setattr(app, "build_daily_session", lambda *args, **kwargs: legacy)
     monkeypatch.setattr(app, "format_quiz_messages", lambda _questions: ["quiz"])
-    monkeypatch.setattr(app, "get_question_attempts", lambda _u: (_ for _ in ()).throw(AssertionError("extra DB read")))
+    reads = []
+    monkeypatch.setattr(app, "get_question_attempts", lambda user_id: reads.append(user_id) or [])
     app.user_modes["not-son"] = "study"
     app.start_quiz("not-son", session_kind="adaptive_daily")
     assert app.study_sessions["not-son"]["all_questions"] == legacy
+    assert reads == ["not-son"]
     app.study_sessions.pop("not-son", None)
 
 

--- a/tests/test_global_short_term_repeat_guard.py
+++ b/tests/test_global_short_term_repeat_guard.py
@@ -1,0 +1,185 @@
+from datetime import datetime, timezone
+import os
+import random
+
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
+os.environ.setdefault("CHANNEL_ACCESS_TOKEN", "test-token")
+os.environ.setdefault("CHANNEL_SECRET", "test-secret")
+
+import app
+import short_term_repeat_guard as guard
+from question_bank import select_questions_by_category, select_random_questions
+from question_equivalence import canonicalize_question_evidence_id
+
+
+NOW = datetime(2026, 9, 10, 12, tzinfo=timezone.utc)
+
+
+def attempt(question_id, node_id="KN0001"):
+    return {
+        "user_id": "learner",
+        "question_id": question_id,
+        "knowledge_node_id": node_id,
+        "is_correct": False,
+        "confidence": 1,
+        "answer_status": "answered",
+        "answered_at": NOW,
+    }
+
+
+def questions(count):
+    return [
+        {
+            "id": f"Q{number}",
+            "question": f"問題{number}",
+            "choices": {key: key for key in "ABCDE"},
+            "answer": "A",
+            "explanation": "解説",
+        }
+        for number in range(1, count + 1)
+    ]
+
+
+def test_guard_blocks_same_evidence_but_allows_same_node_different_question(monkeypatch):
+    monkeypatch.setattr(guard, "derive_all_user_node_states", lambda *_a, **_k: [
+        {"canonical_node_id": "KN0003", "state": "repairing"}
+    ])
+    blocked = guard.blocked_short_term_evidence_ids([attempt("Q3", "KN0003")], as_of=NOW)
+    assert guard.is_short_term_repeat_blocked("Q3", blocked)
+    assert not guard.is_short_term_repeat_blocked("Q1565", blocked)
+
+
+def test_guard_allows_same_evidence_only_when_formal_recheck_is_due(monkeypatch):
+    monkeypatch.setattr(guard, "derive_all_user_node_states", lambda *_a, **_k: [
+        {"canonical_node_id": "KN0003", "state": "recheck_due"}
+    ])
+    assert guard.blocked_short_term_evidence_ids(
+        [attempt("Q3", "KN0003")], as_of=NOW
+    ) == set()
+
+
+def test_exact_repeat_equivalent_is_blocked_together(monkeypatch):
+    monkeypatch.setattr(guard, "derive_all_user_node_states", lambda *_a, **_k: [
+        {"canonical_node_id": "KN1387", "state": "repairing"}
+    ])
+    blocked = guard.blocked_short_term_evidence_ids(
+        [attempt("Q1585", "KN0659")], as_of=NOW
+    )
+    assert guard.is_short_term_repeat_blocked("Q1411", blocked)
+    assert guard.is_short_term_repeat_blocked("Q1585", blocked)
+
+
+def test_random_and_category_selection_never_duplicate_exact_evidence():
+    random.seed(305)
+    random_questions = select_random_questions(200)
+    random_evidence = [
+        canonicalize_question_evidence_id(str(question["id"]))
+        for question in random_questions
+    ]
+    assert len(random_evidence) == len(set(random_evidence))
+
+    category_questions = select_questions_by_category(8, 30, exclude_ids={"Q1"})
+    category_evidence = [
+        canonicalize_question_evidence_id(str(question["id"]))
+        for question in category_questions
+    ]
+    assert len(category_evidence) == len(set(category_evidence))
+
+
+def test_small_category_shortage_uses_non_recent_global_fallback_without_repeat():
+    blocked = {f"Q{number}" for number in range(1, 31)}
+    selected = select_questions_by_category(14, 30, exclude_ids=blocked)
+    evidence = [
+        canonicalize_question_evidence_id(str(question["id"]))
+        for question in selected
+    ]
+    assert len(selected) == 30
+    assert len(evidence) == len(set(evidence))
+    assert not (set(evidence) & blocked)
+
+
+def test_seven_consecutive_thirty_question_random_sessions_have_no_evidence_repeat(monkeypatch):
+    monkeypatch.setattr(guard, "derive_all_user_node_states", lambda items, **_k: [
+        {"canonical_node_id": item["knowledge_node_id"], "state": "checking"}
+        for item in items
+    ])
+    history = []
+    selected_evidence = set()
+    random.seed(304)
+    for _set_number in range(7):
+        blocked = guard.blocked_short_term_evidence_ids(history, as_of=NOW)
+        selected = select_random_questions(30, exclude_ids=blocked)
+        evidence = {
+            canonicalize_question_evidence_id(str(question["id"]))
+            for question in selected
+        }
+        assert not (selected_evidence & evidence)
+        selected_evidence.update(evidence)
+        history.extend(
+            attempt(str(question["id"]), f"KN{index:04d}")
+            for index, question in enumerate(selected, start=len(history) + 1)
+        )
+    assert len(selected_evidence) == 210
+
+
+def test_random_and_category_routes_pass_formal_attempt_guard(monkeypatch):
+    previous = attempt("Q1")
+    monkeypatch.setattr(app, "get_question_attempts", lambda _user_id: [previous])
+    monkeypatch.setattr(
+        guard,
+        "derive_all_user_node_states",
+        lambda *_a, **_k: [{"canonical_node_id": "KN0001", "state": "repairing"}],
+    )
+    calls = []
+
+    def random_selector(count, *, exclude_ids=()):
+        calls.append(("random", set(exclude_ids)))
+        return questions(count)
+
+    def category_selector(category, count, *, exclude_ids=()):
+        calls.append((category, set(exclude_ids)))
+        return questions(count)
+
+    monkeypatch.setattr(app, "select_random_questions", random_selector)
+    monkeypatch.setattr(app, "select_category_questions", category_selector)
+    monkeypatch.setattr(app, "format_quiz_messages", lambda _questions: ["quiz"])
+
+    app.start_quiz("random-user")
+    app.quiz_category_selections["category-user"] = {"category_small": 8}
+    app.start_quiz("category-user")
+
+    assert calls == [("random", {"Q1"}), (8, {"Q1"})]
+
+
+def test_adaptive_fallback_reuses_question_attempts_as_formal_truth(monkeypatch):
+    previous = attempt("Q1")
+    received = []
+    monkeypatch.setattr(app, "ENABLE_NODE_ADAPTIVE_RECOMMENDATION", False)
+    monkeypatch.setattr(app, "get_question_attempts", lambda _user_id: [previous])
+    monkeypatch.setattr(
+        guard,
+        "derive_all_user_node_states",
+        lambda *_a, **_k: [{"canonical_node_id": "KN0001", "state": "repairing"}],
+    )
+    monkeypatch.setattr(
+        app,
+        "build_daily_session",
+        lambda history, count, **kwargs: received.append((history, kwargs["exclude_ids"]))
+        or questions(count),
+    )
+    monkeypatch.setattr(app, "format_quiz_messages", lambda _questions: ["quiz"])
+
+    app.start_quiz("fallback-user", session_kind="adaptive_daily")
+
+    assert received == [([previous], {"Q1"})]
+
+
+def test_initial_assessment_fixed_contract_does_not_read_attempts(monkeypatch):
+    monkeypatch.setattr(
+        app,
+        "get_question_attempts",
+        lambda _user_id: (_ for _ in ()).throw(AssertionError("must not read attempts")),
+    )
+    monkeypatch.setattr(app, "build_initial_assessment", lambda count: questions(count))
+    monkeypatch.setattr(app, "format_quiz_messages", lambda _questions: ["quiz"])
+    assert app.start_quiz("initial-user", session_kind="initial_assessment", question_count=10) == ["quiz"]

--- a/tests/test_prerequisite_backtrack_pilot.py
+++ b/tests/test_prerequisite_backtrack_pilot.py
@@ -190,14 +190,13 @@ def test_feature_flag_false_skips_history_and_preserves_existing_next_set(monkey
 def test_feature_flag_true_queues_one_mip_candidate_without_recursion(monkeypatch, caplog):
     caplog.set_level(logging.INFO)
     session = make_session()
-    source = attempt("Q260", MIP["source_node_id"], True, 2, 1, "old-event", "pilot-user")
     target = attempt(
         "Q386", MIP["target_node_id"], False, 2, 2, "pilot-session:1", "pilot-user"
     )
     app.study_sessions["pilot-user"] = session
     monkeypatch.setattr(app, "ENABLE_PREREQUISITE_BACKTRACK", True)
     monkeypatch.setattr(app, "PREREQUISITE_BACKTRACK_PILOT_USER_IDS", {"pilot-user"})
-    monkeypatch.setattr(app, "get_question_attempts", lambda _user_id: [source, target])
+    monkeypatch.setattr(app, "get_question_attempts", lambda _user_id: [target])
     monkeypatch.setattr(app, "get_reviewed_node_relations", lambda: [MIP])
     monkeypatch.setattr(app, "get_quiz_question", lambda question_id: {"id": question_id})
     monkeypatch.setattr(app, "format_quiz_messages", lambda *args, **kwargs: ["ok"])
@@ -215,11 +214,28 @@ def test_feature_flag_true_queues_one_mip_candidate_without_recursion(monkeypatc
         assert "relation_id=KNR0003" in caplog.text
         assert "source_question_id=Q260" in caplog.text
         assert "target_question_id=Q386" in caplog.text
-        assert "diagnosis=SOURCE_UNSTABLE" in caplog.text
-        assert "reason=uncertain_or_guessed_correct_source" in caplog.text
+        assert "diagnosis=SOURCE_UNSEEN" in caplog.text
+        assert "reason=unanswered_source" in caplog.text
         assert "pilot-user" not in caplog.text
     finally:
         app.study_sessions.pop("pilot-user", None)
+
+
+def test_recent_same_question_is_not_queued_by_prerequisite_backtrack(monkeypatch):
+    session = make_session()
+    source = attempt(
+        "Q260", MIP["source_node_id"], True, 2, 1, "old-event", "pilot-user"
+    )
+    target = attempt(
+        "Q386", MIP["target_node_id"], False, 2, 2, "pilot-session:1", "pilot-user"
+    )
+    monkeypatch.setattr(app, "ENABLE_PREREQUISITE_BACKTRACK", True)
+    monkeypatch.setattr(app, "PREREQUISITE_BACKTRACK_PILOT_USER_IDS", {"pilot-user"})
+    monkeypatch.setattr(app, "get_question_attempts", lambda _user_id: [source, target])
+    monkeypatch.setattr(app, "get_reviewed_node_relations", lambda: [MIP])
+
+    assert app.queue_prerequisite_backtrack_for_next_set("pilot-user", session) is None
+    assert "pending_prerequisite_backtrack" not in session
 
 
 def test_non_allowlisted_and_empty_allowlist_skip_history(monkeypatch):

--- a/tests/test_quiz_answer_numbering.py
+++ b/tests/test_quiz_answer_numbering.py
@@ -228,6 +228,7 @@ def load_current_app_functions() -> SimpleNamespace:
         },
         "known_user_ids": known_user_ids,
         "claim_free_monitor_slot": lambda _user_id: 1,
+        "get_question_attempts": lambda _user_id: [],
         "line_replies": line_replies,
         "user_profile_exists": lambda user_id: user_id in known_user_ids,
     }


### PR DESCRIPTION
Closes #304

## 対応
- formal `question_attempts` と Node-state replay から、`recheck_due` になるまで既出のexact-evidence Qを全通常学習経路で除外
- random / category / adaptive_daily fallback / prerequisite backtrackへ共通ガードを適用
- same-Node different-Q repair、正式day3/day7/month retention、初回診断を維持
- category内の非recent供給不足時は同一Q再利用ではなく、他分野の非recent evidenceで30問を完成
- exact-repeat equivalenceを同一evidenceとして扱う

## 検証
- focused: 173 passed, 1 deselected, 125 subtests passed
- full (LF CI-equivalent): 1268 passed, 6 skipped, 1 deselected, 125 subtests passed
- Question Bank validator: PASS (2000 records, schema/reference errors 0)
- git diff --check: PASS

## 不変範囲
- Question Bank content変更なし
- formal Node transition / repair evidence / Phase11変更なし
- DB migration / Production DB writeなし
- Render環境変更なし