### PR TITLE
refactor: scope durable PT sessions by qualification

### DIFF
--- a/durable_paused_session.py
+++ b/durable_paused_session.py
@@ -1,9 +1,10 @@
 """Durable storage for paused LINE quiz sessions.
 
-The legacy learner flow intentionally keeps active sessions in memory.  A
-paused session, however, is a user-visible promise ("源さんに預ける") and must
-survive a normal Render process restart.  This production composition layer
-persists only paused snapshots; active sessions remain in memory.
+The legacy learner flow intentionally keeps active sessions in memory. A paused
+session, however, is a user-visible promise ("源さんに預ける") and must survive
+a normal Render process restart. This production composition layer currently
+serves the PT runtime and therefore persists/restores PT-qualified snapshots
+only; Takken runtime remains disabled.
 """
 
 from __future__ import annotations
@@ -18,6 +19,7 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 _TABLE = "paused_quiz_sessions"
+_QUALIFICATION_ID = "pt"
 _local_snapshots: dict[str, dict[str, Any]] = {}
 _local_lock = threading.RLock()
 
@@ -31,8 +33,15 @@ def _json_default(value: Any):
 
 
 def _serializable_snapshot(session: dict[str, Any]) -> dict[str, Any]:
-    """Return a detached JSON-compatible snapshot."""
-    return json.loads(json.dumps(session, ensure_ascii=False, default=_json_default))
+    """Return a detached JSON-compatible PT snapshot."""
+    snapshot = json.loads(json.dumps(session, ensure_ascii=False, default=_json_default))
+    existing = snapshot.get("qualification_id")
+    if existing not in {None, _QUALIFICATION_ID}:
+        raise ValueError(
+            f"paused session qualification mismatch: expected {_QUALIFICATION_ID}, got {existing}"
+        )
+    snapshot["qualification_id"] = _QUALIFICATION_ID
+    return snapshot
 
 
 def _restore_snapshot(payload: Any) -> dict[str, Any] | None:
@@ -43,7 +52,11 @@ def _restore_snapshot(payload: Any) -> dict[str, Any] | None:
             return None
     if not isinstance(payload, dict) or payload.get("status") != "paused":
         return None
+    qualification_id = payload.get("qualification_id", _QUALIFICATION_ID)
+    if qualification_id != _QUALIFICATION_ID:
+        return None
     restored = copy.deepcopy(payload)
+    restored["qualification_id"] = _QUALIFICATION_ID
     answers = restored.get("all_answers")
     if isinstance(answers, dict):
         converted = {}
@@ -59,6 +72,7 @@ def _restore_snapshot(payload: Any) -> dict[str, Any] | None:
 class PausedSessionStore:
     def __init__(self, database_module):
         self.database = database_module
+        self.qualification_id = _QUALIFICATION_ID
 
     def save(self, user_id: str, session: dict[str, Any]) -> bool:
         snapshot = _serializable_snapshot(session)
@@ -71,13 +85,20 @@ class PausedSessionStore:
                 with conn.cursor() as cur:
                     cur.execute(
                         f"""
-                        INSERT INTO {_TABLE} (user_id, session_payload, paused_at)
-                        VALUES (%s, %s::jsonb, NOW())
+                        INSERT INTO {_TABLE} (
+                            user_id, qualification_id, session_payload, paused_at
+                        )
+                        VALUES (%s, %s, %s::jsonb, NOW())
                         ON CONFLICT (user_id) DO UPDATE
-                        SET session_payload = EXCLUDED.session_payload,
+                        SET qualification_id = EXCLUDED.qualification_id,
+                            session_payload = EXCLUDED.session_payload,
                             paused_at = EXCLUDED.paused_at
                         """,
-                        (user_id, json.dumps(snapshot, ensure_ascii=False)),
+                        (
+                            user_id,
+                            self.qualification_id,
+                            json.dumps(snapshot, ensure_ascii=False),
+                        ),
                     )
             return True
         except Exception:
