### PR TITLE
refactor: scope PT learning history store by qualification

### DIFF
--- a/qualifications/pt/learning_store.py
+++ b/qualifications/pt/learning_store.py
@@ -1,11 +1,13 @@
-"""PT adapter for the existing learner-history persistence API.
+"""PT adapter for qualification-scoped learner-history persistence.
 
-This adapter preserves current PT behavior exactly. It does not add database
-columns, change queries, or make Takken share PT history.
+Production schema now carries ``qualification_id``. This adapter makes the PT
+boundary explicit while preserving the legacy in-memory fallback used when no
+DATABASE_URL is configured.
 """
 
 from __future__ import annotations
 
+import json
 from datetime import datetime
 
 import database
@@ -14,20 +16,136 @@ from .config import PT
 
 
 class PTLearningHistoryStore:
-    """Expose the legacy PT learning-history API behind a qualification boundary."""
+    """Expose PT learner history without reading another qualification's rows."""
 
     qualification_id: str = PT.qualification_id
 
     def get_question_attempts(
         self, user_id: str, start_at: datetime | None = None
     ) -> list[dict]:
-        return database.get_question_attempts(user_id, start_at=start_at)
+        if not database.database_is_available():
+            return database.get_question_attempts(user_id, start_at=start_at)
+
+        with database.get_db_connection() as conn:
+            with conn.cursor() as cur:
+                if start_at is None:
+                    cur.execute(
+                        """
+                        SELECT event_key, user_id, question_id, knowledge_node_id,
+                               mode, selected_answers, is_correct, confidence,
+                               answered_at, attempt_position
+                        FROM question_attempts
+                        WHERE user_id = %s AND qualification_id = %s
+                        ORDER BY answered_at, event_key, attempt_position
+                        """,
+                        (user_id, self.qualification_id),
+                    )
+                else:
+                    cur.execute(
+                        """
+                        SELECT event_key, user_id, question_id, knowledge_node_id,
+                               mode, selected_answers, is_correct, confidence,
+                               answered_at, attempt_position
+                        FROM question_attempts
+                        WHERE user_id = %s AND qualification_id = %s
+                          AND answered_at >= %s
+                        ORDER BY answered_at, event_key, attempt_position
+                        """,
+                        (user_id, self.qualification_id, start_at),
+                    )
+                columns = (
+                    "event_key", "user_id", "question_id", "knowledge_node_id",
+                    "mode", "selected_answers", "is_correct", "confidence",
+                    "answered_at", "attempt_position",
+                )
+                attempts = [dict(zip(columns, row)) for row in cur.fetchall()]
+
+        for attempt in attempts:
+            attempt["answer_status"] = (
+                "unknown" if not attempt.get("selected_answers") else "answered"
+            )
+        return attempts
 
     def get_question_history(self, user_id: str) -> list[dict]:
-        return database.get_question_history(user_id)
+        if not database.database_is_available():
+            return database.get_question_history(user_id)
+
+        with database.get_db_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT question_results, answered_at
+                    FROM learning_events
+                    WHERE user_id = %s AND qualification_id = %s
+                    ORDER BY answered_at, event_key
+                    """,
+                    (user_id, self.qualification_id),
+                )
+                rows = cur.fetchall()
+
+        history = []
+        for question_results, answered_at in rows:
+            if isinstance(question_results, str):
+                try:
+                    question_results = json.loads(question_results)
+                except json.JSONDecodeError:
+                    continue
+            if not isinstance(question_results, list):
+                continue
+            for result in question_results:
+                if isinstance(result, dict) and result.get("question_id"):
+                    history.append({**result, "timestamp": answered_at})
+        return history
 
     def is_initial_assessment_completed(self, user_id: str) -> bool:
-        return database.is_initial_assessment_completed(user_id)
+        if not database.database_is_available():
+            return database.is_initial_assessment_completed(user_id)
+
+        with database.get_db_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT initial_assessment_completed
+                    FROM qualification_user_state
+                    WHERE user_id = %s AND qualification_id = %s
+                    """,
+                    (user_id, self.qualification_id),
+                )
+                row = cur.fetchone()
+                if row is not None:
+                    return bool(row[0])
+                cur.execute(
+                    """
+                    SELECT EXISTS (
+                        SELECT 1 FROM learning_events
+                        WHERE user_id = %s AND qualification_id = %s
+                          AND answered_count > 0
+                    )
+                    """,
+                    (user_id, self.qualification_id),
+                )
+                evidence = cur.fetchone()
+        return bool(evidence and evidence[0])
 
     def mark_initial_assessment_completed(self, user_id: str) -> None:
