### PR TITLE
feat: add qualification foundation

### DIFF
--- a/qualifications/__init__.py
+++ b/qualifications/__init__.py
@@ -1,0 +1,25 @@
+"""Standalone qualification definitions, not wired into existing PT execution.
+
+The default describes the legacy PT compatibility contract only. It does not
+select a bank or infer the qualification of stored sessions or database rows.
+"""
+
+from .base import QualificationConfig
+from .pt.config import PT
+from .takken.config import TAKKEN
+
+QUALIFICATIONS = (PT, TAKKEN)
+DEFAULT_QUALIFICATION_ID = PT.qualification_id
+
+
+def get_qualification(qualification_id: str) -> QualificationConfig:
+    """Return known metadata; unknown IDs never silently fall back to PT."""
+    for qualification in QUALIFICATIONS:
+        if qualification.qualification_id == qualification_id:
+            return qualification
+    raise KeyError(qualification_id)
+
+
+def get_default_qualification() -> QualificationConfig:
+    """Return PT metadata without changing the existing application default."""
+    return get_qualification(DEFAULT_QUALIFICATION_ID)

--- a/qualifications/base.py
+++ b/qualifications/base.py
@@ -1,0 +1,11 @@
+"""Metadata only: no runtime, storage, or question-bank integration."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class QualificationConfig:
+    """Stable qualification identity and its learner-facing name."""
+
+    qualification_id: str
+    display_name: str

--- a/qualifications/pt/__init__.py
+++ b/qualifications/pt/__init__.py
@@ -1,0 +1,1 @@
+"""Physical therapist qualification metadata."""

--- a/qualifications/pt/config.py
+++ b/qualifications/pt/config.py
@@ -1,0 +1,5 @@
+"""PT metadata; the existing bank and runtime remain untouched."""
+
+from ..base import QualificationConfig
+
+PT = QualificationConfig(qualification_id="pt", display_name="理学療法士")

--- a/qualifications/takken/__init__.py
+++ b/qualifications/takken/__init__.py
@@ -1,0 +1,1 @@
+"""Takken metadata only; no learning service is enabled."""

--- a/qualifications/takken/config.py
+++ b/qualifications/takken/config.py
@@ -1,0 +1,5 @@
+"""Define Takken without connecting a bank, session, or database."""
+
+from ..base import QualificationConfig
+
+TAKKEN = QualificationConfig(qualification_id="takken", display_name="宅地建物取引士")

--- a/tests/test_qualification_foundation.py
+++ b/tests/test_qualification_foundation.py
@@ -1,0 +1,87 @@
+"""Standalone tests: never import the application or its database module."""
+
+from dataclasses import FrozenInstanceError
+from pathlib import Path
+import subprocess
+import sys
+import unittest
+
+from qualifications import (
+    DEFAULT_QUALIFICATION_ID,
+    QUALIFICATIONS,
+    get_default_qualification,
+    get_qualification,
+)
+
+
+class QualificationFoundationTest(unittest.TestCase):
+    def test_ids_are_unique_and_include_pt_and_takken(self):
+        ids = [item.qualification_id for item in QUALIFICATIONS]
+        self.assertEqual(len(ids), len(set(ids)))
+        self.assertTrue({"pt", "takken"}.issubset(ids))
+
+    def test_display_names(self):
+        self.assertEqual(get_qualification("pt").display_name, "理学療法士")
+        self.assertEqual(get_qualification("takken").display_name, "宅地建物取引士")
+
+    def test_default_is_pt(self):
+        self.assertEqual(DEFAULT_QUALIFICATION_ID, "pt")
+        self.assertIs(get_default_qualification(), get_qualification("pt"))
+
+    def test_unknown_id_does_not_fall_back(self):
+        with self.assertRaises(KeyError):
+            get_qualification("unknown")
+
+    def test_config_is_immutable(self):
+        with self.assertRaises(FrozenInstanceError):
+            get_default_qualification().display_name = "changed"
+
+    def test_fresh_import_has_no_db_network_or_write_side_effects(self):
+        # A fresh interpreter prevents cached imports from hiding side effects.
+        # -B disables Python bytecode writes without changing environment vars.
+        script = r'''
+import importlib.abc
+import os
+import sys
+
+blocked = {"app", "wsgi", "database", "question_bank", "psycopg",
+           "psycopg2", "sqlite3", "openai", "linebot"}
+
+class BlockRuntimeImports(importlib.abc.MetaPathFinder):
+    def find_spec(self, fullname, path=None, target=None):
+        if fullname.split(".")[0] in blocked:
+            raise AssertionError("Runtime/DB import: " + fullname)
+
+def audit(event, args):
+    if event == "open":
+        _, mode, flags = args
+        write_flags = os.O_WRONLY | os.O_RDWR | os.O_CREAT | os.O_TRUNC | os.O_APPEND
+        if (mode and any(c in mode for c in "wax+")) or (flags & write_flags):
+            raise AssertionError("File write during import")
+    if event.startswith(("socket.", "subprocess.", "sqlite3.")) or event in {
+        "os.system", "os.mkdir", "os.remove", "os.rmdir", "os.rename",
+        "os.link", "os.symlink", "os.truncate", "os.chmod", "os.utime",
+    }:
+        raise AssertionError("Side effect during import: " + event)
+
+sys.meta_path.insert(0, BlockRuntimeImports())
+sys.addaudithook(audit)
+import qualifications
+import qualifications.base
+import qualifications.pt.config
+import qualifications.takken.config
+assert qualifications.get_default_qualification().qualification_id == "pt"
+assert not blocked.intersection(sys.modules)
+'''
+        result = subprocess.run(
+            [sys.executable, "-B", "-c", script],
+            cwd=Path(__file__).resolve().parents[1],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Purpose
Add the minimum qualification metadata layer for future multi-qualification support without changing the existing PT runtime.

## Changes
- Add immutable qualification config metadata
- Register `pt` and `takken`
- Keep PT as the default compatibility qualification
- Add standalone tests for IDs, display names, immutability, unknown IDs, and import side effects

## Explicitly unchanged
- Existing PT execution paths
- Question bank loading
- Database schema and migrations
- Sessions and event keys
- Render/environment settings
- Existing files

Base: `dbf3937c21887b8e4a07d39293493b676f5e0f14`
Head: `28aa5efca74b9701d58018bdc5ce6fdd6087cf53`