@@ -92,8 +113,11 @@ class PausedSessionStore:
             with self.database.get_db_connection() as conn:
                 with conn.cursor() as cur:
                     cur.execute(
-                        f"SELECT session_payload FROM {_TABLE} WHERE user_id = %s",
-                        (user_id,),
+                        f"""
+                        SELECT session_payload FROM {_TABLE}
+                        WHERE user_id = %s AND qualification_id = %s
+                        """,
+                        (user_id, self.qualification_id),
                     )
                     row = cur.fetchone()
             return _restore_snapshot(row[0]) if row else None
@@ -109,7 +133,13 @@ class PausedSessionStore:
         try:
             with self.database.get_db_connection() as conn:
                 with conn.cursor() as cur:
-                    cur.execute(f"DELETE FROM {_TABLE} WHERE user_id = %s", (user_id,))
+                    cur.execute(
+                        f"""
+                        DELETE FROM {_TABLE}
+                        WHERE user_id = %s AND qualification_id = %s
+                        """,
+                        (user_id, self.qualification_id),
+                    )
             return True
         except Exception:
             logger.exception("paused_session_store delete_failed user_id=%s", user_id)
@@ -117,7 +147,7 @@ class PausedSessionStore:
 
 
 class DurableStudySessions(dict):
-    """Legacy-compatible dict that lazily restores only paused sessions."""
+    """Legacy-compatible dict that lazily restores only paused PT sessions."""
 
     def __init__(self, initial: dict[str, Any], store: PausedSessionStore):
         super().__init__(initial)
@@ -146,8 +176,8 @@ class DurableStudySessions(dict):
         return dict.__contains__(self, user_id)
 
     def __setitem__(self, user_id, session):
-        # Creating/replacing a live session explicitly abandons any old paused
-        # snapshot.  Restoration bypasses this method via dict.__setitem__.
+        # Creating/replacing a live PT session explicitly abandons any old
+        # paused PT snapshot. Restoration bypasses this via dict.__setitem__.
         self.store.delete(user_id)
         dict.__setitem__(self, user_id, session)
 
@@ -157,7 +187,7 @@ class DurableStudySessions(dict):
 
 
 def install_durable_paused_sessions(legacy_module, database_module) -> None:
-    """Compose durable pause/resume behavior onto the legacy learner flow."""
+    """Compose durable PT pause/resume behavior onto the legacy learner flow."""
     if getattr(legacy_module, "_durable_paused_sessions_installed", False):
         return
 

--- a/durable_web_learning_session.py
+++ b/durable_web_learning_session.py
@@ -3,8 +3,8 @@
 The learner-facing Web recommendation flow historically kept every session in
 process memory. A normal Render restart therefore turned an in-progress
 learning URL into a 404 even though the learner's already-confirmed attempts
-were safely stored. This production composition layer persists the small Web
-session snapshot and restores it lazily after a process restart.
+were safely stored. This production composition layer currently serves PT only
+and restores PT-qualified snapshots only; Takken runtime remains disabled.
 """
 
 from __future__ import annotations
@@ -20,12 +20,20 @@ from typing import Any
 logger = logging.getLogger(__name__)
 _TABLE = "web_learning_sessions"
 _RETENTION_DAYS = 7
+_QUALIFICATION_ID = "pt"
 _local_snapshots: dict[str, dict[str, Any]] = {}
 _local_lock = threading.RLock()
 
 
 def _snapshot(session: dict[str, Any]) -> dict[str, Any]:
-    return json.loads(json.dumps(session, ensure_ascii=False))
+    payload = json.loads(json.dumps(session, ensure_ascii=False))
+    existing = payload.get("qualification_id")
+    if existing not in {None, _QUALIFICATION_ID}:
+        raise ValueError(
+            f"web session qualification mismatch: expected {_QUALIFICATION_ID}, got {existing}"
+        )
+    payload["qualification_id"] = _QUALIFICATION_ID
+    return payload
 
 
 def _restore(payload: Any) -> dict[str, Any] | None:
@@ -36,15 +44,21 @@ def _restore(payload: Any) -> dict[str, Any] | None:
             return None
     if not isinstance(payload, dict):
         return None
+    qualification_id = payload.get("qualification_id", _QUALIFICATION_ID)
+    if qualification_id != _QUALIFICATION_ID:
+        return None
     required = {"user_id", "dashboard_token", "question_count", "questions", "current_index"}
     if not required.issubset(payload):
         return None
-    return copy.deepcopy(payload)
+    restored = copy.deepcopy(payload)
+    restored["qualification_id"] = _QUALIFICATION_ID
+    return restored
 
 
 class WebLearningSessionStore:
     def __init__(self, database_module):
         self.database = database_module
+        self.qualification_id = _QUALIFICATION_ID
 
     def save(self, session_id: str, session: dict[str, Any]) -> bool:
         payload = _snapshot(session)
@@ -56,18 +70,32 @@ class WebLearningSessionStore:
             with self.database.get_db_connection() as conn:
                 with conn.cursor() as cur:
                     cur.execute(
-                        f"DELETE FROM {_TABLE} WHERE updated_at < NOW() - INTERVAL '{_RETENTION_DAYS} days'"
+                        f"""
+                        DELETE FROM {_TABLE}
+                        WHERE qualification_id = %s
+                          AND updated_at < NOW() - INTERVAL '{_RETENTION_DAYS} days'
+                        """,
+                        (self.qualification_id,),
                     )
                     cur.execute(
                         f"""
