### PR TITLE
feat: bind production learner history to explicit PT scope

### DIFF
--- a/qualification_history_scope.py
+++ b/qualification_history_scope.py
@@ -1,0 +1,33 @@
+"""Production composition hook for qualification-scoped learner history.
+
+The legacy app imports history functions directly from ``database``. During the
+multi-qualification transition we rebind only those module-local names to the
+explicit PT learning-history store, keeping the existing call sites unchanged.
+"""
+
+from __future__ import annotations
+
+from qualifications.common.learning_store_registry import get_learning_history_store
+
+
+_HISTORY_NAMES = (
+    "get_question_attempts",
+    "get_question_history",
+    "is_initial_assessment_completed",
+    "mark_initial_assessment_completed",
+)
+
+
+def install_pt_learning_history_scope(legacy_module) -> None:
+    """Bind the existing PT learner runtime to explicitly PT-scoped history."""
+    if getattr(legacy_module, "_pt_learning_history_scope_installed", False):
+        return
+
+    store = get_learning_history_store("pt")
+    for name in _HISTORY_NAMES:
+        if not hasattr(legacy_module, name):
+            raise AttributeError(f"legacy learner runtime missing history hook: {name}")
+        setattr(legacy_module, name, getattr(store, name))
+
+    legacy_module._pt_learning_history_store = store
+    legacy_module._pt_learning_history_scope_installed = True

--- a/tests/test_qualification_history_scope.py
+++ b/tests/test_qualification_history_scope.py
@@ -1,0 +1,57 @@
+"""Regression coverage for the production PT history-scope composition hook."""
+
+from types import SimpleNamespace
+
+from qualification_history_scope import install_pt_learning_history_scope
+from qualifications.pt.learning_store import PTLearningHistoryStore
+
+
+NAMES = (
+    "get_question_attempts",
+    "get_question_history",
+    "is_initial_assessment_completed",
+    "mark_initial_assessment_completed",
+)
+
+
+def make_legacy():
+    return SimpleNamespace(**{name: object() for name in NAMES})
+
+
+def test_installer_binds_all_history_hooks_to_one_pt_store():
+    legacy = make_legacy()
+
+    install_pt_learning_history_scope(legacy)
+
+    store = legacy._pt_learning_history_store
+    assert isinstance(store, PTLearningHistoryStore)
+    assert store.qualification_id == "pt"
+    assert legacy._pt_learning_history_scope_installed is True
+    for name in NAMES:
+        bound = getattr(legacy, name)
+        assert bound.__self__ is store
+        assert bound.__func__ is getattr(PTLearningHistoryStore, name)
+
+
+def test_installer_is_idempotent():
+    legacy = make_legacy()
+    install_pt_learning_history_scope(legacy)
+    first_store = legacy._pt_learning_history_store
+    first_hooks = {name: getattr(legacy, name) for name in NAMES}
+
+    install_pt_learning_history_scope(legacy)
+
+    assert legacy._pt_learning_history_store is first_store
+    assert {name: getattr(legacy, name) for name in NAMES} == first_hooks
+
+
+def test_installer_fails_if_legacy_runtime_lacks_required_hook():
+    legacy = make_legacy()
+    delattr(legacy, "get_question_history")
+
+    try:
+        install_pt_learning_history_scope(legacy)
+    except AttributeError as exc:
+        assert "get_question_history" in str(exc)
+    else:
+        raise AssertionError("missing legacy hook must fail closed")

--- a/wsgi.py
+++ b/wsgi.py
@@ -33,6 +33,7 @@ from learning_time_guard import install_learning_time_guard
 from one_question_starter import install_one_question_starter, one_question_quick_reply_item
 from phase11_gate_ui import install_phase11_gate_ui
 from prerequisite_attempt_cache import install_prerequisite_attempt_cache
+from qualification_history_scope import install_pt_learning_history_scope
 from site_beta_copy import install_site_beta_copy
 from site_direct_line_cta import install_site_direct_line_cta
 from site_marketing_hotfix import install_site_marketing_hotfix
@@ -122,6 +123,7 @@ def _apply_rich_menu_v2_if_requested() -> None:
 
 # Registered LINE callbacks resolve these names from the legacy app module at
 # call time, so production behavior can be composed without rewriting app.py.
+install_pt_learning_history_scope(legacy)
 install_durable_paused_sessions(legacy, database_module)
 install_durable_web_learning_sessions(legacy, database_module)
 install_learning_time_guard(legacy, database_module)


### PR DESCRIPTION
## Purpose
Move the live PT learner runtime onto the explicit qualification-scoped history boundary without rewriting legacy app call sites.

## Changes
- add `qualification_history_scope.py` production composition hook
- rebind the legacy app's four history/assessment functions to the PT learning-history store
- install the hook from `wsgi.py` before other learner runtime composition
- add focused idempotency/fail-closed regression tests

## Safety
- PT only; Takken remains unavailable/fail-closed
- no DB schema/migration changes
- no event-key/session format changes
- no Question Bank/selector changes
- existing call-site names stay unchanged

Issue: #321