### PR TITLE
feat: add qualification-scoped learning history store boundary

### DIFF
--- a/qualifications/common/learning_store.py
+++ b/qualifications/common/learning_store.py
@@ -1,0 +1,30 @@
+"""Shared contract for qualification-scoped learner history access.
+
+This is an interface only. It does not change the existing database schema or
+runtime storage behavior.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Protocol
+
+
+class LearningHistoryStore(Protocol):
+    """Small read/assessment-state boundary needed before storage is qualified."""
+
+    qualification_id: str
+
+    def get_question_attempts(
+        self, user_id: str, start_at: datetime | None = None
+    ) -> list[dict]:
+        """Return formal per-question attempts for one qualification."""
+
+    def get_question_history(self, user_id: str) -> list[dict]:
+        """Return learner-facing question history for one qualification."""
+
+    def is_initial_assessment_completed(self, user_id: str) -> bool:
+        """Return whether this qualification's initial assessment is complete."""
+
+    def mark_initial_assessment_completed(self, user_id: str) -> None:
+        """Mark this qualification's initial assessment complete."""

--- a/qualifications/common/learning_store_registry.py
+++ b/qualifications/common/learning_store_registry.py
@@ -1,0 +1,31 @@
+"""Explicit lookup for qualification-scoped learner-history stores."""
+
+from __future__ import annotations
+
+from ..pt.config import PT
+from ..pt.learning_store import PTLearningHistoryStore
+from ..takken.config import TAKKEN
+
+
+class LearningHistoryStoreNotConfigured(LookupError):
+    """Raised when a known qualification has no learning-history store yet."""
+
+
+_PT_STORE = PTLearningHistoryStore()
+_STORES = {
+    PT.qualification_id: _PT_STORE,
+}
+_KNOWN_QUALIFICATION_IDS = frozenset({PT.qualification_id, TAKKEN.qualification_id})
+
+
+def get_learning_history_store(qualification_id: str):
+    """Return the configured store without any implicit PT fallback."""
+    qualification_id = str(qualification_id)
+    if qualification_id not in _KNOWN_QUALIFICATION_IDS:
+        raise KeyError(qualification_id)
+    try:
+        return _STORES[qualification_id]
+    except KeyError as exc:
+        raise LearningHistoryStoreNotConfigured(
+            f"Learning history store is not configured for qualification: {qualification_id}"
+        ) from exc

--- a/qualifications/pt/learning_store.py
+++ b/qualifications/pt/learning_store.py
@@ -1,0 +1,33 @@
+"""PT adapter for the existing learner-history persistence API.
+
+This adapter preserves current PT behavior exactly. It does not add database
+columns, change queries, or make Takken share PT history.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import database
+
+from .config import PT
+
+
+class PTLearningHistoryStore:
+    """Expose the legacy PT learning-history API behind a qualification boundary."""
+
+    qualification_id: str = PT.qualification_id
+
+    def get_question_attempts(
+        self, user_id: str, start_at: datetime | None = None
+    ) -> list[dict]:
+        return database.get_question_attempts(user_id, start_at=start_at)
+
+    def get_question_history(self, user_id: str) -> list[dict]:
+        return database.get_question_history(user_id)
+
+    def is_initial_assessment_completed(self, user_id: str) -> bool:
+        return database.is_initial_assessment_completed(user_id)
+
+    def mark_initial_assessment_completed(self, user_id: str) -> None:
+        database.mark_initial_assessment_completed(user_id)

--- a/tests/test_qualification_learning_store.py
+++ b/tests/test_qualification_learning_store.py
@@ -1,0 +1,66 @@
+"""Regression coverage for qualification-scoped learner-history adapters."""
+
+from datetime import datetime, timezone
+
+import pytest
+
+import database
+from qualifications.common.learning_store_registry import (
+    LearningHistoryStoreNotConfigured,
+    get_learning_history_store,
+)
+from qualifications.pt.learning_store import PTLearningHistoryStore
+
+
+NOW = datetime(2026, 9, 11, tzinfo=timezone.utc)
+
+
+def test_pt_learning_store_is_available_and_stable():
+    first = get_learning_history_store("pt")
+    second = get_learning_history_store("pt")
+    assert isinstance(first, PTLearningHistoryStore)
+    assert first is second
+    assert first.qualification_id == "pt"
+
+
+def test_takken_learning_store_is_not_allowed_to_fall_back_to_pt():
+    with pytest.raises(
+        LearningHistoryStoreNotConfigured,
+        match="not configured for qualification: takken",
+    ):
+        get_learning_history_store("takken")
+
+
+def test_unknown_qualification_fails_closed():
+    with pytest.raises(KeyError):
+        get_learning_history_store("unknown")
+
+
+def test_pt_adapter_delegates_question_attempt_reads_exactly(monkeypatch):
+    store = get_learning_history_store("pt")
+    sentinel = [{"question_id": "Q1"}]
+    calls = []
+
+    def fake(user_id, start_at=None):
+        calls.append((user_id, start_at))
+        return sentinel
+
+    monkeypatch.setattr(database, "get_question_attempts", fake)
+    assert store.get_question_attempts("user-1", start_at=NOW) is sentinel
+    assert calls == [("user-1", NOW)]
+
+
+def test_pt_adapter_delegates_history_and_assessment_state(monkeypatch):
+    store = get_learning_history_store("pt")
+    history = [{"question_id": "Q2"}]
+    marked = []
+
+    monkeypatch.setattr(database, "get_question_history", lambda user_id: history)
+    monkeypatch.setattr(database, "is_initial_assessment_completed", lambda user_id: user_id == "done")
+    monkeypatch.setattr(database, "mark_initial_assessment_completed", lambda user_id: marked.append(user_id))
+
+    assert store.get_question_history("user-1") is history
+    assert store.is_initial_assessment_completed("done") is True
+    assert store.is_initial_assessment_completed("not-yet") is False
+    assert store.mark_initial_assessment_completed("user-1") is None
+    assert marked == ["user-1"]


### PR DESCRIPTION
## Purpose
Introduce the first code-only storage boundary needed for PT/Takken coexistence without changing Production schema or runtime behavior.

## Changes
- add `qualifications/common/learning_store.py`
  - shared protocol for attempts/history/initial-assessment state
- add `qualifications/pt/learning_store.py`
  - exact adapter over the existing PT database API
- add `qualifications/common/learning_store_registry.py`
  - PT resolves explicitly
  - Takken is known but unavailable and fails closed
  - unknown qualification IDs fail closed
- add focused delegation/fail-closed regression tests

## Explicitly unchanged
- `database.py`
- Production DB schema/data
- migrations
- app/runtime imports and learner behavior
- sessions/event keys/reset semantics
- Takken storage implementation
- Render/environment settings

This is Phase A of issue #321 only. It deliberately stops before any qualification column/backfill work.

Base main: `71a1f798d37321e05146b165a50890fe0e4f0d17`.