### PR TITLE
fix: make Web recommendation study time evidence-based

### DIFF
--- a/learning_time_guard.py
+++ b/learning_time_guard.py
@@ -1,14 +1,13 @@
 """Production guard for learner study-time accumulation.
 
-Legacy quiz sessions keep a monotonic-ish wall-clock timestamp in memory and
-persist the whole interval when the session is paused or finished.  That is
-useful for normal short sessions, but an abandoned/open browser or LINE flow
-can turn hours of idle time into study time.
+Legacy quiz sessions keep wall-clock timestamps in memory and persist the whole
+interval when the session is paused or finished. That is useful for normal short
+sessions, but an abandoned/open browser or LINE flow can turn hours of idle time
+into study time.
 
-This module leaves the legacy quiz/session lifecycle untouched and composes a
-safer production ``add_learning_time`` binding.  Only intervals that end at a
-persisted answer activity are counted; long gaps before an answer are capped.
-Trailing idle time after the last persisted answer is never counted.
+This module leaves the learner session lifecycle untouched and composes a safer
+production ``add_learning_time`` binding. Counted time is backed by persisted
+answer activity, long gaps are capped, and trailing idle time is excluded.
 """
 
 from __future__ import annotations
@@ -21,6 +20,8 @@ from typing import Any, Iterable
 
 logger = logging.getLogger(__name__)
 DEFAULT_MAX_ACTIVITY_GAP_SECONDS = 30 * 60
+WEB_RECOMMENDATION_PREFIX = "web-recommendation:"
+WEB_RECOMMENDATION_TIME_SUFFIX = ":time"
 
 
 def _as_utc(value: datetime) -> datetime:
@@ -36,18 +37,36 @@ def _positive_seconds(value: Any) -> float:
         return 0.0
 
 
+def _datetime_from_epoch(value: Any) -> datetime | None:
+    try:
+        return datetime.fromtimestamp(float(value), tz=timezone.utc)
+    except (TypeError, ValueError, OverflowError, OSError):
+        return None
+
+
 def parse_learning_time_event_key(event_key: Any) -> tuple[str, datetime] | None:
-    """Return ``(session_id, active_started_at)`` from legacy interval keys."""
+    """Return ``(session_id, active_started_at)`` from LINE interval keys."""
     text = str(event_key or "").strip()
     session_id, separator, started_text = text.partition(":")
     if not separator or not session_id or not started_text:
         return None
-    try:
-        started_epoch = float(started_text)
-        started_at = datetime.fromtimestamp(started_epoch, tz=timezone.utc)
-    except (TypeError, ValueError, OverflowError, OSError):
+    started_at = _datetime_from_epoch(started_text)
+    if started_at is None:
         return None
     return session_id, started_at
+
+
+def parse_web_recommendation_time_event_key(event_key: Any) -> str | None:
+    """Return the Web recommendation session id from its time-event key."""
+    text = str(event_key or "").strip()
+    if not text.startswith(WEB_RECOMMENDATION_PREFIX) or not text.endswith(
+        WEB_RECOMMENDATION_TIME_SUFFIX
+    ):
+        return None
+    session_id = text[
+        len(WEB_RECOMMENDATION_PREFIX) : -len(WEB_RECOMMENDATION_TIME_SUFFIX)
+    ].strip()
+    return session_id or None
 
 
 def _attempt_timestamp(attempt: dict[str, Any]) -> datetime | None:
@@ -64,10 +83,11 @@ def estimate_active_learning_seconds(
     active_started_at: datetime,
     interval_ended_at: datetime,
     max_activity_gap_seconds: float = DEFAULT_MAX_ACTIVITY_GAP_SECONDS,
+    event_key_prefix: str | None = None,
 ) -> float:
-    """Estimate evidenced study time for one active quiz interval.
+    """Estimate evidenced study time for one active learning interval.
 
-    Each persisted answer batch is a meaningful activity point.  Time from the
+    Each persisted answer batch is a meaningful activity point. Time from the
     previous activity point is counted up to ``max_activity_gap_seconds``.
     Time after the final answer is intentionally excluded because there is no
     later learner activity proving the session remained active.