-                        INSERT INTO {_TABLE} (session_id, user_id, session_payload, updated_at)
-                        VALUES (%s, %s, %s::jsonb, NOW())
+                        INSERT INTO {_TABLE} (
+                            session_id, user_id, qualification_id,
+                            session_payload, updated_at
+                        )
+                        VALUES (%s, %s, %s, %s::jsonb, NOW())
                         ON CONFLICT (session_id) DO UPDATE
                         SET user_id = EXCLUDED.user_id,
+                            qualification_id = EXCLUDED.qualification_id,
                             session_payload = EXCLUDED.session_payload,
                             updated_at = EXCLUDED.updated_at
                         """,
-                        (session_id, str(session.get("user_id", "")), json.dumps(payload, ensure_ascii=False)),
+                        (
+                            session_id,
+                            str(session.get("user_id", "")),
+                            self.qualification_id,
+                            json.dumps(payload, ensure_ascii=False),
+                        ),
                     )
             return True
         except Exception:
@@ -85,9 +113,10 @@ class WebLearningSessionStore:
                         f"""
                         SELECT session_payload FROM {_TABLE}
                         WHERE session_id = %s
+                          AND qualification_id = %s
                           AND updated_at >= NOW() - INTERVAL '{_RETENTION_DAYS} days'
                         """,
-                        (session_id,),
+                        (session_id, self.qualification_id),
                     )
                     row = cur.fetchone()
             return _restore(row[0]) if row else None
@@ -109,9 +138,11 @@ class WebLearningSessionStore:
                     cur.execute(
                         f"""
                         SELECT session_id, session_payload FROM {_TABLE}
-                        WHERE updated_at >= NOW() - INTERVAL '{_RETENTION_DAYS} days'
+                        WHERE qualification_id = %s
+                          AND updated_at >= NOW() - INTERVAL '{_RETENTION_DAYS} days'
                         ORDER BY updated_at
-                        """
+                        """,
+                        (self.qualification_id,),
                     )
                     rows = cur.fetchall()
             restored = {}
@@ -132,7 +163,13 @@ class WebLearningSessionStore:
         try:
             with self.database.get_db_connection() as conn:
                 with conn.cursor() as cur:
-                    cur.execute(f"DELETE FROM {_TABLE} WHERE session_id = %s", (session_id,))
+                    cur.execute(
+                        f"""
+                        DELETE FROM {_TABLE}
+                        WHERE session_id = %s AND qualification_id = %s
+                        """,
+                        (session_id, self.qualification_id),
+                    )
             return True
         except Exception:
             logger.exception("web_learning_session delete_failed session_id=%s", session_id)
@@ -187,7 +224,7 @@ class DurableWebLearningSessions(dict):
 
 
 def install_durable_web_learning_sessions(legacy_module, database_module) -> None:
-    """Compose restart-safe Web recommendation sessions onto the Flask app."""
+    """Compose restart-safe PT Web recommendation sessions onto the Flask app."""
     if getattr(legacy_module, "_durable_web_learning_sessions_installed", False):
         return
 

