### PR TITLE
refactor: scope dashboard question-result rows to PT

### DIFF
--- a/dashboard_read_bundle.py
+++ b/dashboard_read_bundle.py
@@ -1,10 +1,9 @@
 """Read bundle for the learner dashboard.
 
-Production uses one Neon connection for legacy dashboard aggregates, durable
-question attempts, and Trial100 evidence. This keeps item-12 factual inputs
-consistent without adding another serverless connection just for Trial100.
-The formal attempt portion is explicitly PT-scoped during multi-qualification
-migration; legacy aggregate readers remain unchanged until their own cutover.
+Production uses one Neon connection for dashboard aggregates, durable question
+attempts, and Trial100 evidence. Formal PT evidence reads are qualification-
+scoped during multi-qualification migration; summary/activity SQL remains on
+its legacy path until its own small cutover.
 """
 
 from __future__ import annotations
@@ -50,6 +49,23 @@ def _attempts_with_connection(user_id: str, connection) -> list[dict[str, Any]]:
             "unknown" if not attempt.get("selected_answers") else "answered"
         )
     return attempts
+
+
+def _question_result_rows_with_connection(user_id: str, connection):
+    """Return only PT learning-event question results on the shared connection."""
+    with connection.cursor() as cur:
+        cur.execute(
+            """
+            SELECT question_results, answered_at
+            FROM learning_events
+            WHERE user_id = %s
+              AND qualification_id = %s
+              AND question_results IS NOT NULL
+            ORDER BY answered_at, event_key
+            """,
+            (user_id, _QUALIFICATION_ID),
+        )
+        return cur.fetchall()
 
 
 def get_learner_navigation_read_bundle(user_id: str) -> dict[str, Any]:
@@ -108,7 +124,7 @@ def get_dashboard_read_bundle(
         }
 
     with database.get_db_connection() as conn:
-        question_rows = database._get_question_result_rows(user_id, conn)
+        question_rows = _question_result_rows_with_connection(user_id, conn)
         activity = database.get_learning_activity(user_id, _connection=conn)
         activity.update(
             build_today_recommendation_summary(

--- a/tests/test_dashboard_read_bundle.py
+++ b/tests/test_dashboard_read_bundle.py
@@ -112,6 +112,37 @@ def test_attempt_rows_match_formal_database_shape_and_pt_scope():
     assert attempts[0]["answer_status"] == "unknown"
 
 
+def test_question_result_rows_require_explicit_pt_scope():
+    calls = []
+
+    class Cursor:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def execute(self, sql, params):
+            calls.append((" ".join(sql.split()), params))
+
+        def fetchall(self):
+            return [([{"question_id": "Q1"}], "2026-09-04T00:00:00+00:00")]
+
+    class Connection:
+        def cursor(self):
+            return Cursor()
+
+    rows = dashboard_read_bundle._question_result_rows_with_connection(
+        "learner", Connection()
+    )
+
+    assert rows[0][0][0]["question_id"] == "Q1"
+    sql, params = calls[0]
+    assert "FROM learning_events" in sql
+    assert "qualification_id = %s" in sql
+    assert params == ("learner", "pt")
+
+
 def test_learner_navigation_bundle_shares_one_production_connection(monkeypatch):
     connection_obj = object()
     connection_entries = []


### PR DESCRIPTION
## Purpose
Continue #321 by making dashboard question-result evidence explicitly PT-scoped, so recommendation/field/unique-question calculations cannot consume another qualification's learning events.

## Changes
- add a shared-connection PT-scoped `learning_events` question-result reader in `dashboard_read_bundle.py`
- full dashboard recommendation summary, field summary, and unique-question count now receive only PT question-result rows
- formal attempt reads remain PT-scoped from #328
- add focused regression coverage for the PT qualification predicate

## Explicitly unchanged
- summary/activity aggregate SQL remains on the legacy path for a separate small cutover
- Trial100 behavior unchanged
- no schema/migration changes
- no learner-visible layout/copy changes

Issue: #321