### PR TITLE
feat: connect adaptive selector to PT question bank provider

### DIFF
--- a/adaptive_question_selector.py
+++ b/adaptive_question_selector.py
@@ -14,13 +14,8 @@ from knowledge_node_repair_evidence import (
     SAME_QUESTION,
     classify_repair_confirmation,
 )
-from question_bank import (
-    QuestionAvailabilityError,
-    get_category_small,
-    get_question_tag,
-    get_quiz_question,
-    question_ids,
-)
+from question_bank import QuestionAvailabilityError, get_category_small
+from qualifications.pt.provider import PTQuestionBankProvider
 from question_equivalence import (
     canonicalize_question_evidence_id,
     canonicalize_question_evidence_node,
@@ -29,6 +24,13 @@ from prerequisite_backtrack_pilot import (
     is_prerequisite_backtrack_pilot_enabled,
     parse_prerequisite_backtrack_pilot_user_ids,
 )
+
+
+_PT_BANK = PTQuestionBankProvider()
+# Keep the existing module-local names available to callers and test patches.
+question_ids = _PT_BANK.question_ids
+get_question_tag = _PT_BANK.get_question_tag
+get_quiz_question = _PT_BANK.get_quiz_question
 
 
 REPAIR_REASONS = {

--- a/tests/test_adaptive_selector_pt_provider.py
+++ b/tests/test_adaptive_selector_pt_provider.py
@@ -1,0 +1,72 @@
+"""Regression coverage for the adaptive-selector PT provider connection."""
+
+import random
+
+import adaptive_question_selector as selector
+import question_bank
+from qualifications.pt.provider import PTQuestionBankProvider
+
+
+PROVIDER_METHODS = ("question_ids", "get_question_tag", "get_quiz_question")
+
+
+def test_selector_uses_one_pt_provider_for_supported_bank_reads():
+    assert isinstance(selector._PT_BANK, PTQuestionBankProvider)
+    assert selector._PT_BANK.qualification_id == "pt"
+    for name in PROVIDER_METHODS:
+        bound = getattr(selector, name)
+        assert bound.__self__ is selector._PT_BANK
+        assert bound.__func__ is getattr(PTQuestionBankProvider, name)
+
+
+def test_category_lookup_stays_on_legacy_bank_for_now():
+    assert selector.get_category_small is question_bank.get_category_small
+
+
+def test_provider_bound_reads_preserve_arguments_and_results(monkeypatch):
+    for name, args, result in (
+        ("question_ids", (), ("Q2", "Q1")),
+        ("get_question_tag", (" q1 ",), {"raw": [" unchanged "]}),
+        ("get_quiz_question", (" q1 ",), {"raw": [" unchanged "]}),
+    ):
+        calls = []
+
+        def bank_read(*received):
+            calls.append(received)
+            return result
+
+        monkeypatch.setattr(question_bank, name, bank_read)
+        assert getattr(selector, name)(*args) is result
+        assert calls == [args]
+
+
+def test_selector_output_matches_direct_legacy_bank_path(monkeypatch):
+    def build():
+        return selector.select_node_adaptive_questions(
+            [], question_count=12, rng=random.Random(314), category_small=18
+        )
+
+    through_provider = build()
+    with monkeypatch.context() as direct:
+        direct.setattr(selector, "question_ids", question_bank.question_ids)
+        direct.setattr(selector, "get_question_tag", question_bank.get_question_tag)
+        direct.setattr(selector, "get_quiz_question", question_bank.get_quiz_question)
+        direct_legacy = build()
+
+    assert through_provider == direct_legacy
+
+
+def test_built_session_matches_direct_legacy_bank_path(monkeypatch):
+    def build():
+        return selector.build_node_adaptive_session(
+            [], question_count=12, rng=random.Random(314), category_small=18
+        )
+
+    through_provider = build()
+    with monkeypatch.context() as direct:
+        direct.setattr(selector, "question_ids", question_bank.question_ids)
+        direct.setattr(selector, "get_question_tag", question_bank.get_question_tag)
+        direct.setattr(selector, "get_quiz_question", question_bank.get_quiz_question)
+        direct_legacy = build()
+
+    assert through_provider == direct_legacy


### PR DESCRIPTION
## Purpose
Route the adaptive selector's provider-supported PT Question Bank reads through the existing `PTQuestionBankProvider` without changing selector behavior.

## Changes
- `adaptive_question_selector.py`
  - use one `PTQuestionBankProvider` instance for `question_ids`, `get_question_tag`, and `get_quiz_question`
  - keep existing module-local names as bound-method aliases for compatibility
  - keep `get_category_small` and `QuestionAvailabilityError` on legacy `question_bank` for now because category lookup is not part of the provider contract yet
- add focused regression coverage in `tests/test_adaptive_selector_pt_provider.py`

## Explicitly unchanged
- selector scoring, balancing, repair/exploration logic
- Recent Question Cooldown / 3-day hard floor
- Knowledge Node state logic
- DB, migrations, sessions, event keys
- `question_bank.py`
- provider contract / PT provider implementation
- app / learning engine / Render / environment settings

Base main: `4958a1a2e2d02f3bb9795731c8fee0026bd6bf7d`.

This PR intentionally does not add `get_category_small` to the shared provider contract yet.