### PR TITLE
fix: make Web recommendation sessions survive Render restarts

### DIFF
--- a/durable_web_learning_session.py
+++ b/durable_web_learning_session.py
@@ -1,0 +1,217 @@
+"""Durable storage for active/completed Web recommendation study sessions.
+
+The learner-facing Web recommendation flow historically kept every session in
+process memory. A normal Render restart therefore turned an in-progress
+learning URL into a 404 even though the learner's already-confirmed attempts
+were safely stored. This production composition layer persists the small Web
+session snapshot and restores it lazily after a process restart.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import logging
+import threading
+from functools import wraps
+from typing import Any
+
+
+logger = logging.getLogger(__name__)
+_TABLE = "web_learning_sessions"
+_RETENTION_DAYS = 7
+_local_snapshots: dict[str, dict[str, Any]] = {}
+_local_lock = threading.RLock()
+
+
+def _snapshot(session: dict[str, Any]) -> dict[str, Any]:
+    return json.loads(json.dumps(session, ensure_ascii=False))
+
+
+def _restore(payload: Any) -> dict[str, Any] | None:
+    if isinstance(payload, str):
+        try:
+            payload = json.loads(payload)
+        except json.JSONDecodeError:
+            return None
+    if not isinstance(payload, dict):
+        return None
+    required = {"user_id", "dashboard_token", "question_count", "questions", "current_index"}
+    if not required.issubset(payload):
+        return None
+    return copy.deepcopy(payload)
+
+
+class WebLearningSessionStore:
+    def __init__(self, database_module):
+        self.database = database_module
+
+    def save(self, session_id: str, session: dict[str, Any]) -> bool:
+        payload = _snapshot(session)
+        if not self.database.database_is_available():
+            with _local_lock:
+                _local_snapshots[session_id] = payload
+            return True
+        try:
+            with self.database.get_db_connection() as conn:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        f"DELETE FROM {_TABLE} WHERE updated_at < NOW() - INTERVAL '{_RETENTION_DAYS} days'"
+                    )
+                    cur.execute(
+                        f"""
+                        INSERT INTO {_TABLE} (session_id, user_id, session_payload, updated_at)
+                        VALUES (%s, %s, %s::jsonb, NOW())
+                        ON CONFLICT (session_id) DO UPDATE
+                        SET user_id = EXCLUDED.user_id,
+                            session_payload = EXCLUDED.session_payload,
+                            updated_at = EXCLUDED.updated_at
+                        """,
+                        (session_id, str(session.get("user_id", "")), json.dumps(payload, ensure_ascii=False)),
+                    )
+            return True
+        except Exception:
+            logger.exception("web_learning_session save_failed session_id=%s", session_id)
+            return False
+
+    def load(self, session_id: str) -> dict[str, Any] | None:
+        if not self.database.database_is_available():
+            with _local_lock:
+                return _restore(_local_snapshots.get(session_id))
+        try:
+            with self.database.get_db_connection() as conn:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        f"""
+                        SELECT session_payload FROM {_TABLE}
+                        WHERE session_id = %s
+                          AND updated_at >= NOW() - INTERVAL '{_RETENTION_DAYS} days'
+                        """,
+                        (session_id,),
+                    )
+                    row = cur.fetchone()
+            return _restore(row[0]) if row else None
+        except Exception:
+            logger.exception("web_learning_session load_failed session_id=%s", session_id)
+            return None
+
+    def load_all_recent(self) -> dict[str, dict[str, Any]]:
+        if not self.database.database_is_available():
+            with _local_lock:
+                return {
+                    session_id: restored
+                    for session_id, payload in _local_snapshots.items()
+                    if (restored := _restore(payload)) is not None
+                }
+        try:
+            with self.database.get_db_connection() as conn:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        f"""
+                        SELECT session_id, session_payload FROM {_TABLE}
+                        WHERE updated_at >= NOW() - INTERVAL '{_RETENTION_DAYS} days'
+                        ORDER BY updated_at
+                        """
+                    )
+                    rows = cur.fetchall()
+            restored = {}
+            for session_id, payload in rows:
+                session = _restore(payload)
+                if session is not None:
+                    restored[str(session_id)] = session
+            return restored
+        except Exception:
+            logger.exception("web_learning_session load_all_failed")
+            return {}
+
+    def delete(self, session_id: str) -> bool:
+        if not self.database.database_is_available():
+            with _local_lock:
+                _local_snapshots.pop(session_id, None)
+            return True
+        try:
+            with self.database.get_db_connection() as conn:
+                with conn.cursor() as cur:
+                    cur.execute(f"DELETE FROM {_TABLE} WHERE session_id = %s", (session_id,))
+            return True
+        except Exception:
+            logger.exception("web_learning_session delete_failed session_id=%s", session_id)
+            return False
+
+
+class DurableWebLearningSessions(dict):
+    def __init__(self, initial: dict[str, Any], store: WebLearningSessionStore):
+        super().__init__()
+        self.store = store
+        self._lock = threading.RLock()
+        for session_id, session in store.load_all_recent().items():
+            dict.__setitem__(self, session_id, session)
+        for session_id, session in initial.items():
+            dict.__setitem__(self, session_id, session)
+
+    def _restore_if_needed(self, session_id: str) -> None:
+        with self._lock:
+            if dict.__contains__(self, session_id):
+                return
+            session = self.store.load(session_id)
+            if session is not None:
+                dict.__setitem__(self, session_id, session)
+                logger.info("web_learning_session restored session_id=%s", session_id)
+
+    def get(self, session_id, default=None):
+        self._restore_if_needed(session_id)
+        return dict.get(self, session_id, default)
+
+    def __getitem__(self, session_id):
+        self._restore_if_needed(session_id)
+        return dict.__getitem__(self, session_id)
+
+    def __contains__(self, session_id):
+        self._restore_if_needed(session_id)
+        return dict.__contains__(self, session_id)
+
+    def __setitem__(self, session_id, session):
+        dict.__setitem__(self, session_id, session)
+        if not self.store.save(str(session_id), session):
+            logger.error("web_learning_session initial_persistence_not_confirmed session_id=%s", session_id)
+
+    def persist(self, session_id: str) -> bool:
+        session = dict.get(self, session_id)
+        if session is None:
+            return False
+        return self.store.save(session_id, session)
+
+    def pop(self, session_id, *args):
+        self.store.delete(str(session_id))
+        return dict.pop(self, session_id, *args)
+
+
+def install_durable_web_learning_sessions(legacy_module, database_module) -> None:
+    """Compose restart-safe Web recommendation sessions onto the Flask app."""
+    if getattr(legacy_module, "_durable_web_learning_sessions_installed", False):
+        return
+
+    store = WebLearningSessionStore(database_module)
+    existing = getattr(legacy_module, "web_recommendation_sessions", {})
+    if not isinstance(existing, dict):
+        raise TypeError("legacy web_recommendation_sessions must be a dict")
+    durable = DurableWebLearningSessions(existing, store)
+    legacy_module.web_recommendation_sessions = durable
+
+    endpoint = "answer_web_recommendation"
+    original_answer = legacy_module.app.view_functions.get(endpoint)
+    if original_answer is None:
+        raise RuntimeError("answer_web_recommendation endpoint not found")
+
+    @wraps(original_answer)
+    def durable_answer(session_id, *args, **kwargs):
+        response = original_answer(session_id, *args, **kwargs)
+        session = durable.get(session_id)
+        if session is not None and not durable.persist(session_id):
+            logger.error("web_learning_session answer_persistence_not_confirmed session_id=%s", session_id)
+        return response
+
+    legacy_module.answer_web_recommendation = durable_answer
+    legacy_module.app.view_functions[endpoint] = durable_answer
+    legacy_module._durable_web_learning_session_store = store
+    legacy_module._durable_web_learning_sessions_installed = True

--- a/migrations/20260911_web_learning_sessions.sql
+++ b/migrations/20260911_web_learning_sessions.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS web_learning_sessions (
+    session_id TEXT PRIMARY KEY,
+    user_id TEXT NOT NULL REFERENCES user_profiles(user_id) ON DELETE CASCADE,
+    session_payload JSONB NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS web_learning_sessions_user_updated_idx
+ON web_learning_sessions (user_id, updated_at DESC);

--- a/tests/test_durable_web_learning_session.py
+++ b/tests/test_durable_web_learning_session.py
@@ -1,0 +1,128 @@
+from types import SimpleNamespace
+
+import durable_web_learning_session as module
+from durable_web_learning_session import (
+    DurableWebLearningSessions,
+    WebLearningSessionStore,
+    install_durable_web_learning_sessions,
+)
+
+
+def setup_function():
+    module._local_snapshots.clear()
+
+
+def teardown_function():
+    module._local_snapshots.clear()
+
+
+def _database_off():
+    return SimpleNamespace(database_is_available=lambda: False)
+
+
+def _session(user_id="user", current_index=0, completed=False):
+    return {
+        "user_id": user_id,
+        "dashboard_token": "token",
+        "category_small": 8,
+        "question_count": 10,
+        "questions": [{"id": f"Q{n}"} for n in range(1, 11)],
+        "selection_audit": {},
+        "current_index": current_index,
+        "correct_count": current_index,
+        "completed": completed,
+        "started_at": 123.5,
+    }
+
+
+def test_mapping_persists_new_session_and_restores_after_process_rebuild():
+    store = WebLearningSessionStore(_database_off())
+    first = DurableWebLearningSessions({}, store)
+    first["sid"] = _session(current_index=3)
+
+    rebuilt = DurableWebLearningSessions({}, WebLearningSessionStore(_database_off()))
+    restored = rebuilt.get("sid")
+
+    assert restored is not None
+    assert restored["current_index"] == 3
+    assert [q["id"] for q in restored["questions"]] == [f"Q{n}" for n in range(1, 11)]
+
+
+def test_persist_saves_in_place_answer_progress_for_restart():
+    durable = DurableWebLearningSessions({}, WebLearningSessionStore(_database_off()))
+    durable["sid"] = _session()
+    durable["sid"]["current_index"] = 4
+    durable["sid"]["correct_count"] = 2
+    assert durable.persist("sid") is True
+
+    rebuilt = DurableWebLearningSessions({}, WebLearningSessionStore(_database_off()))
+    assert rebuilt["sid"]["current_index"] == 4
+    assert rebuilt["sid"]["correct_count"] == 2
+
+
+def test_completed_session_remains_available_for_final_page_refresh():
+    durable = DurableWebLearningSessions({}, WebLearningSessionStore(_database_off()))
+    durable["sid"] = _session(current_index=10, completed=True)
+
+    rebuilt = DurableWebLearningSessions({}, WebLearningSessionStore(_database_off()))
+    assert rebuilt["sid"]["completed"] is True
+    assert rebuilt["sid"]["current_index"] == 10
+
+
+def test_pop_removes_persisted_session():
+    durable = DurableWebLearningSessions({}, WebLearningSessionStore(_database_off()))
+    durable["sid"] = _session()
+    durable.pop("sid")
+
+    rebuilt = DurableWebLearningSessions({}, WebLearningSessionStore(_database_off()))
+    assert rebuilt.get("sid") is None
+
+
+class _FakeApp:
+    def __init__(self, answer):
+        self.view_functions = {"answer_web_recommendation": answer}
+
+
+def test_install_wraps_answer_endpoint_and_persists_mutated_progress():
+    sessions = {}
+
+    def answer(session_id):
+        session = legacy.web_recommendation_sessions.get(session_id)
+        session["current_index"] += 1
+        session["correct_count"] += 1
+        return {"ok": True}
+
+    legacy = SimpleNamespace(
+        web_recommendation_sessions=sessions,
+        app=_FakeApp(answer),
+        answer_web_recommendation=answer,
+    )
+    database = _database_off()
+
+    install_durable_web_learning_sessions(legacy, database)
+    legacy.web_recommendation_sessions["sid"] = _session()
+    response = legacy.app.view_functions["answer_web_recommendation"]("sid")
+
+    assert response == {"ok": True}
+    rebuilt = DurableWebLearningSessions({}, WebLearningSessionStore(database))
+    assert rebuilt["sid"]["current_index"] == 1
+    assert rebuilt["sid"]["correct_count"] == 1
+
+
+def test_install_is_idempotent():
+    def answer(_session_id):
+        return {"ok": True}
+
+    legacy = SimpleNamespace(
+        web_recommendation_sessions={},
+        app=_FakeApp(answer),
+        answer_web_recommendation=answer,
+    )
+    database = _database_off()
+    install_durable_web_learning_sessions(legacy, database)
+    first_mapping = legacy.web_recommendation_sessions
+    first_endpoint = legacy.app.view_functions["answer_web_recommendation"]
+
+    install_durable_web_learning_sessions(legacy, database)
+    assert legacy.web_recommendation_sessions is first_mapping
+    assert legacy.app.view_functions["answer_web_recommendation"] is first_endpoint

--- a/wsgi.py
+++ b/wsgi.py
@@ -28,6 +28,7 @@ from daily_wrong_review import REVIEW_COMMAND, install_daily_wrong_review
 from dashboard_progress_trend import install_dashboard_progress_trend
 from developer_access_recovery import install_developer_access_recovery
 from durable_paused_session import install_durable_paused_sessions
+from durable_web_learning_session import install_durable_web_learning_sessions
 from learning_time_guard import install_learning_time_guard
 from one_question_starter import install_one_question_starter, one_question_quick_reply_item
 from phase11_gate_ui import install_phase11_gate_ui
@@ -122,6 +123,7 @@ def _apply_rich_menu_v2_if_requested() -> None:
 # Registered LINE callbacks resolve these names from the legacy app module at
 # call time, so production behavior can be composed without rewriting app.py.
 install_durable_paused_sessions(legacy, database_module)
+install_durable_web_learning_sessions(legacy, database_module)
 install_learning_time_guard(legacy, database_module)
 install_prerequisite_attempt_cache(legacy)
 install_dashboard_progress_trend(legacy, goukaku_module)


### PR DESCRIPTION
## Total inspection finding
The Web recommendation learner flow stores `web_recommendation_sessions` only in process memory. A normal Render restart therefore turns an in-progress `/goukaku-no-michi/learning/<session_id>` URL into a 404 even though confirmed attempts were persisted. This violates the v1.0 requirement that ordinary learning should not become uncontinuable mid-flow.

## Fix
- add durable `web_learning_sessions` storage for recent Web learning sessions
- persist the initial recommendation session snapshot when created
- persist answer progress after each successful answer request
- lazy-restore a session by session ID after process restart
- hydrate recent sessions so duplicate-start protection continues after restart
- keep completed sessions available for final-page refresh for up to 7 days
- cascade session cleanup when the learner profile is fully reset
- no Question Bank, selector, Node-state, repeat-guard, Phase11, or answer-scoring changes

## Validation
Focused tests cover initial persistence, restart restore, in-place answer progress persistence, completed-session refresh, explicit removal, endpoint composition, and idempotent installation. Full repository CI is required before merge.

## Production ordering
Do not merge/deploy until the additive `web_learning_sessions` migration has been applied to Production Neon and verified. Applying that schema change requires explicit user approval.
