### PR TITLE
refactor: point qualification configs at common contract

### DIFF
--- a/qualifications/__init__.py
+++ b/qualifications/__init__.py
@@ -4,7 +4,7 @@ The default describes the legacy PT compatibility contract only. It does not
 select a bank or infer the qualification of stored sessions or database rows.
 """
 
-from .base import QualificationConfig
+from .common.base import QualificationConfig
 from .pt.config import PT
 from .takken.config import TAKKEN
 

--- a/qualifications/pt/config.py
+++ b/qualifications/pt/config.py
@@ -1,5 +1,5 @@
 """PT metadata; the existing bank and runtime remain untouched."""
 
-from ..base import QualificationConfig
+from ..common.base import QualificationConfig
 
 PT = QualificationConfig(qualification_id="pt", display_name="理学療法士")

--- a/qualifications/takken/config.py
+++ b/qualifications/takken/config.py
@@ -1,5 +1,5 @@
 """Define Takken without connecting a bank, session, or database."""
 
-from ..base import QualificationConfig
+from ..common.base import QualificationConfig
 
 TAKKEN = QualificationConfig(qualification_id="takken", display_name="宅地建物取引士")


### PR DESCRIPTION
## Purpose
Finish the first common/PT/Takken package boundary by having the PT and Takken configs depend directly on the shared common contract rather than the legacy compatibility shim.

## Changes
- `qualifications/pt/config.py` imports `QualificationConfig` from `qualifications.common.base`
- `qualifications/takken/config.py` does the same

## Explicitly unchanged
- qualification IDs and display names
- provider behavior
- runtime wiring
- Question Bank data
- DB, migrations, sessions, event keys
- Render/environment settings

Existing common-package regression coverage already checks both configs are instances of the shared contract.

Base main: `bdb097af982809f844097570dbde1822dce7c57b`.