### PR TITLE
refactor: scope dashboard formal attempts to PT

### DIFF
--- a/dashboard_read_bundle.py
+++ b/dashboard_read_bundle.py
@@ -1,8 +1,10 @@
 """Read bundle for the learner dashboard.
 
 Production uses one Neon connection for legacy dashboard aggregates, durable
-question attempts, and Trial100 evidence.  This keeps item-12 factual inputs
+question attempts, and Trial100 evidence. This keeps item-12 factual inputs
 consistent without adding another serverless connection just for Trial100.
+The formal attempt portion is explicitly PT-scoped during multi-qualification
+migration; legacy aggregate readers remain unchanged until their own cutover.
 """
 
 from __future__ import annotations
@@ -14,6 +16,7 @@ from recommendation_daily_summary import build_today_recommendation_summary
 from trial100_store import get_trial100_records
 
 
+_QUALIFICATION_ID = "pt"
 _ATTEMPT_COLUMNS = (
     "event_key",
     "user_id",
@@ -36,10 +39,10 @@ def _attempts_with_connection(user_id: str, connection) -> list[dict[str, Any]]:
                    mode, selected_answers, is_correct, confidence,
                    answered_at, attempt_position
             FROM question_attempts
-            WHERE user_id = %s
+            WHERE user_id = %s AND qualification_id = %s
             ORDER BY answered_at, event_key, attempt_position
             """,
-            (user_id,),
+            (user_id, _QUALIFICATION_ID),
         )
         attempts = [dict(zip(_ATTEMPT_COLUMNS, row)) for row in cur.fetchall()]
     for attempt in attempts:

--- a/tests/test_dashboard_read_bundle.py
+++ b/tests/test_dashboard_read_bundle.py
@@ -71,7 +71,7 @@ def test_optional_evidence_reads_are_skipped(monkeypatch):
     assert result["trial100_records"] == []
 
 
-def test_attempt_rows_match_formal_database_shape():
+def test_attempt_rows_match_formal_database_shape_and_pt_scope():
     class Cursor:
         def __enter__(self):
             return self
@@ -81,7 +81,8 @@ def test_attempt_rows_match_formal_database_shape():
 
         def execute(self, sql, params):
             assert "FROM question_attempts" in sql
-            assert params == ("learner",)
+            assert "qualification_id = %s" in sql
+            assert params == ("learner", "pt")
 
         def fetchall(self):
             return [


### PR DESCRIPTION
## Purpose
Continue #321 by ensuring dashboard/navigation formal attempt evidence cannot read another qualification's question attempts.

## Changes
- `dashboard_read_bundle._attempts_with_connection` now requires `qualification_id='pt'`
- learner-navigation and optional dashboard attempt reads therefore stay PT-scoped in Production
- local fallback remains unchanged because local runtime is PT-only
- focused test now asserts the PT qualification predicate and parameters

## Explicitly unchanged
- legacy dashboard summary/activity/field aggregate readers are not yet cut over
- Trial100 behavior unchanged
- no schema/migration changes
- no learner-visible layout/copy changes

Issue: #321