@@ -78,7 +98,7 @@ def estimate_active_learning_seconds(
         return 0.0
 
     cap = max(_positive_seconds(max_activity_gap_seconds), 1.0)
-    prefix = f"{session_id}:"
+    prefix = event_key_prefix or f"{session_id}:"
     activity_times = {
         timestamp
         for attempt in attempts
@@ -108,19 +128,41 @@ def _configured_gap_cap() -> float:
 
 
 def _current_session_has_formal_id(legacy_module, user_id: str) -> bool:
-    """Return whether the active legacy quiz session has its real session id.
+    """Return whether the active LINE quiz session has its real session id.
 
     Some isolated legacy unit tests intentionally construct only
-    ``{"active_started_at": ...}``.  Production quiz sessions created by
-    ``start_quiz`` always have a formal ``session_id``.  Preserving the former
-    avoids letting production composition mutate the meaning of those legacy
-    tests without weakening the production idle-time guard.
+    ``{"active_started_at": ...}``. Production quiz sessions created by
+    ``start_quiz`` always have a formal ``session_id``. Preserving the former
+    avoids changing the meaning of those legacy tests without weakening the
+    production idle-time guard.
     """
     sessions = getattr(legacy_module, "study_sessions", None)
     if not isinstance(sessions, dict):
         return False
     session = sessions.get(user_id)
     return isinstance(session, dict) and bool(session.get("session_id"))
+
+
+def _web_recommendation_window(
+    legacy_module,
+    *,
+    user_id: str,
+    event_key: Any,
+) -> tuple[str, datetime, str] | None:
+    """Resolve Web recommendation session identity and activity prefix."""
+    session_id = parse_web_recommendation_time_event_key(event_key)
+    if session_id is None:
+        return None
+    sessions = getattr(legacy_module, "web_recommendation_sessions", None)
+    if not isinstance(sessions, dict):
+        return None
+    session = sessions.get(session_id)
+    if not isinstance(session, dict) or session.get("user_id") != user_id:
+        return None
+    started_at = _datetime_from_epoch(session.get("started_at"))
+    if started_at is None:
+        return None
+    return session_id, started_at, f"web-recommendation:{session_id}:"
 
 
 def install_learning_time_guard(legacy_module, database_module) -> None:
@@ -138,11 +180,56 @@ def install_learning_time_guard(legacy_module, database_module) -> None:
         event_key: str | None = None,
     ) -> bool:
         raw_seconds = _positive_seconds(elapsed_seconds)
-        parsed = parse_learning_time_event_key(event_key)
+        interval_ended_at = _as_utc(recorded_at or datetime.now(timezone.utc))
 
+        web_window = _web_recommendation_window(
+            legacy_module,
+            user_id=user_id,
+            event_key=event_key,
+        )
+        if web_window is not None:
+            session_id, active_started_at, event_prefix = web_window
+            try:
+                attempts = database_module.get_question_attempts(
+                    user_id,
+                    start_at=active_started_at,
+                )
+                safe_seconds = estimate_active_learning_seconds(
+                    attempts,
+                    session_id=session_id,
+                    active_started_at=active_started_at,
+                    interval_ended_at=interval_ended_at,
+                    max_activity_gap_seconds=gap_cap,
+                    event_key_prefix=event_prefix,
+                )
+            except Exception:
+                logger.exception(
+                    "learning_time_guard status=web_evidence_lookup_failed user_id=%s session_id=%s",
+                    user_id,
+                    session_id,
+                )
+                safe_seconds = min(raw_seconds, gap_cap)
+
+            logger.info(
+                "learning_time_guard status=web_applied user_id=%s session_id=%s raw_seconds=%.3f safe_seconds=%.3f",
+                user_id,
+                session_id,
+                raw_seconds,
+                safe_seconds,
+            )
+            if safe_seconds <= 0:
+                return True
+            return original_add_learning_time(
+                user_id,
+                safe_seconds,
+                recorded_at=recorded_at,
+                event_key=event_key,
+            )
+
+        parsed = parse_learning_time_event_key(event_key)
         if parsed is None:
-            # Fail closed on malformed legacy interval keys: keep at most one
-            # activity-gap window instead of allowing an hours-long wall clock.
+            # Unknown/malformed interval keys fail closed to one activity-gap
+            # window instead of allowing an hours-long wall clock.
             safe_seconds = min(raw_seconds, gap_cap)
             logger.warning(
                 "learning_time_guard status=unparseable_key user_id=%s raw_seconds=%.3f safe_seconds=%.3f",
@@ -157,9 +244,10 @@ def install_learning_time_guard(legacy_module, database_module) -> None:
                 event_key=event_key,
             )
 
-        # Production quiz sessions always carry a formal session id.  A session
-        # without one is a legacy/synthetic path; preserve its old accounting
-        # semantics, but still cap it so it cannot become an hours-long outlier.
+        # Production LINE quiz sessions always carry a formal session id. A
+        # session without one is a legacy/synthetic path; preserve its old
+        # accounting semantics, but cap it so it cannot become an hours-long
+        # outlier.
         if not _current_session_has_formal_id(legacy_module, user_id):
             safe_seconds = min(raw_seconds, gap_cap)
             logger.info(
@@ -176,7 +264,6 @@ def install_learning_time_guard(legacy_module, database_module) -> None:
             )
 
         session_id, active_started_at = parsed
-        interval_ended_at = _as_utc(recorded_at or datetime.now(timezone.utc))
         try:
             attempts = database_module.get_question_attempts(
                 user_id,

--- a/tests/test_learning_time_guard.py
+++ b/tests/test_learning_time_guard.py
@@ -5,12 +5,20 @@ from learning_time_guard import (
     estimate_active_learning_seconds,
     install_learning_time_guard,
     parse_learning_time_event_key,
+    parse_web_recommendation_time_event_key,
 )
 
 
 def _attempt(session_id, answered_at, suffix="1"):
     return {
         "event_key": f"{session_id}:{suffix}",
+        "answered_at": answered_at,
+    }
+
+
+def _web_attempt(session_id, answered_at, suffix="1"):
+    return {
+        "event_key": f"web-recommendation:{session_id}:{suffix}",
         "answered_at": answered_at,
     }
 
@@ -22,6 +30,17 @@ def test_parse_learning_time_event_key_reads_session_and_start_epoch():
     assert session_id == "123"
     assert started_at.tzinfo == timezone.utc
     assert abs(started_at.timestamp() - 1789031570.7290385) < 0.001
+
+
+def test_parse_web_recommendation_time_event_key():
+    assert (
+        parse_web_recommendation_time_event_key(
+            "web-recommendation:abc_DEF-123:time"
+        )
+        == "abc_DEF-123"
+    )
+    assert parse_web_recommendation_time_event_key("web-recommendation::time") is None
+    assert parse_web_recommendation_time_event_key("ordinary:123.0") is None
 
 
 def test_estimate_counts_normal_answer_gaps_but_not_trailing_idle():
@@ -61,6 +80,25 @@ def test_estimate_caps_long_idle_gap_before_answer_activity():
     assert seconds == 38 * 60
 
 
+def test_estimate_supports_explicit_web_event_prefix():
+    start = datetime(2026, 9, 10, 9, 0, tzinfo=timezone.utc)
+    attempts = [
+        _web_attempt("web1", start + timedelta(minutes=4), "1"),
+        _web_attempt("web1", start + timedelta(minutes=11), "2"),
+        _web_attempt("other", start + timedelta(minutes=20), "1"),
+    ]
+
+    seconds = estimate_active_learning_seconds(
+        attempts,
+        session_id="web1",
+        active_started_at=start,
+        interval_ended_at=start + timedelta(minutes=40),
+        event_key_prefix="web-recommendation:web1:",
+    )
+
+    assert seconds == 11 * 60
+
+
 def test_estimate_returns_zero_when_session_has_no_answer_evidence():
     start = datetime(2026, 9, 10, 9, 0, tzinfo=timezone.utc)
     attempts = [_attempt("other-session", start + timedelta(minutes=5))]
@@ -85,6 +123,7 @@ def test_guard_persists_evidence_time_instead_of_raw_wall_clock(monkeypatch):
     legacy = SimpleNamespace(
         add_learning_time=original_add,
         study_sessions={"user": {"session_id": "session"}},
+        web_recommendation_sessions={},
     )
     database = SimpleNamespace(
         get_question_attempts=lambda user_id, start_at=None: [
@@ -108,12 +147,80 @@ def test_guard_persists_evidence_time_instead_of_raw_wall_clock(monkeypatch):
     assert calls[0][2] == end
 
 
+def test_guard_web_recommendation_uses_answer_evidence_not_raw_wall_clock(monkeypatch):
+    start = datetime(2026, 9, 10, 9, 0, tzinfo=timezone.utc)
+    end = start + timedelta(hours=4)
+    calls = []
+
+    def original_add(user_id, elapsed_seconds, recorded_at=None, event_key=None):
+        calls.append((user_id, elapsed_seconds, recorded_at, event_key))
+        return True
+
+    legacy = SimpleNamespace(
+        add_learning_time=original_add,
+        study_sessions={},
+        web_recommendation_sessions={
+            "web1": {
+                "user_id": "user",
+                "started_at": start.timestamp(),
+                "completed": True,
+            }
+        },
+    )
+    database = SimpleNamespace(
+        get_question_attempts=lambda user_id, start_at=None: [
+            _web_attempt("web1", start + timedelta(minutes=10), "1"),
+            _web_attempt("web1", start + timedelta(minutes=22), "2"),
+            _web_attempt("web1", start + timedelta(hours=3), "3"),
+            _web_attempt("web1", start + timedelta(hours=3, minutes=8), "4"),
+        ]
+    )
+    monkeypatch.delenv("LT_LEARNING_ACTIVITY_GAP_CAP_SECONDS", raising=False)
+
+    install_learning_time_guard(legacy, database)
+    assert legacy.add_learning_time(
+        "user",
+        4 * 60 * 60,
+        recorded_at=end,
+        event_key="web-recommendation:web1:time",
+    ) is True
+
+    assert len(calls) == 1
+    # 10m + 12m + capped 30m + 8m = 60m. Raw 4h and the trailing 52m idle
+    # after the last answer are not counted.
+    assert calls[0][1] == 60 * 60
+    assert calls[0][3] == "web-recommendation:web1:time"
+
+
+def test_guard_web_recommendation_falls_closed_if_session_identity_is_missing(monkeypatch):
+    start = datetime(2026, 9, 10, 9, 0, tzinfo=timezone.utc)
+    calls = []
+    legacy = SimpleNamespace(
+        add_learning_time=lambda *args, **kwargs: calls.append((args, kwargs)) or True,
+        study_sessions={},
+        web_recommendation_sessions={},
+    )
+    database = SimpleNamespace(get_question_attempts=lambda *args, **kwargs: [])
+    monkeypatch.delenv("LT_LEARNING_ACTIVITY_GAP_CAP_SECONDS", raising=False)
+
+    install_learning_time_guard(legacy, database)
+    assert legacy.add_learning_time(
+        "user",
+        3 * 60 * 60,
+        recorded_at=start + timedelta(hours=3),
+        event_key="web-recommendation:missing:time",
+    ) is True
+    assert len(calls) == 1
+    assert calls[0][0][1] == 30 * 60
+
+
 def test_guard_does_not_persist_abandoned_session_without_answers(monkeypatch):
     start = datetime(2026, 9, 10, 9, 0, tzinfo=timezone.utc)
     calls = []
     legacy = SimpleNamespace(
         add_learning_time=lambda *args, **kwargs: calls.append((args, kwargs)) or True,
         study_sessions={"user": {"session_id": "session"}},
+        web_recommendation_sessions={},
     )
     database = SimpleNamespace(get_question_attempts=lambda *args, **kwargs: [])
     monkeypatch.delenv("LT_LEARNING_ACTIVITY_GAP_CAP_SECONDS", raising=False)
@@ -134,6 +241,7 @@ def test_guard_preserves_legacy_session_without_formal_id_but_caps_it(monkeypatc
     legacy = SimpleNamespace(
         add_learning_time=lambda *args, **kwargs: calls.append((args, kwargs)) or True,
         study_sessions={"user": {"active_started_at": start.timestamp()}},
+        web_recommendation_sessions={},
     )
     database = SimpleNamespace(get_question_attempts=lambda *args, **kwargs: [])
     monkeypatch.delenv("LT_LEARNING_ACTIVITY_GAP_CAP_SECONDS", raising=False)
@@ -154,6 +262,7 @@ def test_guard_is_idempotent(monkeypatch):
     legacy = SimpleNamespace(
         add_learning_time=lambda *args, **kwargs: calls.append((args, kwargs)) or True,
         study_sessions={},
+        web_recommendation_sessions={},
     )
     database = SimpleNamespace(get_question_attempts=lambda *args, **kwargs: [])
     monkeypatch.delenv("LT_LEARNING_ACTIVITY_GAP_CAP_SECONDS", raising=False)


### PR DESCRIPTION
## Total inspection finding
PR #307 fixed LINE quiz wall-clock inflation, but the Web recommendation completion path records time with keys shaped `web-recommendation:<session_id>:time`. The first guard treated that key as unparseable and merely capped it at 30 minutes. This prevents huge inflation but is not the same evidence-based accounting used for LINE; a long-but-active Web session could also be undercounted.

## Fix
- recognize Web recommendation time-event keys explicitly
- resolve the in-memory Web session's real `started_at` and user identity
- use persisted `question_attempts` with prefix `web-recommendation:<session_id>:` as activity evidence
- apply the same 30-minute max activity gap rule
- exclude trailing idle time after the last persisted answer
- fail closed to max 30 minutes if Web session identity/evidence lookup cannot be resolved

## Scope
No Question Bank, selector, repeat guard, Node state, Phase11, DB schema, or learner routing changes.

## Validation
Focused tests cover Web key parsing, prefix isolation, normal/long Web sessions, trailing idle exclusion, missing-session fail-closed behavior, plus existing LINE/legacy cases. Full repository CI is required before merge.