+        if not database.database_is_available():
+            database.mark_initial_assessment_completed(user_id)
+            return
+
+        with database.get_db_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    INSERT INTO qualification_user_state (
+                        user_id, qualification_id,
+                        initial_assessment_completed, updated_at
+                    )
+                    VALUES (%s, %s, TRUE, NOW())
+                    ON CONFLICT (user_id, qualification_id) DO UPDATE SET
+                        initial_assessment_completed = TRUE,
+                        updated_at = NOW()
+                    """,
+                    (user_id, self.qualification_id),
+                )
+        # Keep the legacy PT profile flag in sync during the transition period.
         database.mark_initial_assessment_completed(user_id)

--- a/tests/test_qualification_learning_store.py
+++ b/tests/test_qualification_learning_store.py
@@ -15,6 +15,45 @@ from qualifications.pt.learning_store import PTLearningHistoryStore
 NOW = datetime(2026, 9, 11, tzinfo=timezone.utc)
 
 
+class FakeCursor:
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.calls = []
+        self.current = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def execute(self, sql, params=()):
+        self.calls.append((" ".join(sql.split()), params))
+        self.current = self.responses.pop(0) if self.responses else []
+
+    def fetchall(self):
+        return list(self.current or [])
+
+    def fetchone(self):
+        if not self.current:
+            return None
+        return self.current[0]
+
+
+class FakeConnection:
+    def __init__(self, cursor):
+        self._cursor = cursor
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def cursor(self):
+        return self._cursor
+
+
 def test_pt_learning_store_is_available_and_stable():
     first = get_learning_history_store("pt")
     second = get_learning_history_store("pt")
@@ -36,10 +75,12 @@ def test_unknown_qualification_fails_closed():
         get_learning_history_store("unknown")
 
 
-def test_pt_adapter_delegates_question_attempt_reads_exactly(monkeypatch):
+def test_pt_adapter_preserves_legacy_local_fallback(monkeypatch):
     store = get_learning_history_store("pt")
     sentinel = [{"question_id": "Q1"}]
     calls = []
+
+    monkeypatch.setattr(database, "database_is_available", lambda: False)
 
     def fake(user_id, start_at=None):
         calls.append((user_id, start_at))
@@ -50,17 +91,62 @@ def test_pt_adapter_delegates_question_attempt_reads_exactly(monkeypatch):
     assert calls == [("user-1", NOW)]
 
 
-def test_pt_adapter_delegates_history_and_assessment_state(monkeypatch):
+def test_pt_attempt_reads_require_explicit_pt_scope(monkeypatch):
     store = get_learning_history_store("pt")
-    history = [{"question_id": "Q2"}]
-    marked = []
+    row = (
+        "event:1", "user-1", "Q1", "KN0001", "study", [1], True, 1,
+        NOW, 1,
+    )
+    cursor = FakeCursor([[row]])
+    monkeypatch.setattr(database, "database_is_available", lambda: True)
+    monkeypatch.setattr(database, "get_db_connection", lambda: FakeConnection(cursor))
 
-    monkeypatch.setattr(database, "get_question_history", lambda user_id: history)
-    monkeypatch.setattr(database, "is_initial_assessment_completed", lambda user_id: user_id == "done")
-    monkeypatch.setattr(database, "mark_initial_assessment_completed", lambda user_id: marked.append(user_id))
+    attempts = store.get_question_attempts("user-1", start_at=NOW)
 
-    assert store.get_question_history("user-1") is history
-    assert store.is_initial_assessment_completed("done") is True
-    assert store.is_initial_assessment_completed("not-yet") is False
+    assert attempts[0]["question_id"] == "Q1"
+    assert attempts[0]["answer_status"] == "answered"
+    sql, params = cursor.calls[0]
+    assert "qualification_id = %s" in sql
+    assert params == ("user-1", "pt", NOW)
+
+
+def test_pt_history_reads_require_explicit_pt_scope(monkeypatch):
+    store = get_learning_history_store("pt")
+    cursor = FakeCursor([[
+        ([{"question_id": "Q2", "is_correct": False}], NOW),
+    ]])
+    monkeypatch.setattr(database, "database_is_available", lambda: True)
+    monkeypatch.setattr(database, "get_db_connection", lambda: FakeConnection(cursor))
+
+    history = store.get_question_history("user-1")
+
+    assert history == [{"question_id": "Q2", "is_correct": False, "timestamp": NOW}]
+    sql, params = cursor.calls[0]
+    assert "qualification_id = %s" in sql
+    assert params == ("user-1", "pt")
+
+
+def test_pt_assessment_state_reads_and_writes_qualified_row(monkeypatch):
+    store = get_learning_history_store("pt")
+    read_cursor = FakeCursor([[(True,)]])
+    monkeypatch.setattr(database, "database_is_available", lambda: True)
+    monkeypatch.setattr(database, "get_db_connection", lambda: FakeConnection(read_cursor))
+
+    assert store.is_initial_assessment_completed("user-1") is True
+    sql, params = read_cursor.calls[0]
+    assert "qualification_user_state" in sql
+    assert "qualification_id = %s" in sql
+    assert params == ("user-1", "pt")
+
+    write_cursor = FakeCursor([[]])
+    monkeypatch.setattr(database, "get_db_connection", lambda: FakeConnection(write_cursor))
+    legacy_marked = []
+    monkeypatch.setattr(
+        database, "mark_initial_assessment_completed", legacy_marked.append
+    )
+
     assert store.mark_initial_assessment_completed("user-1") is None
-    assert marked == ["user-1"]
+    sql, params = write_cursor.calls[0]
+    assert "qualification_user_state" in sql
+    assert params == ("user-1", "pt")
+    assert legacy_marked == ["user-1"]


### PR DESCRIPTION
## Purpose
Make the PT learning-history adapter use the new Production `qualification_id` boundary explicitly, while preserving the legacy local fallback.

## Changes
- PT question-attempt reads now filter `qualification_id='pt'`
- PT learning-event history reads now filter `qualification_id='pt'`
- PT initial-assessment state now reads/writes `qualification_user_state`
- transition-period dual write keeps the legacy PT profile flag synchronized
- focused tests cover explicit PT SQL scope and local fallback

## Explicitly unchanged
- app/runtime callers are not rewired in this PR
- Takken storage remains unavailable/fail-closed
- no schema or migration changes
- no session/event-key/reset/dashboard changes
- no Question Bank or selector behavior changes

Issue: #321