### PR TITLE
refactor: establish common PT Takken qualification package split

### DIFF
--- a/qualifications/bank_provider.py
+++ b/qualifications/bank_provider.py
@@ -1,27 +1,5 @@
-"""Minimal qualification-scoped question-bank provider contract.
+"""Compatibility import for the shared Question Bank provider contract."""
 
-This module defines metadata/data access only. It is intentionally not wired
-into the current PT runtime yet and must stay free of database/network effects.
-"""
+from .common.bank_provider import QuestionBankProvider
 
-from __future__ import annotations
-
-from typing import Protocol
-
-
-class QuestionBankProvider(Protocol):
-    """Smallest shared contract needed to read qualification question data."""
-
-    qualification_id: str
-
-    def question_ids(self) -> tuple[str, ...]:
-        """Return stable question IDs in provider-defined order."""
-
-    def get_question(self, q_id: str) -> dict:
-        """Return the stored question record for one question ID."""
-
-    def get_question_tag(self, q_id: str) -> dict:
-        """Return qualification-specific learning metadata for one question."""
-
-    def get_quiz_question(self, q_id: str) -> dict:
-        """Return the learner-facing assembled quiz question."""
+__all__ = ["QuestionBankProvider"]

--- a/qualifications/base.py
+++ b/qualifications/base.py
@@ -1,11 +1,5 @@
-"""Metadata only: no runtime, storage, or question-bank integration."""
+"""Compatibility import for shared qualification metadata."""
 
-from dataclasses import dataclass
+from .common.base import QualificationConfig
 
-
-@dataclass(frozen=True)
-class QualificationConfig:
-    """Stable qualification identity and its learner-facing name."""
-
-    qualification_id: str
-    display_name: str
+__all__ = ["QualificationConfig"]

--- a/qualifications/common/__init__.py
+++ b/qualifications/common/__init__.py
@@ -1,0 +1,5 @@
+"""Shared qualification infrastructure.
+
+Keep package import side effects minimal; concrete shared contracts live in
+submodules so PT and future qualifications can depend on them safely.
+"""

--- a/qualifications/common/bank_provider.py
+++ b/qualifications/common/bank_provider.py
@@ -1,0 +1,27 @@
+"""Shared qualification-scoped Question Bank provider contract.
+
+This module defines metadata/data access only and stays free of database and
+network side effects.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+
+class QuestionBankProvider(Protocol):
+    """Smallest shared contract needed to read qualification question data."""
+
+    qualification_id: str
+
+    def question_ids(self) -> tuple[str, ...]:
+        """Return stable question IDs in provider-defined order."""
+
+    def get_question(self, q_id: str) -> dict:
+        """Return the stored question record for one question ID."""
+
+    def get_question_tag(self, q_id: str) -> dict:
+        """Return qualification-specific learning metadata for one question."""
+
+    def get_quiz_question(self, q_id: str) -> dict:
+        """Return the learner-facing assembled quiz question."""

--- a/qualifications/common/base.py
+++ b/qualifications/common/base.py
@@ -1,0 +1,11 @@
+"""Shared qualification metadata contract only."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class QualificationConfig:
+    """Stable qualification identity and its learner-facing name."""
+
+    qualification_id: str
+    display_name: str

--- a/qualifications/common/provider_registry.py
+++ b/qualifications/common/provider_registry.py
@@ -1,0 +1,36 @@
+"""Shared qualification-scoped Question Bank provider lookup.
+
+The registry is intentionally explicit: PT is available today, while a known
+qualification without a provider must fail instead of silently falling back to
+PT. Runtime qualification selection is not implemented here.
+"""
+
+from __future__ import annotations
+
+from ..pt.config import PT
+from ..pt.provider import PTQuestionBankProvider
+from ..takken.config import TAKKEN
+
+
+class QuestionBankProviderNotConfigured(LookupError):
+    """Raised when a known qualification has no Question Bank provider yet."""
+
+
+_PT_PROVIDER = PTQuestionBankProvider()
+_PROVIDERS = {
+    PT.qualification_id: _PT_PROVIDER,
+}
+_KNOWN_QUALIFICATION_IDS = frozenset({PT.qualification_id, TAKKEN.qualification_id})
+
+
+def get_question_bank_provider(qualification_id: str):
+    """Return the configured provider without any implicit PT fallback."""
+    qualification_id = str(qualification_id)
+    if qualification_id not in _KNOWN_QUALIFICATION_IDS:
+        raise KeyError(qualification_id)
+    try:
+        return _PROVIDERS[qualification_id]
+    except KeyError as exc:
+        raise QuestionBankProviderNotConfigured(
+            f"Question Bank provider is not configured for qualification: {qualification_id}"
+        ) from exc

