### PR TITLE
test: align dashboard assertions with official exam date

### DIFF
--- a/tests/test_goukaku_ui.py
+++ b/tests/test_goukaku_ui.py
@@ -31,10 +31,10 @@ def test_goukaku_home_renders(monkeypatch):
     assert "data-close" not in text
     assert "今日やること" in text
     assert "今日の学習を始める" in text
-    assert "（暫定）" in text
+    assert "（暫定）" not in text
     assert "field-progress-row" in text
     assert "正答率" in text
-    assert "2027/02/20" in text
+    assert "2027/02/21" in text
     assert ">0<small>問</small>" in text
     assert "data-line-message=\"相談する\"" in text
     assert 'class="app-shell"' in text


### PR DESCRIPTION
test_goukaku_home_renders still expected the old provisional date even though the official UI shows 2027/02/21 without （暫定）. Update only those two assertions to match the current UI.

Validation: the targeted test passes locally. The full local run passes 1311 tests but encounters an unrelated CRLF/LF byte-comparison failure in test_integration_is_idempotent; the existing Ubuntu/Python 3.13 workflow will verify the full suite with DATABASE_URL empty and PYTHONPATH=.. No application, data, workflow, or production configuration changes.