### PR TITLE
fix: make paused LINE quiz sessions survive Render restarts

### DIFF
--- a/durable_paused_session.py
+++ b/durable_paused_session.py
@@ -1,0 +1,194 @@
+"""Durable storage for paused LINE quiz sessions.
+
+The legacy learner flow intentionally keeps active sessions in memory.  A
+paused session, however, is a user-visible promise ("源さんに預ける") and must
+survive a normal Render process restart.  This production composition layer
+persists only paused snapshots; active sessions remain in memory.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import logging
+import threading
+from datetime import datetime
+from typing import Any
+
+
+logger = logging.getLogger(__name__)
+_TABLE = "paused_quiz_sessions"
+_local_snapshots: dict[str, dict[str, Any]] = {}
+_local_lock = threading.RLock()
+
+
+def _json_default(value: Any):
+    if isinstance(value, set):
+        return sorted(value)
+    if isinstance(value, datetime):
+        return value.isoformat()
+    raise TypeError(f"Unsupported paused-session value: {type(value).__name__}")
+
+
+def _serializable_snapshot(session: dict[str, Any]) -> dict[str, Any]:
+    """Return a detached JSON-compatible snapshot."""
+    return json.loads(json.dumps(session, ensure_ascii=False, default=_json_default))
+
+
+def _restore_snapshot(payload: Any) -> dict[str, Any] | None:
+    if isinstance(payload, str):
+        try:
+            payload = json.loads(payload)
+        except json.JSONDecodeError:
+            return None
+    if not isinstance(payload, dict) or payload.get("status") != "paused":
+        return None
+    restored = copy.deepcopy(payload)
+    answers = restored.get("all_answers")
+    if isinstance(answers, dict):
+        converted = {}
+        for key, value in answers.items():
+            try:
+                converted[int(key)] = value
+            except (TypeError, ValueError):
+                converted[key] = value
+        restored["all_answers"] = converted
+    return restored
+
+
+class PausedSessionStore:
+    def __init__(self, database_module):
+        self.database = database_module
+
+    def save(self, user_id: str, session: dict[str, Any]) -> bool:
+        snapshot = _serializable_snapshot(session)
+        if not self.database.database_is_available():
+            with _local_lock:
+                _local_snapshots[user_id] = snapshot
+            return True
+        try:
+            with self.database.get_db_connection() as conn:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        f"""
+                        INSERT INTO {_TABLE} (user_id, session_payload, paused_at)
+                        VALUES (%s, %s::jsonb, NOW())
+                        ON CONFLICT (user_id) DO UPDATE
+                        SET session_payload = EXCLUDED.session_payload,
+                            paused_at = EXCLUDED.paused_at
+                        """,
+                        (user_id, json.dumps(snapshot, ensure_ascii=False)),
+                    )
+            return True
+        except Exception:
+            logger.exception("paused_session_store save_failed user_id=%s", user_id)
+            return False
+
+    def load(self, user_id: str) -> dict[str, Any] | None:
+        if not self.database.database_is_available():
+            with _local_lock:
+                return _restore_snapshot(_local_snapshots.get(user_id))
+        try:
+            with self.database.get_db_connection() as conn:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        f"SELECT session_payload FROM {_TABLE} WHERE user_id = %s",
+                        (user_id,),
+                    )
+                    row = cur.fetchone()
+            return _restore_snapshot(row[0]) if row else None
+        except Exception:
+            logger.exception("paused_session_store load_failed user_id=%s", user_id)
+            return None
+
+    def delete(self, user_id: str) -> bool:
+        if not self.database.database_is_available():
+            with _local_lock:
+                _local_snapshots.pop(user_id, None)
+            return True
+        try:
+            with self.database.get_db_connection() as conn:
+                with conn.cursor() as cur:
+                    cur.execute(f"DELETE FROM {_TABLE} WHERE user_id = %s", (user_id,))
+            return True
+        except Exception:
+            logger.exception("paused_session_store delete_failed user_id=%s", user_id)
+            return False
+
+
+class DurableStudySessions(dict):
+    """Legacy-compatible dict that lazily restores only paused sessions."""
+
+    def __init__(self, initial: dict[str, Any], store: PausedSessionStore):
+        super().__init__(initial)
+        self.store = store
+        self._lock = threading.RLock()
+
+    def _restore_if_needed(self, user_id):
+        with self._lock:
+            if dict.__contains__(self, user_id):
+                return
+            snapshot = self.store.load(user_id)
+            if snapshot is not None:
+                dict.__setitem__(self, user_id, snapshot)
+                logger.info("paused_session_store restored user_id=%s", user_id)
+
+    def get(self, user_id, default=None):
+        self._restore_if_needed(user_id)
+        return dict.get(self, user_id, default)
+
+    def __getitem__(self, user_id):
+        self._restore_if_needed(user_id)
+        return dict.__getitem__(self, user_id)
+
+    def __contains__(self, user_id):
+        self._restore_if_needed(user_id)
+        return dict.__contains__(self, user_id)
+
+    def __setitem__(self, user_id, session):
+        # Creating/replacing a live session explicitly abandons any old paused
+        # snapshot.  Restoration bypasses this method via dict.__setitem__.
+        self.store.delete(user_id)
+        dict.__setitem__(self, user_id, session)
+
+    def pop(self, user_id, *args):
+        self.store.delete(user_id)
+        return dict.pop(self, user_id, *args)
+
+
+def install_durable_paused_sessions(legacy_module, database_module) -> None:
+    """Compose durable pause/resume behavior onto the legacy learner flow."""
+    if getattr(legacy_module, "_durable_paused_sessions_installed", False):
+        return
+
+    store = PausedSessionStore(database_module)
+    existing_sessions = getattr(legacy_module, "study_sessions", {})
+    if not isinstance(existing_sessions, dict):
+        raise TypeError("legacy study_sessions must be a dict")
+    durable_sessions = DurableStudySessions(existing_sessions, store)
+    legacy_module.study_sessions = durable_sessions
+
+    original_pause = legacy_module.pause_quiz_session
+    original_resume = legacy_module.resume_quiz_session
+
+    def durable_pause(user_id):
+        paused = original_pause(user_id)
+        if not paused:
+            return paused
+        session = durable_sessions.get(user_id)
+        if not session or session.get("status") != "paused":
+            return paused
+        if not store.save(user_id, session):
+            logger.error("paused_session_store persistence_not_confirmed user_id=%s", user_id)
+        return paused
+
+    def durable_resume(user_id):
+        session = original_resume(user_id)
+        if session is not None:
+            store.delete(user_id)
+        return session
+
+    legacy_module.pause_quiz_session = durable_pause
+    legacy_module.resume_quiz_session = durable_resume
+    legacy_module._durable_paused_session_store = store
+    legacy_module._durable_paused_sessions_installed = True

--- a/migrations/20260911_paused_quiz_sessions.sql
+++ b/migrations/20260911_paused_quiz_sessions.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS paused_quiz_sessions (
+    user_id TEXT PRIMARY KEY REFERENCES user_profiles(user_id) ON DELETE CASCADE,
+    session_payload JSONB NOT NULL,
+    paused_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS paused_quiz_sessions_paused_at_idx
+ON paused_quiz_sessions (paused_at);

--- a/tests/test_durable_paused_session.py
+++ b/tests/test_durable_paused_session.py
@@ -1,0 +1,160 @@
+from types import SimpleNamespace
+
+import durable_paused_session as durable
+from durable_paused_session import (
+    DurableStudySessions,
+    PausedSessionStore,
+    install_durable_paused_sessions,
+)
+
+
+def setup_function():
+    durable._local_snapshots.clear()
+
+
+def teardown_function():
+    durable._local_snapshots.clear()
+
+
+class LocalDatabase:
+    @staticmethod
+    def database_is_available():
+        return False
+
+
+class FakeLegacy(SimpleNamespace):
+    def __init__(self):
+        super().__init__()
+        self.study_sessions = {}
+
+        def pause(user_id):
+            session = self.study_sessions.get(user_id)
+            if not session:
+                return False
+            if session.get("status") != "paused":
+                session["resume_status"] = session.get("status", "waiting_for_answers")
+            session.pop("active_started_at", None)
+            session["status"] = "paused"
+            return True
+
+        def resume(user_id):
+            session = self.study_sessions.get(user_id)
+            if not session or session.get("status") != "paused":
+                return None
+            session["status"] = session.pop("resume_status", "waiting_for_answers")
+            session["active_started_at"] = 999.0
+            return session
+
+        self.pause_quiz_session = pause
+        self.resume_quiz_session = resume
+
+
+def _session():
+    return {
+        "session_id": "session-1",
+        "status": "waiting_for_continue",
+        "current_set": 2,
+        "question_count": 30,
+        "questions_per_set": 5,
+        "total_sets": 6,
+        "questions": [{"id": "Q6"}],
+        "all_questions": [{"id": f"Q{n}"} for n in range(1, 31)],
+        "all_answers": {
+            1: {"answer": "A", "confidence": "1"},
+            2: {"answer": "B", "confidence": "2"},
+        },
+        "expected_numbers": [6, 7, 8, 9, 10],
+        "mode": "study",
+        "started_at": 100.0,
+        "active_started_at": 200.0,
+        "category_small": None,
+        "session_kind": "random",
+    }
+
+
+def test_paused_snapshot_survives_recreated_in_memory_dict_and_restores_int_answer_keys():
+    store = PausedSessionStore(LocalDatabase())
+    snapshot = _session()
+    snapshot["resume_status"] = snapshot["status"]
+    snapshot["status"] = "paused"
+    snapshot.pop("active_started_at", None)
+    assert store.save("user", snapshot) is True
+
+    restarted = DurableStudySessions({}, PausedSessionStore(LocalDatabase()))
+    restored = restarted.get("user")
+
+    assert restored is not None
+    assert restored["status"] == "paused"
+    assert restored["session_id"] == "session-1"
+    assert restored["current_set"] == 2
+    assert 1 in restored["all_answers"]
+    assert "1" not in restored["all_answers"]
+
+
+def test_install_pause_persists_then_process_restart_can_resume_exact_session():
+    legacy = FakeLegacy()
+    install_durable_paused_sessions(legacy, LocalDatabase())
+    legacy.study_sessions["user"] = _session()
+
+    assert legacy.pause_quiz_session("user") is True
+    expected_questions = legacy.study_sessions["user"]["all_questions"]
+
+    # Simulate a Render process restart: in-memory dict disappears, durable
+    # storage remains. A fresh composition layer must lazily restore it.
+    restarted = FakeLegacy()
+    install_durable_paused_sessions(restarted, LocalDatabase())
+    restored = restarted.study_sessions.get("user")
+
+    assert restored is not None
+    assert restored["status"] == "paused"
+    assert restored["all_questions"] == expected_questions
+    assert restarted.resume_quiz_session("user") is restored
+    assert restored["status"] == "waiting_for_continue"
+    assert restored["active_started_at"] == 999.0
+
+    # Successful resume consumes the durable paused snapshot.
+    restarted.study_sessions.clear()
+    assert restarted.study_sessions.get("user") is None
+
+
+def test_new_live_session_replaces_stale_paused_snapshot():
+    store = PausedSessionStore(LocalDatabase())
+    paused = _session()
+    paused["status"] = "paused"
+    paused["resume_status"] = "waiting_for_answers"
+    paused.pop("active_started_at", None)
+    assert store.save("user", paused)
+
+    sessions = DurableStudySessions({}, store)
+    sessions["user"] = {"session_id": "new", "status": "waiting_for_answers"}
+    sessions.clear()
+
+    assert store.load("user") is None
+
+
+def test_pop_removes_durable_snapshot_for_finish_reset_or_start_over():
+    store = PausedSessionStore(LocalDatabase())
+    paused = _session()
+    paused["status"] = "paused"
+    paused["resume_status"] = "waiting_for_answers"
+    paused.pop("active_started_at", None)
+    assert store.save("user", paused)
+
+    sessions = DurableStudySessions({}, store)
+    assert sessions.get("user") is not None
+    sessions.pop("user", None)
+
+    fresh = DurableStudySessions({}, store)
+    assert fresh.get("user") is None
+
+
+def test_install_is_idempotent():
+    legacy = FakeLegacy()
+    install_durable_paused_sessions(legacy, LocalDatabase())
+    sessions = legacy.study_sessions
+    pause = legacy.pause_quiz_session
+
+    install_durable_paused_sessions(legacy, LocalDatabase())
+
+    assert legacy.study_sessions is sessions
+    assert legacy.pause_quiz_session is pause

--- a/wsgi.py
+++ b/wsgi.py
@@ -27,6 +27,7 @@ from linebot.models import (
 from daily_wrong_review import REVIEW_COMMAND, install_daily_wrong_review
 from dashboard_progress_trend import install_dashboard_progress_trend
 from developer_access_recovery import install_developer_access_recovery
+from durable_paused_session import install_durable_paused_sessions
 from learning_time_guard import install_learning_time_guard
 from one_question_starter import install_one_question_starter, one_question_quick_reply_item
 from phase11_gate_ui import install_phase11_gate_ui
@@ -120,6 +121,7 @@ def _apply_rich_menu_v2_if_requested() -> None:
 
 # Registered LINE callbacks resolve these names from the legacy app module at
 # call time, so production behavior can be composed without rewriting app.py.
+install_durable_paused_sessions(legacy, database_module)
 install_learning_time_guard(legacy, database_module)
 install_prerequisite_attempt_cache(legacy)
 install_dashboard_progress_trend(legacy, goukaku_module)


### PR DESCRIPTION
## Total inspection finding
`app.py` explicitly keeps `study_sessions` only in process memory and notes that Render restart clears them. This conflicts with the learner-facing `源さんに預ける` / `続きから始める` promise and the PT v1.0 requirement that pause/resume works safely.

## Fix
- add a production composition layer `durable_paused_session.py`
- persist **only paused** quiz-session snapshots; active sessions remain the existing in-memory flow
- lazily restore a paused snapshot through the same `study_sessions` mapping after process restart
- preserve exact `session_id`, question order, current set, answers, mode, category and resume status
- normalize integer `all_answers` keys after JSONB restore
- successful resume or explicit session replacement/removal deletes the durable paused snapshot
- add `paused_quiz_sessions` migration with `ON DELETE CASCADE` from `user_profiles`, so full profile reset cannot leave an orphan snapshot
- install only from `wsgi.py`; no Question Bank, selector, Node-state, repeat-guard or Phase11 logic changes

## Validation
Focused tests simulate a process restart, restore the exact paused question list/progress, resume, consume the snapshot, start-over cleanup, reset/pop cleanup, and idempotent composition. Full repository CI required before merge.

## Production ordering
Do not merge/deploy until the additive `paused_quiz_sessions` migration has been applied to Production Neon and verified. Applying that schema change requires explicit user approval.