--- a/tests/test_pt_session_qualification_scope.py
+++ b/tests/test_pt_session_qualification_scope.py
@@ -1,0 +1,127 @@
+"""Regression coverage for explicit PT scope in durable session stores."""
+
+import pytest
+
+from durable_paused_session import PausedSessionStore
+from durable_web_learning_session import WebLearningSessionStore
+
+
+class Cursor:
+    def __init__(self, rows=None):
+        self.calls = []
+        self.rows = rows or []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def execute(self, sql, params=()):
+        self.calls.append((" ".join(sql.split()), params))
+
+    def fetchone(self):
+        return self.rows[0] if self.rows else None
+
+    def fetchall(self):
+        return list(self.rows)
+
+
+class Connection:
+    def __init__(self, cursor):
+        self._cursor = cursor
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def cursor(self):
+        return self._cursor
+
+
+class Database:
+    def __init__(self, cursor):
+        self.cursor = cursor
+
+    @staticmethod
+    def database_is_available():
+        return True
+
+    def get_db_connection(self):
+        return Connection(self.cursor)
+
+
+def paused_session(**extra):
+    return {
+        "status": "paused",
+        "all_answers": {},
+        **extra,
+    }
+
+
+def web_session(**extra):
+    return {
+        "user_id": "user-1",
+        "dashboard_token": "token",
+        "question_count": 1,
+        "questions": [{"id": "Q1"}],
+        "current_index": 0,
+        **extra,
+    }
+
+
+def test_paused_store_writes_explicit_pt_scope():
+    cursor = Cursor()
+    store = PausedSessionStore(Database(cursor))
+
+    assert store.save("user-1", paused_session()) is True
+    sql, params = cursor.calls[0]
+    assert "qualification_id" in sql
+    assert params[0:2] == ("user-1", "pt")
+
+
+def test_paused_store_load_and_delete_filter_pt_scope():
+    cursor = Cursor()
+    store = PausedSessionStore(Database(cursor))
+    store.load("user-1")
+    store.delete("user-1")
+
+    load_sql, load_params = cursor.calls[0]
+    delete_sql, delete_params = cursor.calls[1]
+    assert "qualification_id = %s" in load_sql
+    assert load_params == ("user-1", "pt")
+    assert "qualification_id = %s" in delete_sql
+    assert delete_params == ("user-1", "pt")
+
+
+def test_paused_store_rejects_cross_qualification_payload():
+    store = PausedSessionStore(Database(Cursor()))
+    with pytest.raises(ValueError, match="qualification mismatch"):
+        store.save("user-1", paused_session(qualification_id="takken"))
+
+
+def test_web_store_writes_and_reads_explicit_pt_scope():
+    cursor = Cursor()
+    store = WebLearningSessionStore(Database(cursor))
+
+    assert store.save("sid", web_session()) is True
+    cleanup_sql, cleanup_params = cursor.calls[0]
+    insert_sql, insert_params = cursor.calls[1]
+    assert "qualification_id = %s" in cleanup_sql
+    assert cleanup_params == ("pt",)
+    assert "qualification_id" in insert_sql
+    assert insert_params[0:3] == ("sid", "user-1", "pt")
+
+    cursor.calls.clear()
+    store.load("sid")
+    sql, params = cursor.calls[0]
+    assert "qualification_id = %s" in sql
+    assert params == ("sid", "pt")
+
+
+def test_web_store_rejects_cross_qualification_payload():
+    store = WebLearningSessionStore(Database(Cursor()))
+    with pytest.raises(ValueError, match="qualification mismatch"):
+        store.save("sid", web_session(qualification_id="takken"))


### PR DESCRIPTION
## Purpose
Make durable LINE pause/resume and Web learning-session persistence explicitly PT-scoped now that Production tables carry `qualification_id`.

## Changes
- paused LINE snapshots persist/load/delete with `qualification_id='pt'`
- Web learning sessions persist/load/list/delete with `qualification_id='pt'`
- session payloads carry `qualification_id='pt'`
- mismatched qualification payloads fail closed
- legacy snapshots without a payload qualification remain readable as PT during transition
- focused SQL-scope regression tests added

## Explicitly unchanged
- existing DB primary keys remain unchanged in this phase
- Takken runtime remains disabled
- no migration/schema changes
- no question selection/history/event-key changes

Issue: #321