### PR TITLE
feat: scope PT learning time for qualified runtime

### DIFF
--- a/qualification_learning_time_scope.py
+++ b/qualification_learning_time_scope.py
@@ -1,0 +1,70 @@
+"""Production composition for PT-scoped learning-time totals.
+
+The legacy recorder remains authoritative for today's PT runtime and already
+writes ``learning_time_events`` rows that default to ``qualification_id='pt'``.
+This hook mirrors only successful, deduplicated PT time additions into the new
+qualification-scoped totals table so later dashboard/reset cutovers have a
+separate PT authority without breaking the legacy total.
+"""
+
+from __future__ import annotations
+
+import logging
+
+
+logger = logging.getLogger(__name__)
+_QUALIFICATION_ID = "pt"
+
+
+def install_pt_learning_time_scope(legacy_module, database_module) -> None:
+    """Mirror successful legacy PT time additions into scoped PT totals."""
+    if getattr(legacy_module, "_pt_learning_time_scope_installed", False):
+        return
+
+    original_add_learning_time = legacy_module.add_learning_time
+
+    def qualified_add_learning_time(
+        user_id,
+        elapsed_seconds,
+        recorded_at=None,
+        event_key=None,
+    ):
+        result = original_add_learning_time(
+            user_id,
+            elapsed_seconds,
+            recorded_at=recorded_at,
+            event_key=event_key,
+        )
+        if not result or not database_module.database_is_available():
+            return result
+
+        seconds = max(float(elapsed_seconds), 0.0)
+        try:
+            with database_module.get_db_connection() as conn:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        """
+                        INSERT INTO qualification_learning_time_totals (
+                            user_id, qualification_id, total_seconds
+                        ) VALUES (%s, %s, %s)
+                        ON CONFLICT (user_id, qualification_id) DO UPDATE SET
+                            total_seconds =
+                                qualification_learning_time_totals.total_seconds
+                                + EXCLUDED.total_seconds
+                        """,
+                        (user_id, _QUALIFICATION_ID, seconds),
+                    )
+        except Exception:
+            # The learner's already-recorded PT event/time must not be rolled
+            # back by a transitional mirror failure. It can be reconciled from
+            # qualification-tagged learning_time_events.
+            logger.exception(
+                "pt_learning_time_scope mirror_failed user_id=%s event_key=%s",
+                user_id,
+                event_key,
+            )
+        return result
+
+    legacy_module.add_learning_time = qualified_add_learning_time
+    legacy_module._pt_learning_time_scope_original = original_add_learning_time
+    legacy_module._pt_learning_time_scope_installed = True

--- a/tests/test_qualification_learning_time_scope.py
+++ b/tests/test_qualification_learning_time_scope.py
@@ -1,0 +1,88 @@
+"""Regression coverage for PT qualification-scoped learning-time totals."""
+
+from types import SimpleNamespace
+
+from qualification_learning_time_scope import install_pt_learning_time_scope
+
+
+class Cursor:
+    def __init__(self):
+        self.calls = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def execute(self, sql, params=()):
+        self.calls.append((" ".join(sql.split()), params))
+
+
+class Connection:
+    def __init__(self, cursor):
+        self._cursor = cursor
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def cursor(self):
+        return self._cursor
+
+
+def test_successful_pt_time_addition_is_mirrored_once():
+    calls = []
+    legacy = SimpleNamespace(
+        add_learning_time=lambda *args, **kwargs: calls.append((args, kwargs)) or True
+    )
+    cursor = Cursor()
+    database = SimpleNamespace(
+        database_is_available=lambda: True,
+        get_db_connection=lambda: Connection(cursor),
+    )
+
+    install_pt_learning_time_scope(legacy, database)
+    assert legacy.add_learning_time("user-1", 90, event_key="event-1") is True
+
+    assert len(calls) == 1
+    assert len(cursor.calls) == 1
+    sql, params = cursor.calls[0]
+    assert "qualification_learning_time_totals" in sql
+    assert "ON CONFLICT (user_id, qualification_id)" in sql
+    assert params == ("user-1", "pt", 90.0)
+
+
+def test_duplicate_rejected_by_legacy_recorder_is_not_mirrored():
+    legacy = SimpleNamespace(add_learning_time=lambda *args, **kwargs: False)
+    cursor = Cursor()
+    database = SimpleNamespace(
+        database_is_available=lambda: True,
+        get_db_connection=lambda: Connection(cursor),
+    )
+
+    install_pt_learning_time_scope(legacy, database)
+    assert legacy.add_learning_time("user-1", 90, event_key="duplicate") is False
+    assert cursor.calls == []
+
+
+def test_local_fallback_preserves_legacy_result_without_scoped_db_write():
+    sentinel = object()
+    legacy = SimpleNamespace(add_learning_time=lambda *args, **kwargs: sentinel)
+    database = SimpleNamespace(database_is_available=lambda: False)
+
+    install_pt_learning_time_scope(legacy, database)
+    assert legacy.add_learning_time("user-1", 12) is sentinel
+
+
+def test_installer_is_idempotent():
+    legacy = SimpleNamespace(add_learning_time=lambda *args, **kwargs: True)
+    database = SimpleNamespace(database_is_available=lambda: False)
+
+    install_pt_learning_time_scope(legacy, database)
+    first = legacy.add_learning_time
+    install_pt_learning_time_scope(legacy, database)
+
+    assert legacy.add_learning_time is first

--- a/wsgi.py
+++ b/wsgi.py
@@ -34,6 +34,7 @@ from one_question_starter import install_one_question_starter, one_question_quic
 from phase11_gate_ui import install_phase11_gate_ui
 from prerequisite_attempt_cache import install_prerequisite_attempt_cache
 from qualification_history_scope import install_pt_learning_history_scope
+from qualification_learning_time_scope import install_pt_learning_time_scope
 from site_beta_copy import install_site_beta_copy
 from site_direct_line_cta import install_site_direct_line_cta
 from site_marketing_hotfix import install_site_marketing_hotfix
@@ -126,7 +127,8 @@ def _apply_rich_menu_v2_if_requested() -> None:
 install_pt_learning_history_scope(legacy)
 install_durable_paused_sessions(legacy, database_module)
 install_durable_web_learning_sessions(legacy, database_module)
-install_learning_time_guard(legacy, database_module)
+install_pt_learning_time_scope(legacy, database_module)
+install_learning_time_guard(legacy, legacy._pt_learning_history_store)
 install_prerequisite_attempt_cache(legacy)
 install_dashboard_progress_trend(legacy, goukaku_module)
 install_one_question_starter(legacy)


### PR DESCRIPTION
## Purpose
Advance Phase D of #321 by making PT learning-time evidence and totals qualification-scoped without breaking the existing learner-facing total.

## Changes
- add `qualification_learning_time_scope.py`
  - successful, deduplicated legacy PT time additions are mirrored into `qualification_learning_time_totals`
  - legacy `learning_time_totals` remains updated for current dashboard compatibility
- production learning-time guard now reads answer evidence through the already-qualified PT history store
- add focused mirror/dedup/idempotency tests

## Safety
- PT only; Takken remains disabled/fail-closed
- no schema/migration changes
- no event-key format changes
- legacy time total stays authoritative for current UI during transition
- mirror failures do not break study completion and can be reconciled from PT-tagged time events

Issue: #321