### PR TITLE
feat: add qualification question bank provider registry

### DIFF
--- a/qualifications/provider_registry.py
+++ b/qualifications/provider_registry.py
@@ -1,0 +1,34 @@
+"""Qualification-scoped Question Bank provider lookup.
+
+The registry is intentionally explicit: PT is available today, while a known
+qualification without a provider must fail instead of silently falling back to
+PT. Runtime qualification selection is not implemented here.
+"""
+
+from __future__ import annotations
+
+from .pt.provider import PTQuestionBankProvider
+
+
+class QuestionBankProviderNotConfigured(LookupError):
+    """Raised when a known qualification has no Question Bank provider yet."""
+
+
+_PT_PROVIDER = PTQuestionBankProvider()
+_PROVIDERS = {
+    _PT_PROVIDER.qualification_id: _PT_PROVIDER,
+}
+_KNOWN_QUALIFICATION_IDS = frozenset({"pt", "takken"})
+
+
+def get_question_bank_provider(qualification_id: str):
+    """Return the configured provider without any implicit PT fallback."""
+    qualification_id = str(qualification_id)
+    if qualification_id not in _KNOWN_QUALIFICATION_IDS:
+        raise KeyError(qualification_id)
+    try:
+        return _PROVIDERS[qualification_id]
+    except KeyError as exc:
+        raise QuestionBankProviderNotConfigured(
+            f"Question Bank provider is not configured for qualification: {qualification_id}"
+        ) from exc

--- a/qualifications/provider_registry.py
+++ b/qualifications/provider_registry.py
@@ -7,7 +7,9 @@ PT. Runtime qualification selection is not implemented here.
 
 from __future__ import annotations
 
+from .pt.config import PT
 from .pt.provider import PTQuestionBankProvider
+from .takken.config import TAKKEN
 
 
 class QuestionBankProviderNotConfigured(LookupError):
@@ -16,9 +18,9 @@ class QuestionBankProviderNotConfigured(LookupError):
 
 _PT_PROVIDER = PTQuestionBankProvider()
 _PROVIDERS = {
-    _PT_PROVIDER.qualification_id: _PT_PROVIDER,
+    PT.qualification_id: _PT_PROVIDER,
 }
-_KNOWN_QUALIFICATION_IDS = frozenset({"pt", "takken"})
+_KNOWN_QUALIFICATION_IDS = frozenset({PT.qualification_id, TAKKEN.qualification_id})
 
 
 def get_question_bank_provider(qualification_id: str):

--- a/tests/test_question_bank_provider_registry.py
+++ b/tests/test_question_bank_provider_registry.py
@@ -1,0 +1,36 @@
+"""Regression coverage for explicit qualification-scoped provider lookup."""
+
+import pytest
+
+from qualifications.provider_registry import (
+    QuestionBankProviderNotConfigured,
+    get_question_bank_provider,
+)
+from qualifications.pt.provider import PTQuestionBankProvider
+
+
+def test_pt_provider_is_available_and_stable():
+    first = get_question_bank_provider("pt")
+    second = get_question_bank_provider("pt")
+    assert isinstance(first, PTQuestionBankProvider)
+    assert first is second
+    assert first.qualification_id == "pt"
+
+
+def test_takken_does_not_silently_fall_back_to_pt():
+    with pytest.raises(
+        QuestionBankProviderNotConfigured,
+        match="not configured for qualification: takken",
+    ):
+        get_question_bank_provider("takken")
+
+
+def test_unknown_qualification_fails_closed():
+    with pytest.raises(KeyError):
+        get_question_bank_provider("unknown")
+
+
+def test_lookup_does_not_normalize_or_infer_ids():
+    for value in ("PT", " pt ", ""):
+        with pytest.raises(KeyError):
+            get_question_bank_provider(value)


### PR DESCRIPTION
## Purpose
Add one explicit common lookup point for qualification-scoped Question Bank providers without changing runtime qualification selection.

## Changes
- add `qualifications/provider_registry.py`
  - PT resolves to one stable `PTQuestionBankProvider`
  - known-but-unconfigured Takken fails explicitly
  - unknown qualification IDs fail closed
  - known IDs derive from PT/Takken qualification configs rather than duplicated literals
- add focused regression tests

## Explicitly unchanged
- app / learning runtime wiring
- PT Question Bank data and selector logic
- Takken Question Bank implementation (still absent)
- DB, migrations, sessions, event keys
- Render/environment settings

Base main: `50bf7ad94d6cdbdd9bf3285b7ce2686c28b39ae4`.