--- a/qualifications/provider_registry.py
+++ b/qualifications/provider_registry.py
@@ -1,36 +1,11 @@
-"""Qualification-scoped Question Bank provider lookup.
+"""Compatibility imports for shared qualification provider lookup."""
 
-The registry is intentionally explicit: PT is available today, while a known
-qualification without a provider must fail instead of silently falling back to
-PT. Runtime qualification selection is not implemented here.
-"""
+from .common.provider_registry import (
+    QuestionBankProviderNotConfigured,
+    get_question_bank_provider,
+)
 
-from __future__ import annotations
-
-from .pt.config import PT
-from .pt.provider import PTQuestionBankProvider
-from .takken.config import TAKKEN
-
-
-class QuestionBankProviderNotConfigured(LookupError):
-    """Raised when a known qualification has no Question Bank provider yet."""
-
-
-_PT_PROVIDER = PTQuestionBankProvider()
-_PROVIDERS = {
-    PT.qualification_id: _PT_PROVIDER,
-}
-_KNOWN_QUALIFICATION_IDS = frozenset({PT.qualification_id, TAKKEN.qualification_id})
-
-
-def get_question_bank_provider(qualification_id: str):
-    """Return the configured provider without any implicit PT fallback."""
-    qualification_id = str(qualification_id)
-    if qualification_id not in _KNOWN_QUALIFICATION_IDS:
-        raise KeyError(qualification_id)
-    try:
-        return _PROVIDERS[qualification_id]
-    except KeyError as exc:
-        raise QuestionBankProviderNotConfigured(
-            f"Question Bank provider is not configured for qualification: {qualification_id}"
-        ) from exc
+__all__ = [
+    "QuestionBankProviderNotConfigured",
+    "get_question_bank_provider",
+]

--- a/tests/test_qualification_common_package.py
+++ b/tests/test_qualification_common_package.py
@@ -1,0 +1,34 @@
+"""Compatibility coverage for the common/PT/Takken package split."""
+
+from qualifications.base import QualificationConfig as LegacyQualificationConfig
+from qualifications.bank_provider import QuestionBankProvider as LegacyQuestionBankProvider
+from qualifications.common.base import QualificationConfig
+from qualifications.common.bank_provider import QuestionBankProvider
+from qualifications.common.provider_registry import (
+    QuestionBankProviderNotConfigured,
+    get_question_bank_provider,
+)
+from qualifications.provider_registry import (
+    QuestionBankProviderNotConfigured as LegacyProviderNotConfigured,
+    get_question_bank_provider as legacy_get_question_bank_provider,
+)
+from qualifications.pt.config import PT
+from qualifications.takken.config import TAKKEN
+
+
+def test_common_contracts_preserve_legacy_import_identity():
+    assert LegacyQualificationConfig is QualificationConfig
+    assert LegacyQuestionBankProvider is QuestionBankProvider
+    assert LegacyProviderNotConfigured is QuestionBankProviderNotConfigured
+    assert legacy_get_question_bank_provider is get_question_bank_provider
+
+
+def test_qualification_configs_use_common_config_contract():
+    assert isinstance(PT, QualificationConfig)
+    assert isinstance(TAKKEN, QualificationConfig)
+    assert PT.qualification_id == "pt"
+    assert TAKKEN.qualification_id == "takken"
+
+
+def test_common_registry_keeps_pt_only_provider_behavior():
+    assert get_question_bank_provider("pt").qualification_id == "pt"


### PR DESCRIPTION
## Purpose
Make the qualification package physically reflect the intended common / PT / Takken separation without breaking existing import paths.

## Changes
- add `qualifications/common/`
  - `base.py`: shared `QualificationConfig`
  - `bank_provider.py`: shared Question Bank provider protocol
  - `provider_registry.py`: shared qualification-scoped provider lookup
- keep compatibility shims at the previous root paths:
  - `qualifications/base.py`
  - `qualifications/bank_provider.py`
  - `qualifications/provider_registry.py`
- add focused identity/regression coverage so legacy imports and new common imports resolve to the same objects

## Explicitly unchanged
- PT and Takken config values
- PT Question Bank provider behavior
- learning/selector behavior
- app/runtime qualification selection
- DB, migrations, sessions, event keys
- Render/environment settings

This is a structural boundary step only; it does not move the existing PT runtime or bank data yet.

Base main: `e60b6714fe05f9c55bc6d700f349b62be2921d50`.