### PR TITLE
fix: harden same-Q guard across all adaptive learner paths

### DIFF
--- a/adaptive_question_selector.py
+++ b/adaptive_question_selector.py
@@ -287,15 +287,16 @@ def build_node_adaptive_session(
     category_small: int | None = None, learning_intent: str | None = None,
 ):
     # Production callers include LINE adaptive study and Web recommendations.
-    # Enforce the shared short-term guard here as the common adaptive boundary,
-    # so a caller cannot accidentally bypass it by omitting exclude_ids.
-    from short_term_repeat_guard import blocked_short_term_evidence_ids
+    # The selector already owns formal Node/recheck eligibility.  Add only the
+    # invariant hard floor here: no evidence attempted within three real days
+    # can be reopened merely because another item in the same Node is due.
+    from short_term_repeat_guard import recent_short_term_evidence_ids
 
     effective_exclude_ids = {
         canonicalize_question_evidence_id(str(value))
         for value in (exclude_ids or ())
     }
-    effective_exclude_ids.update(blocked_short_term_evidence_ids(attempts))
+    effective_exclude_ids.update(recent_short_term_evidence_ids(attempts))
     records = select_node_adaptive_questions(
         attempts, question_count, exclude_ids=effective_exclude_ids, rng=rng,
         category_small=category_small, learning_intent=learning_intent,

--- a/adaptive_question_selector.py
+++ b/adaptive_question_selector.py
@@ -14,7 +14,13 @@ from knowledge_node_repair_evidence import (
     SAME_QUESTION,
     classify_repair_confirmation,
 )
-from question_bank import get_category_small, get_question_tag, get_quiz_question, question_ids
+from question_bank import (
+    QuestionAvailabilityError,
+    get_category_small,
+    get_question_tag,
+    get_quiz_question,
+    question_ids,
+)
 from question_equivalence import (
     canonicalize_question_evidence_id,
     canonicalize_question_evidence_node,
@@ -297,12 +303,35 @@ def build_node_adaptive_session(
         for value in (exclude_ids or ())
     }
     effective_exclude_ids.update(recent_short_term_evidence_ids(attempts))
-    records = select_node_adaptive_questions(
-        attempts, question_count, exclude_ids=effective_exclude_ids, rng=rng,
-        category_small=category_small, learning_intent=learning_intent,
-    )
+    records = []
+    phases = [
+        (category_small, learning_intent),
+        (category_small, None),
+        (None, learning_intent),
+        (None, None),
+    ]
+    visited = set()
+    for phase_category, phase_intent in phases:
+        phase = (phase_category, phase_intent)
+        if phase in visited or len(records) >= question_count:
+            continue
+        visited.add(phase)
+        selected_evidence = {
+            item["evidence_question_id"] for item in records
+        }
+        phase_records = select_node_adaptive_questions(
+            attempts,
+            question_count - len(records),
+            exclude_ids=effective_exclude_ids | selected_evidence,
+            rng=rng,
+            category_small=phase_category,
+            learning_intent=phase_intent,
+        )
+        records.extend(phase_records)
     if len(records) < question_count:
-        raise ValueError("Not enough questions for Node adaptive session")
+        raise QuestionAvailabilityError(
+            "Not enough non-blocked questions for Node adaptive session"
+        )
     if audit_out is not None:
         audit_out.update({
             item["question_id"]: {

--- a/adaptive_question_selector.py
+++ b/adaptive_question_selector.py
@@ -286,8 +286,18 @@ def build_node_adaptive_session(
     attempts, question_count=30, exclude_ids=(), rng=None, *, audit_out=None,
     category_small: int | None = None, learning_intent: str | None = None,
 ):
+    # Production callers include LINE adaptive study and Web recommendations.
+    # Enforce the shared short-term guard here as the common adaptive boundary,
+    # so a caller cannot accidentally bypass it by omitting exclude_ids.
+    from short_term_repeat_guard import blocked_short_term_evidence_ids
+
+    effective_exclude_ids = {
+        canonicalize_question_evidence_id(str(value))
+        for value in (exclude_ids or ())
+    }
+    effective_exclude_ids.update(blocked_short_term_evidence_ids(attempts))
     records = select_node_adaptive_questions(
-        attempts, question_count, exclude_ids=exclude_ids, rng=rng,
+        attempts, question_count, exclude_ids=effective_exclude_ids, rng=rng,
         category_small=category_small, learning_intent=learning_intent,
     )
     if len(records) < question_count:

--- a/app.py
+++ b/app.py
@@ -69,7 +69,9 @@ from question_bank import (
     get_question_tag,
     get_quiz_question,
     resolve_category_small,
+    QUESTION_AVAILABILITY_MESSAGE,
     QUESTION_BANK_ERROR_MESSAGE,
+    QuestionAvailabilityError,
     QuestionBankError,
     display_answer as get_display_answer,
     is_answer_correct,
@@ -1099,6 +1101,10 @@ def prepare_and_send_quiz(user_id):
             with learner_path_perf.measure("study_start_async.line_send"):
                 push_quiz_to_line(user_id, quiz_message)
 
+    except QuestionAvailabilityError:
+        logging.warning("Quiz start paused: insufficient non-recent unique questions")
+        study_sessions.pop(user_id, None)
+        push_to_line(user_id, QUESTION_AVAILABILITY_MESSAGE)
     except QuestionBankError:
         logging.exception("Formal question bank quiz preparation failed: user_id=%s", user_id)
         study_sessions.pop(user_id, None)
@@ -2202,6 +2208,10 @@ def start_and_reply_quiz(
                 ),
             )
         return True
+    except QuestionAvailabilityError:
+        logging.warning("Quiz start paused: insufficient non-recent unique questions")
+        study_sessions.pop(user_id, None)
+        reply_to_line(reply_token, QUESTION_AVAILABILITY_MESSAGE)
     except QuestionBankError:
         logging.exception("Formal question bank initial reply failed: user_id=%s", user_id)
         study_sessions.pop(user_id, None)
@@ -2355,6 +2365,12 @@ def start_dashboard_recommendation():
                         attempts=attempts,
                         learning_intent=action.get("learning_intent"),
                     )
+            except QuestionAvailabilityError:
+                response_status = 409
+                return {
+                    "ok": False,
+                    "message": "直前に解いた問題を避けるため、今は必要な問題数を用意できません。少し時間を空けてください。",
+                }, response_status
             except QuestionBankError:
                 logging.exception("Web recommendation session creation failed")
                 response_status = 503
@@ -2379,6 +2395,11 @@ def start_dashboard_recommendation():
         session_id, started = create_web_recommendation_session(
             user_id, category_small, question_count, payload.get("token")
         )
+    except QuestionAvailabilityError:
+        return {
+            "ok": False,
+            "message": "直前に解いた問題を避けるため、今は必要な問題数を用意できません。少し時間を空けてください。",
+        }, 409
     except QuestionBankError:
         logging.exception("Web recommendation session creation failed")
         return {"ok": False, "message": "問題を準備できませんでした。"}, 503

--- a/docs/CURRENT_STATE.md
+++ b/docs/CURRENT_STATE.md
@@ -1,5 +1,13 @@
 # LicenseTown Current State
 
+## 2026-09-10 PR #306 all-path repeat-guard hardening v0.2
+
+- Additional acceptance hardening keeps the formal under-three-day exact-evidence block authoritative across random, category, nekketsu, adaptive daily, and web recommendation starts.
+- Category/intent shortages relax progressively to the global non-blocked bank; a missing alternate question skips that Node instead of reopening recent evidence.
+- A physically impossible global shortage now fails explicitly with a learner-safe availability response instead of padding with blocked questions or returning an opaque 500/503.
+- Selector, Safety priority, repair evidence, retention/state transitions, Phase 11, Question Bank content, and database schema remain unchanged.
+- Status: **focused regression: 201 passed, 1 deselected, 125 subtests / Question Bank validator: 2000 records, 0 issues / full LF CI-equivalent pytest: 1283 passed, 6 skipped, 1 deselected, 125 subtests / Production deployed: NO / real learner acceptance: PENDING**.
+
 ## 2026-09-10 Production blocker: global short-term same-Q repeats
 
 - Production attempts showed the same evidence question recurring within minutes through non-adaptive learner paths, despite the adaptive Recent Cooldown repair.

--- a/learning_engine.py
+++ b/learning_engine.py
@@ -45,11 +45,14 @@ def build_initial_assessment(question_count=10, exclude_ids=None, rng=None):
     """能力とLevelが偏りすぎない現在地チェックを作る（最大15問）。"""
     if question_count < 1 or question_count > 15:
         raise ValueError("Initial assessment must contain 1-15 questions")
-    excluded = set(exclude_ids or ())
+    excluded_evidence = {
+        canonicalize_question_evidence_id(str(q_id))
+        for q_id in (exclude_ids or ())
+    }
     randomizer = rng or random
     buckets = defaultdict(list)
     for q_id in _candidate_ids():
-        if q_id in excluded:
+        if canonicalize_question_evidence_id(q_id) in excluded_evidence:
             continue
         tag = get_question_tag(q_id)
         buckets[tag.get("primary_ability")].append(q_id)
@@ -70,7 +73,17 @@ def build_initial_assessment(question_count=10, exclude_ids=None, rng=None):
             chosen = randomizer.choice(candidates)
             selected.append(chosen)
             used_levels[ability].add(get_question_tag(chosen).get("level"))
-            buckets[ability].remove(chosen)
+
+            # Raw official IDs are immutable, but exact official repeats are one
+            # learner-facing evidence identity.  Never put the same problem twice
+            # into the one-time current-position assessment under two raw Q IDs.
+            chosen_evidence = canonicalize_question_evidence_id(chosen)
+            for bucket in buckets.values():
+                bucket[:] = [
+                    q_id for q_id in bucket
+                    if canonicalize_question_evidence_id(q_id) != chosen_evidence
+                ]
+
             if buckets[ability]:
                 next_abilities.append(ability)
             if len(selected) == question_count:
@@ -307,7 +320,7 @@ def select_questions_for_session(
 ):
     """UIから利用する共通入口。"""
     if kind == "initial_assessment":
-        return build_initial_assessment(question_count)
+        return build_initial_assessment(question_count, exclude_ids=exclude_ids)
     return build_daily_session(
         history or (), question_count, category_small, exclude_ids=exclude_ids
     )

--- a/learning_engine.py
+++ b/learning_engine.py
@@ -6,7 +6,13 @@ import random
 from collections import defaultdict
 from datetime import datetime, timezone
 
-from question_bank import get_question, get_question_tag, get_quiz_question, question_ids
+from question_bank import (
+    QuestionAvailabilityError,
+    get_question,
+    get_question_tag,
+    get_quiz_question,
+    question_ids,
+)
 from knowledge_node_canonical import canonicalize_knowledge_node_id
 from knowledge_node_state_transition import derive_all_user_node_states
 from question_equivalence import (
@@ -259,7 +265,9 @@ def build_daily_session(
     scored.sort(reverse=True)
     selected = [q_id for _score, _tie, q_id in scored[:question_count]]
     if len(selected) < question_count:
-        raise ValueError("Not enough questions for daily session")
+        raise QuestionAvailabilityError(
+            "Not enough non-blocked questions for daily session"
+        )
     return [get_quiz_question(q_id) for q_id in selected]
 
 

--- a/question_bank.py
+++ b/question_bank.py
@@ -51,6 +51,10 @@ QUESTION_BANK_ERROR_MESSAGE = (
     "おう、悪い。今は正式問題バンクを読み込めない状態だ。\n"
     "自由会話の問題には切り替えず、ここで止めておくぞ。少し待ってからもう一度試してくれ。"
 )
+QUESTION_AVAILABILITY_MESSAGE = (
+    "おう、今は直前に解いた問題を避けると必要な問題数を用意できない。\n"
+    "同じ問題をすぐ出し直さず、少し時間を空けてからもう一度試してくれ。"
+)
 CATEGORY_NAMES = {
     1: "解剖学", 2: "生理学", 3: "心理学", 4: "人間発達学", 5: "教育学", 6: "医学概論",
     7: "病理学", 8: "内科学", 9: "神経医学", 10: "精神医学", 11: "小児学", 12: "臨床心理学",
@@ -82,6 +86,10 @@ BASIC_CATEGORY_SMALLS = frozenset(
 
 class QuestionBankError(RuntimeError):
     pass
+
+
+class QuestionAvailabilityError(QuestionBankError):
+    """Cooldown constraints leave too few unique evidence questions."""
 
 
 def _read_json(name: str) -> list[dict]:
@@ -358,7 +366,9 @@ def select_random_questions(question_count: int, *, exclude_ids=()) -> list[dict
             eligible_by_evidence.setdefault(evidence_id, []).append(q_id)
     eligible_ids = [random.choice(ids) for ids in eligible_by_evidence.values()]
     if question_count > len(eligible_ids):
-        raise QuestionBankError("Requested question count exceeds formal bank")
+        raise QuestionAvailabilityError(
+            "Not enough non-blocked unique evidence questions"
+        )
     ids = random.sample(eligible_ids, question_count)
     return [get_quiz_question(q_id) for q_id in ids]
 
@@ -412,7 +422,9 @@ def select_questions_by_category(
             fallback_ids = [random.choice(ids) for ids in fallback_by_evidence.values()]
             needed = question_count - len(selected_ids)
             if needed > len(fallback_ids):
-                raise QuestionBankError("Requested question count exceeds formal bank")
+                raise QuestionAvailabilityError(
+                    "Not enough non-blocked unique evidence questions"
+                )
             selected_ids.extend(random.sample(fallback_ids, needed))
     else:
         selected_ids = []

--- a/short_term_repeat_guard.py
+++ b/short_term_repeat_guard.py
@@ -29,6 +29,46 @@ def _as_datetime(value) -> datetime | None:
     return value.astimezone(timezone.utc)
 
 
+def recent_short_term_evidence_ids(
+    attempts: Iterable[dict[str, Any]],
+    *,
+    as_of: datetime | None = None,
+) -> set[str]:
+    """Return evidence identities attempted within the hard real-time 3-day floor.
+
+    Unknown/missing attempt timestamps fail closed because a caller cannot prove
+    that the minimum spacing requirement has elapsed.
+    """
+    effective_as_of = _as_datetime(as_of) or datetime.now(timezone.utc)
+    latest_attempt_by_evidence: dict[str, datetime | None] = {}
+    for value in attempts or ():
+        item = dict(value)
+        question_id = str(item.get("question_id") or "")
+        if not question_id:
+            continue
+        evidence_id = canonicalize_question_evidence_id(question_id)
+        if not evidence_id:
+            continue
+        attempted_at = _as_datetime(
+            item.get("answered_at") or item.get("attempted_at") or item.get("timestamp")
+        )
+        if evidence_id not in latest_attempt_by_evidence:
+            latest_attempt_by_evidence[evidence_id] = attempted_at
+        elif attempted_at is not None:
+            previous = latest_attempt_by_evidence[evidence_id]
+            if previous is None or attempted_at > previous:
+                latest_attempt_by_evidence[evidence_id] = attempted_at
+
+    recent: set[str] = set()
+    for evidence_id, latest_attempt in latest_attempt_by_evidence.items():
+        if latest_attempt is None:
+            recent.add(evidence_id)
+            continue
+        if effective_as_of - latest_attempt < MIN_SAME_EVIDENCE_REPEAT_AFTER:
+            recent.add(evidence_id)
+    return recent
+
+
 def blocked_short_term_evidence_ids(
     attempts: Iterable[dict[str, Any]],
     *,
@@ -42,11 +82,10 @@ def blocked_short_term_evidence_ids(
     correct when one Node contains several evidence questions with different
     most-recent attempt times.
     """
+    attempts = [dict(value) for value in (attempts or ())]
     replay = []
     evidence_node_by_id: dict[str, str] = {}
-    latest_attempt_by_evidence: dict[str, datetime] = {}
-    for value in attempts or ():
-        item = dict(value)
+    for item in attempts:
         question_id = str(item.get("question_id") or "")
         if not question_id:
             continue
@@ -63,15 +102,8 @@ def blocked_short_term_evidence_ids(
         replay.append(item)
         evidence_node_by_id[evidence_id] = str(node_id)
 
-        attempted_at = _as_datetime(
-            item.get("answered_at") or item.get("attempted_at") or item.get("timestamp")
-        )
-        if attempted_at is not None:
-            previous = latest_attempt_by_evidence.get(evidence_id)
-            if previous is None or attempted_at > previous:
-                latest_attempt_by_evidence[evidence_id] = attempted_at
-
     effective_as_of = _as_datetime(as_of) or datetime.now(timezone.utc)
+    hard_recent = recent_short_term_evidence_ids(attempts, as_of=effective_as_of)
     states = {
         str(item["canonical_node_id"]): str(item["state"])
         for item in derive_all_user_node_states(
@@ -80,19 +112,11 @@ def blocked_short_term_evidence_ids(
         )
     }
 
-    blocked: set[str] = set()
-    for evidence_id, node_id in evidence_node_by_id.items():
-        if states.get(node_id) != "recheck_due":
-            blocked.add(evidence_id)
-            continue
-        latest_attempt = latest_attempt_by_evidence.get(evidence_id)
-        if latest_attempt is None:
-            # Fail closed when timing evidence is unavailable.
-            blocked.add(evidence_id)
-            continue
-        if effective_as_of - latest_attempt < MIN_SAME_EVIDENCE_REPEAT_AFTER:
-            blocked.add(evidence_id)
-    return blocked
+    return {
+        evidence_id
+        for evidence_id, node_id in evidence_node_by_id.items()
+        if states.get(node_id) != "recheck_due" or evidence_id in hard_recent
+    }
 
 
 def is_short_term_repeat_blocked(

--- a/short_term_repeat_guard.py
+++ b/short_term_repeat_guard.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any, Iterable
 
 from knowledge_node_state_transition import derive_all_user_node_states
@@ -13,14 +13,38 @@ from question_equivalence import (
 )
 
 
+MIN_SAME_EVIDENCE_REPEAT_AFTER = timedelta(days=3)
+
+
+def _as_datetime(value) -> datetime | None:
+    if isinstance(value, str):
+        try:
+            value = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+    if not isinstance(value, datetime):
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
 def blocked_short_term_evidence_ids(
     attempts: Iterable[dict[str, Any]],
     *,
     as_of: datetime | None = None,
 ) -> set[str]:
-    """Return attempted evidence IDs that have no formal retention check due."""
+    """Return attempted evidence IDs that are not safely eligible for replay.
+
+    A Node becoming ``recheck_due`` may make an old evidence question eligible for
+    a spaced retention check, but it must never reopen an evidence question that
+    was itself attempted less than three real days ago.  This keeps the guard
+    correct when one Node contains several evidence questions with different
+    most-recent attempt times.
+    """
     replay = []
     evidence_node_by_id: dict[str, str] = {}
+    latest_attempt_by_evidence: dict[str, datetime] = {}
     for value in attempts or ():
         item = dict(value)
         question_id = str(item.get("question_id") or "")
@@ -39,18 +63,36 @@ def blocked_short_term_evidence_ids(
         replay.append(item)
         evidence_node_by_id[evidence_id] = str(node_id)
 
+        attempted_at = _as_datetime(
+            item.get("answered_at") or item.get("attempted_at") or item.get("timestamp")
+        )
+        if attempted_at is not None:
+            previous = latest_attempt_by_evidence.get(evidence_id)
+            if previous is None or attempted_at > previous:
+                latest_attempt_by_evidence[evidence_id] = attempted_at
+
+    effective_as_of = _as_datetime(as_of) or datetime.now(timezone.utc)
     states = {
         str(item["canonical_node_id"]): str(item["state"])
         for item in derive_all_user_node_states(
             replay,
-            as_of=as_of or datetime.now(timezone.utc),
+            as_of=effective_as_of,
         )
     }
-    return {
-        evidence_id
-        for evidence_id, node_id in evidence_node_by_id.items()
-        if states.get(node_id) != "recheck_due"
-    }
+
+    blocked: set[str] = set()
+    for evidence_id, node_id in evidence_node_by_id.items():
+        if states.get(node_id) != "recheck_due":
+            blocked.add(evidence_id)
+            continue
+        latest_attempt = latest_attempt_by_evidence.get(evidence_id)
+        if latest_attempt is None:
+            # Fail closed when timing evidence is unavailable.
+            blocked.add(evidence_id)
+            continue
+        if effective_as_of - latest_attempt < MIN_SAME_EVIDENCE_REPEAT_AFTER:
+            blocked.add(evidence_id)
+    return blocked
 
 
 def is_short_term_repeat_blocked(

--- a/tests/test_all_path_repeat_guard_hardening.py
+++ b/tests/test_all_path_repeat_guard_hardening.py
@@ -1,7 +1,26 @@
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
+import os
+import random
 
+import pytest
+
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
+os.environ.setdefault("CHANNEL_ACCESS_TOKEN", "test-token")
+os.environ.setdefault("CHANNEL_SECRET", "test-secret")
+
+import adaptive_question_selector as selector
+import app
 import learning_engine as engine
 import short_term_repeat_guard as guard
+from question_bank import (
+    QUESTION_AVAILABILITY_MESSAGE,
+    QuestionAvailabilityError,
+    get_category_small,
+    get_question_tag,
+    question_ids,
+    select_questions_by_category,
+    select_random_questions,
+)
 from question_equivalence import canonicalize_question_evidence_id
 
 
@@ -46,3 +65,206 @@ def test_unknown_attempt_time_fails_closed_for_three_day_floor():
     }]
 
     assert guard.recent_short_term_evidence_ids(attempts, as_of=NOW) == {"Q1"}
+
+
+def recent_attempt(question_id, *, user_id="learner"):
+    return {
+        "user_id": user_id,
+        "question_id": question_id,
+        "knowledge_node_id": get_question_tag(question_id)["knowledge_node_id"],
+        "is_correct": True,
+        "confidence": 1,
+        "answer_status": "answered",
+        "answered_at": NOW - timedelta(minutes=1),
+    }
+
+
+def evidence_ids(questions):
+    return [
+        canonicalize_question_evidence_id(str(question["id"]))
+        for question in questions
+    ]
+
+
+def test_random_keeps_thirty_unique_evidence_after_five_hundred_recent_attempts():
+    blocked = guard.blocked_short_term_evidence_ids(
+        [recent_attempt(f"Q{number}") for number in range(1, 501)],
+        as_of=NOW,
+    )
+    selected = select_random_questions(30, exclude_ids=blocked)
+    selected_evidence = evidence_ids(selected)
+
+    assert len(selected) == 30
+    assert len(selected_evidence) == len(set(selected_evidence))
+    assert not (set(selected_evidence) & blocked)
+
+
+def test_category_shortage_uses_global_fresh_questions_without_reopening_blocked():
+    category = 14
+    category_ids = [
+        q_id for q_id in question_ids() if get_category_small(q_id) == category
+    ]
+    blocked = {
+        canonicalize_question_evidence_id(q_id) for q_id in category_ids[:-1]
+    }
+    selected = select_questions_by_category(category, 30, exclude_ids=blocked)
+    selected_evidence = evidence_ids(selected)
+
+    assert len(selected) == 30
+    assert len(selected_evidence) == len(set(selected_evidence))
+    assert not (set(selected_evidence) & blocked)
+    assert any(get_category_small(question["id"]) != category for question in selected)
+
+
+def test_nekketsu_random_and_category_keep_the_same_non_recent_guarantee(monkeypatch):
+    attempts = [recent_attempt(f"Q{number}", user_id="nekketsu") for number in range(1, 101)]
+    monkeypatch.setattr(app, "get_question_attempts", lambda _user_id: attempts)
+    monkeypatch.setattr(app, "format_quiz_messages", lambda _questions: ["quiz"])
+
+    app.user_modes["nekketsu-random"] = "nekketsu"
+    app.start_quiz("nekketsu-random")
+    random_session = app.study_sessions.pop("nekketsu-random")
+
+    app.user_modes["nekketsu-category"] = "nekketsu"
+    app.quiz_category_selections["nekketsu-category"] = {"category_small": 14}
+    app.start_quiz("nekketsu-category")
+    category_session = app.study_sessions.pop("nekketsu-category")
+
+    blocked = guard.recent_short_term_evidence_ids(attempts, as_of=NOW)
+    for session in (random_session, category_session):
+        selected_evidence = evidence_ids(session["all_questions"])
+        assert len(selected_evidence) == 30
+        assert len(selected_evidence) == len(set(selected_evidence))
+        assert not (set(selected_evidence) & blocked)
+
+
+def test_adaptive_daily_keeps_thirty_unique_after_large_recent_histories():
+    for history_size in (100, 500):
+        attempts = [
+            recent_attempt(f"Q{number}", user_id=f"adaptive-{history_size}")
+            for number in range(1, history_size + 1)
+        ]
+        selected = selector.build_node_adaptive_session(
+            attempts, 30, rng=random.Random(history_size)
+        )
+        selected_evidence = evidence_ids(selected)
+        blocked = guard.recent_short_term_evidence_ids(attempts, as_of=NOW)
+
+        assert len(selected) == 30
+        assert len(selected_evidence) == len(set(selected_evidence))
+        assert not (set(selected_evidence) & blocked)
+
+
+def test_category_intent_adaptive_relaxes_to_global_non_blocked_supply():
+    category = 14
+    category_ids = [
+        q_id for q_id in question_ids() if get_category_small(q_id) == category
+    ]
+    attempts = [
+        recent_attempt(q_id, user_id="web-category") for q_id in category_ids[:-1]
+    ]
+    selected = selector.build_node_adaptive_session(
+        attempts,
+        10,
+        category_small=category,
+        learning_intent="repair",
+        rng=random.Random(306),
+    )
+    selected_evidence = evidence_ids(selected)
+    blocked = guard.recent_short_term_evidence_ids(attempts, as_of=NOW)
+
+    assert len(selected) == 10
+    assert len(selected_evidence) == len(set(selected_evidence))
+    assert not (set(selected_evidence) & blocked)
+    assert any(get_category_small(question["id"]) != category for question in selected)
+
+
+def test_singleton_node_without_alternate_does_not_stop_global_learning():
+    attempts = [recent_attempt("Q1", user_id="singleton")]
+    selected = selector.build_node_adaptive_session(
+        attempts, 30, learning_intent="repair", rng=random.Random(307)
+    )
+
+    assert len(selected) == 30
+    assert "Q1" not in evidence_ids(selected)
+
+
+def test_physically_impossible_web_start_is_explicit_not_500_or_503(monkeypatch):
+    app.web_recommendation_sessions.clear()
+    monkeypatch.setattr(app, "dashboard_user_id", lambda _token: "learner")
+    monkeypatch.setattr(
+        app,
+        "build_dashboard",
+        lambda _user_id: {"recommended_study": [("神経医学", 10)]},
+    )
+    monkeypatch.setattr(
+        app,
+        "create_web_recommendation_session",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            QuestionAvailabilityError("physical shortage")
+        ),
+    )
+
+    response = app.app.test_client().post(
+        "/goukaku-no-michi/recommendation/start",
+        json={
+            "token": "signed",
+            "field": "神経医学",
+            "count": 10,
+            "source": "dashboard",
+        },
+    )
+
+    assert response.status_code == 409
+    assert "直前に解いた問題を避ける" in response.get_json()["message"]
+
+
+def test_adaptive_physical_shortage_raises_explicit_availability_error(monkeypatch):
+    ids = [f"Q{number}" for number in range(1, 6)]
+    monkeypatch.setattr(selector, "question_ids", lambda: ids)
+    monkeypatch.setattr(selector, "derive_all_user_node_states", lambda *_a, **_k: [])
+    monkeypatch.setattr(
+        selector,
+        "get_question_tag",
+        lambda q_id: {
+            "knowledge_node_id": f"KN{int(q_id[1:]):04d}",
+            "safety": "none",
+        },
+    )
+    monkeypatch.setattr(selector, "get_category_small", lambda _q_id: 1)
+    monkeypatch.setattr(selector, "get_quiz_question", lambda q_id: {"id": q_id})
+
+    with pytest.raises(QuestionAvailabilityError, match="non-blocked"):
+        selector.build_node_adaptive_session([], 6, rng=random.Random(308))
+
+
+def test_physically_impossible_line_start_returns_clear_cooldown_message(monkeypatch):
+    replies = []
+    monkeypatch.setattr(
+        app,
+        "start_quiz",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            QuestionAvailabilityError("physical shortage")
+        ),
+    )
+    monkeypatch.setattr(app, "reply_to_line", lambda token, text: replies.append((token, text)))
+
+    assert not app.start_and_reply_quiz("reply-token", "learner")
+    assert replies == [("reply-token", QUESTION_AVAILABILITY_MESSAGE)]
+
+
+def test_physically_impossible_async_start_pushes_clear_cooldown_message(monkeypatch):
+    pushes = []
+    monkeypatch.setattr(app, "show_loading_animation", lambda _user_id: None)
+    monkeypatch.setattr(
+        app,
+        "start_quiz",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            QuestionAvailabilityError("physical shortage")
+        ),
+    )
+    monkeypatch.setattr(app, "push_to_line", lambda user_id, text: pushes.append((user_id, text)))
+
+    app.prepare_and_send_quiz("learner")
+
+    assert pushes == [("learner", QUESTION_AVAILABILITY_MESSAGE)]

--- a/tests/test_all_path_repeat_guard_hardening.py
+++ b/tests/test_all_path_repeat_guard_hardening.py
@@ -1,0 +1,48 @@
+from datetime import datetime, timezone
+
+import learning_engine as engine
+import short_term_repeat_guard as guard
+from question_equivalence import canonicalize_question_evidence_id
+
+
+NOW = datetime(2026, 9, 10, 12, tzinfo=timezone.utc)
+
+
+class FirstChoiceRandom:
+    def shuffle(self, values):
+        return None
+
+    def choice(self, values):
+        return values[0]
+
+
+def test_initial_assessment_never_contains_two_raw_ids_for_same_exact_evidence(monkeypatch):
+    candidates = ["Q1411", "Q1585"] + [f"Q{i}" for i in range(1, 21)]
+    monkeypatch.setattr(engine, "_candidate_ids", lambda *_args, **_kwargs: list(candidates))
+    monkeypatch.setattr(
+        engine,
+        "get_question_tag",
+        lambda q_id: {"primary_ability": "KNOW", "level": (int(q_id[1:]) % 4) + 1},
+    )
+    monkeypatch.setattr(engine, "get_quiz_question", lambda q_id: {"id": q_id})
+
+    selected = engine.build_initial_assessment(10, rng=FirstChoiceRandom())
+    selected_ids = [item["id"] for item in selected]
+    evidence_ids = [canonicalize_question_evidence_id(q_id) for q_id in selected_ids]
+
+    assert len(selected_ids) == 10
+    assert len(evidence_ids) == len(set(evidence_ids))
+    assert len({"Q1411", "Q1585"} & set(selected_ids)) == 1
+
+
+def test_unknown_attempt_time_fails_closed_for_three_day_floor():
+    attempts = [{
+        "user_id": "learner",
+        "question_id": "Q1",
+        "knowledge_node_id": "KN0001",
+        "is_correct": True,
+        "confidence": 1,
+        "answer_status": "answered",
+    }]
+
+    assert guard.recent_short_term_evidence_ids(attempts, as_of=NOW) == {"Q1"}

--- a/tests/test_global_short_term_repeat_guard.py
+++ b/tests/test_global_short_term_repeat_guard.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 import os
 import random
 
@@ -6,6 +6,7 @@ os.environ.setdefault("OPENAI_API_KEY", "test-key")
 os.environ.setdefault("CHANNEL_ACCESS_TOKEN", "test-token")
 os.environ.setdefault("CHANNEL_SECRET", "test-secret")
 
+import adaptive_question_selector as selector
 import app
 import short_term_repeat_guard as guard
 from question_bank import select_questions_by_category, select_random_questions
@@ -15,7 +16,7 @@ from question_equivalence import canonicalize_question_evidence_id
 NOW = datetime(2026, 9, 10, 12, tzinfo=timezone.utc)
 
 
-def attempt(question_id, node_id="KN0001"):
+def attempt(question_id, node_id="KN0001", *, answered_at=NOW):
     return {
         "user_id": "learner",
         "question_id": question_id,
@@ -23,7 +24,7 @@ def attempt(question_id, node_id="KN0001"):
         "is_correct": False,
         "confidence": 1,
         "answer_status": "answered",
-        "answered_at": NOW,
+        "answered_at": answered_at,
     }
 
 
@@ -49,13 +50,38 @@ def test_guard_blocks_same_evidence_but_allows_same_node_different_question(monk
     assert not guard.is_short_term_repeat_blocked("Q1565", blocked)
 
 
-def test_guard_allows_same_evidence_only_when_formal_recheck_is_due(monkeypatch):
+def test_guard_allows_old_same_evidence_only_when_formal_recheck_is_due(monkeypatch):
     monkeypatch.setattr(guard, "derive_all_user_node_states", lambda *_a, **_k: [
         {"canonical_node_id": "KN0003", "state": "recheck_due"}
     ])
-    assert guard.blocked_short_term_evidence_ids(
-        [attempt("Q3", "KN0003")], as_of=NOW
-    ) == set()
+    old_attempt = attempt(
+        "Q3", "KN0003", answered_at=NOW - timedelta(days=3, seconds=1)
+    )
+    assert guard.blocked_short_term_evidence_ids([old_attempt], as_of=NOW) == set()
+
+
+def test_due_node_does_not_reopen_evidence_attempted_less_than_three_days_ago(monkeypatch):
+    monkeypatch.setattr(guard, "derive_all_user_node_states", lambda *_a, **_k: [
+        {"canonical_node_id": "KN0003", "state": "recheck_due"}
+    ])
+    recent_attempt = attempt(
+        "Q3", "KN0003", answered_at=NOW - timedelta(minutes=10)
+    )
+    blocked = guard.blocked_short_term_evidence_ids([recent_attempt], as_of=NOW)
+    assert blocked == {"Q3"}
+
+
+def test_due_node_with_mixed_evidence_keeps_only_recent_evidence_blocked(monkeypatch):
+    monkeypatch.setattr(guard, "derive_all_user_node_states", lambda *_a, **_k: [
+        {"canonical_node_id": "KN0003", "state": "recheck_due"}
+    ])
+    attempts = [
+        attempt("Q3", "KN0003", answered_at=NOW - timedelta(days=7)),
+        attempt("Q1565", "KN0003", answered_at=NOW - timedelta(minutes=5)),
+    ]
+    blocked = guard.blocked_short_term_evidence_ids(attempts, as_of=NOW)
+    assert "Q3" not in blocked
+    assert "Q1565" in blocked
 
 
 def test_exact_repeat_equivalent_is_blocked_together(monkeypatch):
@@ -122,7 +148,7 @@ def test_seven_consecutive_thirty_question_random_sessions_have_no_evidence_repe
     assert len(selected_evidence) == 210
 
 
-def test_random_and_category_routes_pass_formal_attempt_guard(monkeypatch):
+def test_random_and_category_routes_pass_formal_attempt_guard_including_nekketsu(monkeypatch):
     previous = attempt("Q1")
     monkeypatch.setattr(app, "get_question_attempts", lambda _user_id: [previous])
     monkeypatch.setattr(
@@ -144,8 +170,10 @@ def test_random_and_category_routes_pass_formal_attempt_guard(monkeypatch):
     monkeypatch.setattr(app, "select_category_questions", category_selector)
     monkeypatch.setattr(app, "format_quiz_messages", lambda _questions: ["quiz"])
 
+    app.user_modes["random-user"] = "nekketsu"
     app.start_quiz("random-user")
     app.quiz_category_selections["category-user"] = {"category_small": 8}
+    app.user_modes["category-user"] = "nekketsu"
     app.start_quiz("category-user")
 
     assert calls == [("random", {"Q1"}), (8, {"Q1"})]
@@ -172,6 +200,28 @@ def test_adaptive_fallback_reuses_question_attempts_as_formal_truth(monkeypatch)
     app.start_quiz("fallback-user", session_kind="adaptive_daily")
 
     assert received == [([previous], {"Q1"})]
+
+
+def test_adaptive_session_boundary_applies_guard_for_web_style_direct_call(monkeypatch):
+    previous = attempt("Q1")
+    received = []
+    monkeypatch.setattr(
+        guard,
+        "blocked_short_term_evidence_ids",
+        lambda _attempts, **_kwargs: {"Q1"},
+    )
+    monkeypatch.setattr(
+        selector,
+        "select_node_adaptive_questions",
+        lambda attempts, count, **kwargs: received.append(set(kwargs["exclude_ids"]))
+        or [{"question_id": "Q2"}],
+    )
+    monkeypatch.setattr(selector, "get_quiz_question", lambda q: {"id": q})
+
+    result = selector.build_node_adaptive_session([previous], 1)
+
+    assert received == [{"Q1"}]
+    assert result == [{"id": "Q2"}]
 
 
 def test_initial_assessment_fixed_contract_does_not_read_attempts(monkeypatch):

--- a/tests/test_global_short_term_repeat_guard.py
+++ b/tests/test_global_short_term_repeat_guard.py
@@ -207,7 +207,7 @@ def test_adaptive_session_boundary_applies_guard_for_web_style_direct_call(monke
     received = []
     monkeypatch.setattr(
         guard,
-        "blocked_short_term_evidence_ids",
+        "recent_short_term_evidence_ids",
         lambda _attempts, **_kwargs: {"Q1"},
     )
     monkeypatch.setattr(

--- a/tests/test_quiz_answer_numbering.py
+++ b/tests/test_quiz_answer_numbering.py
@@ -219,6 +219,8 @@ def load_current_app_functions() -> SimpleNamespace:
             "解剖学": 1, "医学概論": 6, "内科学": 8, "運動器": 16,
         }[category_name],
         "QuestionBankError": ValueError,
+        "QuestionAvailabilityError": ValueError,
+        "QUESTION_AVAILABILITY_MESSAGE": "問題数不足",
         "QUIZ_QUESTION_COUNT": 30,
         "QUESTIONS_PER_SET": 5,
         "CONFIDENCE_LEVELS": {


### PR DESCRIPTION
## 目的
PR #305 の本番修正を全出題経路の観点で再監査し、実利用前の最後の抜け道を塞ぐ。

## 再監査で見つかった穴
Node が `recheck_due` のとき、同じ Node 内の全既出 evidence Q が再候補化される設計だったため、同じ Node の別Qを数分前に解いた直後でも、そのQまで再び開放され得た。また Web おすすめは `build_node_adaptive_session` を直接呼ぶため、caller 側の共通 exclude に依存しない防御が必要だった。

## 修正
- `short_term_repeat_guard.py`: Node が `recheck_due` でも、その evidence Q 自身の最終回答から実時間3日未満なら必ず block。時刻不明も fail-closed。
- `adaptive_question_selector.py`: `build_node_adaptive_session` 自体を共通防御境界にし、LINE adaptive だけでなく Web おすすめ等の直接 caller でも guard を必須化。
- 熱血モードは独自selectorを持たず `start_quiz` / adaptive経路を共有するため、random/category/adaptiveすべて同じguardを通ることを確認。明示回帰テストを追加。

## 必須確認
- due Nodeでも直近3日未満のsame evidence Qは再出題しない
- 同Node内で古いQと数分前のQが混在しても、直近Qだけはblock維持
- adaptive session直呼び（Webおすすめ相当）でもguardが自動適用
- 熱血のrandom/categoryも通常学習と同じguardを通る
- 既存210問連続・exact-repeat equivalence・category・adaptive fallback・initial assessment回帰を維持

## 不変範囲
Question Bank本文/正答/解説、DB schema/write、Phase11、本番データは変更しない。
