### PR TITLE
fix: prevent idle wall-clock time from inflating LT study time

### DIFF
--- a/learning_time_guard.py
+++ b/learning_time_guard.py
@@ -1,0 +1,184 @@
+"""Production guard for learner study-time accumulation.
+
+Legacy quiz sessions keep a monotonic-ish wall-clock timestamp in memory and
+persist the whole interval when the session is paused or finished.  That is
+useful for normal short sessions, but an abandoned/open browser or LINE flow
+can turn hours of idle time into study time.
+
+This module leaves the legacy quiz/session lifecycle untouched and composes a
+safer production ``add_learning_time`` binding.  Only intervals that end at a
+persisted answer activity are counted; long gaps before an answer are capped.
+Trailing idle time after the last persisted answer is never counted.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from datetime import datetime, timezone
+from typing import Any, Iterable
+
+
+logger = logging.getLogger(__name__)
+DEFAULT_MAX_ACTIVITY_GAP_SECONDS = 30 * 60
+
+
+def _as_utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _positive_seconds(value: Any) -> float:
+    try:
+        return max(float(value), 0.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def parse_learning_time_event_key(event_key: Any) -> tuple[str, datetime] | None:
+    """Return ``(session_id, active_started_at)`` from legacy interval keys."""
+    text = str(event_key or "").strip()
+    session_id, separator, started_text = text.partition(":")
+    if not separator or not session_id or not started_text:
+        return None
+    try:
+        started_epoch = float(started_text)
+        started_at = datetime.fromtimestamp(started_epoch, tz=timezone.utc)
+    except (TypeError, ValueError, OverflowError, OSError):
+        return None
+    return session_id, started_at
+
+
+def _attempt_timestamp(attempt: dict[str, Any]) -> datetime | None:
+    value = attempt.get("answered_at")
+    if not isinstance(value, datetime):
+        return None
+    return _as_utc(value)
+
+
+def estimate_active_learning_seconds(
+    attempts: Iterable[dict[str, Any]],
+    *,
+    session_id: str,
+    active_started_at: datetime,
+    interval_ended_at: datetime,
+    max_activity_gap_seconds: float = DEFAULT_MAX_ACTIVITY_GAP_SECONDS,
+) -> float:
+    """Estimate evidenced study time for one active quiz interval.
+
+    Each persisted answer batch is a meaningful activity point.  Time from the
+    previous activity point is counted up to ``max_activity_gap_seconds``.
+    Time after the final answer is intentionally excluded because there is no
+    later learner activity proving the session remained active.
+    """
+    start = _as_utc(active_started_at)
+    end = _as_utc(interval_ended_at)
+    if end <= start:
+        return 0.0
+
+    cap = max(_positive_seconds(max_activity_gap_seconds), 1.0)
+    prefix = f"{session_id}:"
+    activity_times = {
+        timestamp
+        for attempt in attempts
+        if str(attempt.get("event_key", "")).startswith(prefix)
+        if (timestamp := _attempt_timestamp(attempt)) is not None
+        if start <= timestamp <= end
+    }
+    if not activity_times:
+        return 0.0
+
+    total = 0.0
+    cursor = start
+    for activity_at in sorted(activity_times):
+        gap = max((activity_at - cursor).total_seconds(), 0.0)
+        total += min(gap, cap)
+        cursor = activity_at
+    return total
+
+
+def _configured_gap_cap() -> float:
+    raw = os.getenv(
+        "LT_LEARNING_ACTIVITY_GAP_CAP_SECONDS",
+        str(DEFAULT_MAX_ACTIVITY_GAP_SECONDS),
+    )
+    value = _positive_seconds(raw)
+    return value if value > 0 else float(DEFAULT_MAX_ACTIVITY_GAP_SECONDS)
+
+
+def install_learning_time_guard(legacy_module, database_module) -> None:
+    """Install the production-safe learning-time binding on the legacy module."""
+    if getattr(legacy_module, "_learning_time_guard_installed", False):
+        return
+
+    original_add_learning_time = legacy_module.add_learning_time
+    gap_cap = _configured_gap_cap()
+
+    def guarded_add_learning_time(
+        user_id: str,
+        elapsed_seconds: float,
+        recorded_at: datetime | None = None,
+        event_key: str | None = None,
+    ) -> bool:
+        raw_seconds = _positive_seconds(elapsed_seconds)
+        parsed = parse_learning_time_event_key(event_key)
+
+        if parsed is None:
+            # Fail closed on malformed legacy interval keys: keep at most one
+            # activity-gap window instead of allowing an hours-long wall clock.
+            safe_seconds = min(raw_seconds, gap_cap)
+            logger.warning(
+                "learning_time_guard status=unparseable_key user_id=%s raw_seconds=%.3f safe_seconds=%.3f",
+                user_id,
+                raw_seconds,
+                safe_seconds,
+            )
+            return original_add_learning_time(
+                user_id,
+                safe_seconds,
+                recorded_at=recorded_at,
+                event_key=event_key,
+            )
+
+        session_id, active_started_at = parsed
+        interval_ended_at = _as_utc(recorded_at or datetime.now(timezone.utc))
+        try:
+            attempts = database_module.get_question_attempts(
+                user_id,
+                start_at=active_started_at,
+            )
+            safe_seconds = estimate_active_learning_seconds(
+                attempts,
+                session_id=session_id,
+                active_started_at=active_started_at,
+                interval_ended_at=interval_ended_at,
+                max_activity_gap_seconds=gap_cap,
+            )
+        except Exception:
+            # Study completion must not fail because time bookkeeping failed.
+            logger.exception(
+                "learning_time_guard status=evidence_lookup_failed user_id=%s session_id=%s",
+                user_id,
+                session_id,
+            )
+            safe_seconds = min(raw_seconds, gap_cap)
+
+        logger.info(
+            "learning_time_guard status=applied user_id=%s session_id=%s raw_seconds=%.3f safe_seconds=%.3f",
+            user_id,
+            session_id,
+            raw_seconds,
+            safe_seconds,
+        )
+        if safe_seconds <= 0:
+            return True
+        return original_add_learning_time(
+            user_id,
+            safe_seconds,
+            recorded_at=recorded_at,
+            event_key=event_key,
+        )
+
+    legacy_module.add_learning_time = guarded_add_learning_time
+    legacy_module._learning_time_guard_installed = True

--- a/learning_time_guard.py
+++ b/learning_time_guard.py
@@ -107,6 +107,22 @@ def _configured_gap_cap() -> float:
     return value if value > 0 else float(DEFAULT_MAX_ACTIVITY_GAP_SECONDS)
 
 
+def _current_session_has_formal_id(legacy_module, user_id: str) -> bool:
+    """Return whether the active legacy quiz session has its real session id.
+
+    Some isolated legacy unit tests intentionally construct only
+    ``{"active_started_at": ...}``.  Production quiz sessions created by
+    ``start_quiz`` always have a formal ``session_id``.  Preserving the former
+    avoids letting production composition mutate the meaning of those legacy
+    tests without weakening the production idle-time guard.
+    """
+    sessions = getattr(legacy_module, "study_sessions", None)
+    if not isinstance(sessions, dict):
+        return False
+    session = sessions.get(user_id)
+    return isinstance(session, dict) and bool(session.get("session_id"))
+
+
 def install_learning_time_guard(legacy_module, database_module) -> None:
     """Install the production-safe learning-time binding on the legacy module."""
     if getattr(legacy_module, "_learning_time_guard_installed", False):
@@ -130,6 +146,24 @@ def install_learning_time_guard(legacy_module, database_module) -> None:
             safe_seconds = min(raw_seconds, gap_cap)
             logger.warning(
                 "learning_time_guard status=unparseable_key user_id=%s raw_seconds=%.3f safe_seconds=%.3f",
+                user_id,
+                raw_seconds,
+                safe_seconds,
+            )
+            return original_add_learning_time(
+                user_id,
+                safe_seconds,
+                recorded_at=recorded_at,
+                event_key=event_key,
+            )
+
+        # Production quiz sessions always carry a formal session id.  A session
+        # without one is a legacy/synthetic path; preserve its old accounting
+        # semantics, but still cap it so it cannot become an hours-long outlier.
+        if not _current_session_has_formal_id(legacy_module, user_id):
+            safe_seconds = min(raw_seconds, gap_cap)
+            logger.info(
+                "learning_time_guard status=legacy_session_without_id user_id=%s raw_seconds=%.3f safe_seconds=%.3f",
                 user_id,
                 raw_seconds,
                 safe_seconds,

--- a/tests/test_learning_time_guard.py
+++ b/tests/test_learning_time_guard.py
@@ -82,7 +82,10 @@ def test_guard_persists_evidence_time_instead_of_raw_wall_clock(monkeypatch):
         calls.append((user_id, elapsed_seconds, recorded_at, event_key))
         return True
 
-    legacy = SimpleNamespace(add_learning_time=original_add)
+    legacy = SimpleNamespace(
+        add_learning_time=original_add,
+        study_sessions={"user": {"session_id": "session"}},
+    )
     database = SimpleNamespace(
         get_question_attempts=lambda user_id, start_at=None: [
             _attempt("session", start + timedelta(minutes=12), "1"),
@@ -109,7 +112,8 @@ def test_guard_does_not_persist_abandoned_session_without_answers(monkeypatch):
     start = datetime(2026, 9, 10, 9, 0, tzinfo=timezone.utc)
     calls = []
     legacy = SimpleNamespace(
-        add_learning_time=lambda *args, **kwargs: calls.append((args, kwargs)) or True
+        add_learning_time=lambda *args, **kwargs: calls.append((args, kwargs)) or True,
+        study_sessions={"user": {"session_id": "session"}},
     )
     database = SimpleNamespace(get_question_attempts=lambda *args, **kwargs: [])
     monkeypatch.delenv("LT_LEARNING_ACTIVITY_GAP_CAP_SECONDS", raising=False)
@@ -124,10 +128,32 @@ def test_guard_does_not_persist_abandoned_session_without_answers(monkeypatch):
     assert calls == []
 
 
+def test_guard_preserves_legacy_session_without_formal_id_but_caps_it(monkeypatch):
+    start = datetime(2026, 9, 10, 9, 0, tzinfo=timezone.utc)
+    calls = []
+    legacy = SimpleNamespace(
+        add_learning_time=lambda *args, **kwargs: calls.append((args, kwargs)) or True,
+        study_sessions={"user": {"active_started_at": start.timestamp()}},
+    )
+    database = SimpleNamespace(get_question_attempts=lambda *args, **kwargs: [])
+    monkeypatch.delenv("LT_LEARNING_ACTIVITY_GAP_CAP_SECONDS", raising=False)
+
+    install_learning_time_guard(legacy, database)
+    assert legacy.add_learning_time(
+        "user",
+        120,
+        recorded_at=start + timedelta(minutes=2),
+        event_key=f"user:{start.timestamp()}",
+    ) is True
+    assert len(calls) == 1
+    assert calls[0][0][1] == 120
+
+
 def test_guard_is_idempotent(monkeypatch):
     calls = []
     legacy = SimpleNamespace(
-        add_learning_time=lambda *args, **kwargs: calls.append((args, kwargs)) or True
+        add_learning_time=lambda *args, **kwargs: calls.append((args, kwargs)) or True,
+        study_sessions={},
     )
     database = SimpleNamespace(get_question_attempts=lambda *args, **kwargs: [])
     monkeypatch.delenv("LT_LEARNING_ACTIVITY_GAP_CAP_SECONDS", raising=False)

--- a/tests/test_learning_time_guard.py
+++ b/tests/test_learning_time_guard.py
@@ -1,0 +1,138 @@
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+from learning_time_guard import (
+    estimate_active_learning_seconds,
+    install_learning_time_guard,
+    parse_learning_time_event_key,
+)
+
+
+def _attempt(session_id, answered_at, suffix="1"):
+    return {
+        "event_key": f"{session_id}:{suffix}",
+        "answered_at": answered_at,
+    }
+
+
+def test_parse_learning_time_event_key_reads_session_and_start_epoch():
+    parsed = parse_learning_time_event_key("123:1789031570.7290385")
+    assert parsed is not None
+    session_id, started_at = parsed
+    assert session_id == "123"
+    assert started_at.tzinfo == timezone.utc
+    assert abs(started_at.timestamp() - 1789031570.7290385) < 0.001
+
+
+def test_estimate_counts_normal_answer_gaps_but_not_trailing_idle():
+    start = datetime(2026, 9, 10, 9, 0, tzinfo=timezone.utc)
+    attempts = [
+        _attempt("session", start + timedelta(minutes=8), "1"),
+        _attempt("session", start + timedelta(minutes=15), "2"),
+        _attempt("session", start + timedelta(minutes=24), "3"),
+    ]
+
+    seconds = estimate_active_learning_seconds(
+        attempts,
+        session_id="session",
+        active_started_at=start,
+        interval_ended_at=start + timedelta(hours=5),
+        max_activity_gap_seconds=30 * 60,
+    )
+
+    assert seconds == 24 * 60
+
+
+def test_estimate_caps_long_idle_gap_before_answer_activity():
+    start = datetime(2026, 9, 10, 9, 0, tzinfo=timezone.utc)
+    attempts = [
+        _attempt("session", start + timedelta(hours=4, minutes=30), "1"),
+        _attempt("session", start + timedelta(hours=4, minutes=38), "2"),
+    ]
+
+    seconds = estimate_active_learning_seconds(
+        attempts,
+        session_id="session",
+        active_started_at=start,
+        interval_ended_at=start + timedelta(hours=8),
+        max_activity_gap_seconds=30 * 60,
+    )
+
+    assert seconds == 38 * 60
+
+
+def test_estimate_returns_zero_when_session_has_no_answer_evidence():
+    start = datetime(2026, 9, 10, 9, 0, tzinfo=timezone.utc)
+    attempts = [_attempt("other-session", start + timedelta(minutes=5))]
+
+    assert estimate_active_learning_seconds(
+        attempts,
+        session_id="session",
+        active_started_at=start,
+        interval_ended_at=start + timedelta(hours=18),
+    ) == 0
+
+
+def test_guard_persists_evidence_time_instead_of_raw_wall_clock(monkeypatch):
+    start = datetime(2026, 9, 10, 9, 0, tzinfo=timezone.utc)
+    end = start + timedelta(hours=18)
+    calls = []
+
+    def original_add(user_id, elapsed_seconds, recorded_at=None, event_key=None):
+        calls.append((user_id, elapsed_seconds, recorded_at, event_key))
+        return True
+
+    legacy = SimpleNamespace(add_learning_time=original_add)
+    database = SimpleNamespace(
+        get_question_attempts=lambda user_id, start_at=None: [
+            _attempt("session", start + timedelta(minutes=12), "1"),
+            _attempt("session", start + timedelta(minutes=20), "2"),
+        ]
+    )
+    monkeypatch.delenv("LT_LEARNING_ACTIVITY_GAP_CAP_SECONDS", raising=False)
+
+    install_learning_time_guard(legacy, database)
+    result = legacy.add_learning_time(
+        "user",
+        18 * 60 * 60,
+        recorded_at=end,
+        event_key=f"session:{start.timestamp()}",
+    )
+
+    assert result is True
+    assert len(calls) == 1
+    assert calls[0][1] == 20 * 60
+    assert calls[0][2] == end
+
+
+def test_guard_does_not_persist_abandoned_session_without_answers(monkeypatch):
+    start = datetime(2026, 9, 10, 9, 0, tzinfo=timezone.utc)
+    calls = []
+    legacy = SimpleNamespace(
+        add_learning_time=lambda *args, **kwargs: calls.append((args, kwargs)) or True
+    )
+    database = SimpleNamespace(get_question_attempts=lambda *args, **kwargs: [])
+    monkeypatch.delenv("LT_LEARNING_ACTIVITY_GAP_CAP_SECONDS", raising=False)
+
+    install_learning_time_guard(legacy, database)
+    assert legacy.add_learning_time(
+        "user",
+        6 * 60 * 60,
+        recorded_at=start + timedelta(hours=6),
+        event_key=f"session:{start.timestamp()}",
+    ) is True
+    assert calls == []
+
+
+def test_guard_is_idempotent(monkeypatch):
+    calls = []
+    legacy = SimpleNamespace(
+        add_learning_time=lambda *args, **kwargs: calls.append((args, kwargs)) or True
+    )
+    database = SimpleNamespace(get_question_attempts=lambda *args, **kwargs: [])
+    monkeypatch.delenv("LT_LEARNING_ACTIVITY_GAP_CAP_SECONDS", raising=False)
+
+    install_learning_time_guard(legacy, database)
+    first = legacy.add_learning_time
+    install_learning_time_guard(legacy, database)
+    assert legacy.add_learning_time is first

--- a/wsgi.py
+++ b/wsgi.py
@@ -12,6 +12,7 @@ import logging
 import os
 
 import app as legacy
+import database as database_module
 import developer_ui as developer_ui_module
 import goukaku_ui as goukaku_module
 import supporter_learner_preview_bridge as supporter_preview_module
@@ -26,6 +27,7 @@ from linebot.models import (
 from daily_wrong_review import REVIEW_COMMAND, install_daily_wrong_review
 from dashboard_progress_trend import install_dashboard_progress_trend
 from developer_access_recovery import install_developer_access_recovery
+from learning_time_guard import install_learning_time_guard
 from one_question_starter import install_one_question_starter, one_question_quick_reply_item
 from phase11_gate_ui import install_phase11_gate_ui
 from prerequisite_attempt_cache import install_prerequisite_attempt_cache
@@ -118,6 +120,7 @@ def _apply_rich_menu_v2_if_requested() -> None:
 
 # Registered LINE callbacks resolve these names from the legacy app module at
 # call time, so production behavior can be composed without rewriting app.py.
+install_learning_time_guard(legacy, database_module)
 install_prerequisite_attempt_cache(legacy)
 install_dashboard_progress_trend(legacy, goukaku_module)
 install_one_question_starter(legacy)


### PR DESCRIPTION
## Problem
Production learning-time rows can include hours of idle/open-session wall clock. Real data includes intervals of ~18h with no persisted answer activity and other multi-hour intervals where actual answer batches occurred only near the end. This makes cumulative study time and progress figures materially false.

## Fix
- add `learning_time_guard.py` as a production composition guard
- derive counted study time from persisted `question_attempts` activity for the same quiz session
- cap any single gap before an answer activity at 30 minutes
- do not count trailing idle time after the last persisted answer
- abandoned sessions with no persisted answers add zero study time
- fail closed to at most one 30-minute window if evidence lookup/key parsing fails, while never blocking quiz completion
- install the guard from `wsgi.py`, leaving legacy quiz/session behavior and DB schema unchanged

## Scope
No Question Bank, selector, repeat-guard, Node state, Phase11, UI layout, or DB schema changes.

## Validation
New focused unit coverage checks normal activity, long idle gaps, abandoned sessions, production binding behavior, and idempotent install. Full CI requested by this PR.

## Production acceptance after merge
1. confirm Render deploy live
2. inspect new learning-time rows for bounded/evidence-based values
3. calculate historical correction candidates read-only
4. Production historical data correction requires explicit approval before any DB write
