### PR TITLE
refactor: scope dashboard summary and activity to PT

### DIFF
--- a/dashboard_read_bundle.py
+++ b/dashboard_read_bundle.py
@@ -1,14 +1,15 @@
 """Read bundle for the learner dashboard.
 
 Production uses one Neon connection for dashboard aggregates, durable question
-attempts, and Trial100 evidence. Formal PT evidence reads are qualification-
-scoped during multi-qualification migration; summary/activity SQL remains on
-its legacy path until its own small cutover.
+attempts, and Trial100 evidence. PT dashboard reads are explicitly
+qualification-scoped during multi-qualification migration.
 """
 
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
 from typing import Any
+from zoneinfo import ZoneInfo
 
 import database
 from recommendation_daily_summary import build_today_recommendation_summary
@@ -68,12 +69,131 @@ def _question_result_rows_with_connection(user_id: str, connection):
         return cur.fetchall()
 
 
+def _summary_with_connection(
+    user_id: str,
+    connection,
+    *,
+    now: datetime | None = None,
+) -> dict[str, int]:
+    """Return the legacy summary shape using PT-only durable rows."""
+    current = now or datetime.now(timezone.utc)
+    today = current.astimezone(ZoneInfo("Asia/Tokyo")).date()
+    seven_days_ago = current - timedelta(days=7)
+    with connection.cursor() as cur:
+        cur.execute(
+            """
+            SELECT
+                COALESCE(SUM(answered_count), 0),
+                COALESCE(SUM(correct_count), 0),
+                COALESCE(SUM(answered_count) FILTER (WHERE answered_at >= %s), 0),
+                COALESCE(SUM(correct_count) FILTER (WHERE answered_at >= %s), 0),
+                COALESCE(SUM(answered_count) FILTER (
+                    WHERE (answered_at AT TIME ZONE 'Asia/Tokyo')::date = %s
+                ), 0)
+            FROM learning_events
+            WHERE user_id = %s AND qualification_id = %s
+            """,
+            (seven_days_ago, seven_days_ago, today, user_id, _QUALIFICATION_ID),
+        )
+        values = cur.fetchone()
+        cur.execute(
+            """
+            SELECT COALESCE(total_seconds, 0)
+            FROM qualification_learning_time_totals
+            WHERE user_id = %s AND qualification_id = %s
+            """,
+            (user_id, _QUALIFICATION_ID),
+        )
+        row = cur.fetchone()
+    return database._summary_values(*values, row[0] if row else 0)
+
+
+def _activity_with_connection(
+    user_id: str,
+    connection,
+    *,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Return the legacy seven-day activity shape using PT-only durable rows."""
+    current = database._as_utc(now or datetime.now(timezone.utc))
+    jst = ZoneInfo("Asia/Tokyo")
+    today = current.astimezone(jst).date()
+    dates = [today - timedelta(days=offset) for offset in range(6, -1, -1)]
+    answers_by_date = {day: 0 for day in dates}
+    correct_by_date = {day: 0 for day in dates}
+    seconds_by_date = {day: 0.0 for day in dates}
+
+    with connection.cursor() as cur:
+        cur.execute(
+            """
+            SELECT answered_count, correct_count, answered_at
+            FROM learning_events
+            WHERE user_id = %s AND qualification_id = %s
+            """,
+            (user_id, _QUALIFICATION_ID),
+        )
+        learning_rows = cur.fetchall()
+        cur.execute(
+            """
+            SELECT elapsed_seconds, recorded_at
+            FROM learning_time_events
+            WHERE user_id = %s AND qualification_id = %s
+            """,
+            (user_id, _QUALIFICATION_ID),
+        )
+        time_rows = cur.fetchall()
+
+    active_dates = set()
+    for answered_count, correct_count, answered_at in learning_rows:
+        day = database._as_utc(answered_at).astimezone(jst).date()
+        if int(answered_count) > 0:
+            active_dates.add(day)
+        if day in answers_by_date:
+            answers_by_date[day] += int(answered_count)
+            correct_by_date[day] += int(correct_count)
+    for elapsed_seconds, recorded_at in time_rows:
+        day = database._as_utc(recorded_at).astimezone(jst).date()
+        if day in seconds_by_date:
+            seconds_by_date[day] += float(elapsed_seconds)
+
+    streak_days = database.calculate_learning_streak(active_dates, today)
+    daily = [
+        {
+            "date": day.isoformat(),
+            "label": f"{day.month}/{day.day}",
+            "answered_count": answers_by_date[day],
+            "correct_count": correct_by_date[day],
+            "accuracy": (
+                round(correct_by_date[day] / answers_by_date[day] * 100)
+                if answers_by_date[day] else 0
+            ),
+            "study_minutes": round(seconds_by_date[day] / 60),
+        }
+        for day in dates
+    ]
+    weekly_minutes = round(sum(seconds_by_date.values()) / 60)
+    weekly_answers = sum(answers_by_date.values())
+    weekly_correct = sum(correct_by_date.values())
+    return {
+        "daily": daily,
+        "streak_days": streak_days,
+        "weekly_study_minutes": weekly_minutes,
+        "average_daily_study_minutes": round(weekly_minutes / 7),
+        "weekly_learning_days": sum(1 for value in answers_by_date.values() if value > 0),
+        "weekly_answers": weekly_answers,
+        "weekly_correct": weekly_correct,
+        "weekly_accuracy": (
+            round(weekly_correct / weekly_answers * 100) if weekly_answers else 0
+        ),
+    }
+
+
 def get_learner_navigation_read_bundle(user_id: str) -> dict[str, Any]:
     """Return only the formal inputs needed to validate learner navigation.
 
     Production intentionally shares one connection for attempts and Trial100.
-    Unlike the full dashboard bundle, this path does not calculate legacy
-    dashboard aggregates that cannot affect the structured CTA contract.
+    Unlike the full dashboard bundle, this path does not calculate dashboard
+    aggregates that cannot affect the structured CTA contract.
     """
     user_id = str(user_id or "").strip()
     if not user_id:
@@ -125,7 +245,7 @@ def get_dashboard_read_bundle(
 
     with database.get_db_connection() as conn:
         question_rows = _question_result_rows_with_connection(user_id, conn)
-        activity = database.get_learning_activity(user_id, _connection=conn)
+        activity = _activity_with_connection(user_id, conn)
         activity.update(
             build_today_recommendation_summary(
                 user_id,
@@ -134,7 +254,7 @@ def get_dashboard_read_bundle(
             )
         )
         learning_data = {
-            "summary": database.get_learning_summary(user_id, _connection=conn),
+            "summary": _summary_with_connection(user_id, conn),
             "activity": activity,
             "fields": database.get_field_learning_summary(
                 user_id,

--- a/tests/test_dashboard_read_bundle.py
+++ b/tests/test_dashboard_read_bundle.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
+
 import dashboard_read_bundle
 
 
@@ -141,6 +143,79 @@ def test_question_result_rows_require_explicit_pt_scope():
     assert "FROM learning_events" in sql
     assert "qualification_id = %s" in sql
     assert params == ("learner", "pt")
+
+
+def test_summary_reads_only_pt_events_and_pt_time_total():
+    calls = []
+    fetches = iter([(5, 4, 3, 2, 1), (600,)])
+
+    class Cursor:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def execute(self, sql, params):
+            calls.append((" ".join(sql.split()), params))
+
+        def fetchone(self):
+            return next(fetches)
+
+    class Connection:
+        def cursor(self):
+            return Cursor()
+
+    result = dashboard_read_bundle._summary_with_connection(
+        "learner",
+        Connection(),
+        now=datetime(2026, 9, 12, tzinfo=timezone.utc),
+    )
+
+    assert result["total_answers"] == 5
+    assert result["study_minutes"] == 10
+    assert "FROM learning_events" in calls[0][0]
+    assert "qualification_id = %s" in calls[0][0]
+    assert calls[0][1][-2:] == ("learner", "pt")
+    assert "FROM qualification_learning_time_totals" in calls[1][0]
+    assert calls[1][1] == ("learner", "pt")
+
+
+def test_activity_reads_only_pt_events_and_pt_time_events():
+    calls = []
+    now = datetime(2026, 9, 12, 0, 0, tzinfo=timezone.utc)
+    answered_at = now - timedelta(days=1)
+    result_sets = iter([
+        [(2, 1, answered_at)],
+        [(300.0, answered_at)],
+    ])
+
+    class Cursor:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def execute(self, sql, params):
+            calls.append((" ".join(sql.split()), params))
+
+        def fetchall(self):
+            return next(result_sets)
+
+    class Connection:
+        def cursor(self):
+            return Cursor()
+
+    result = dashboard_read_bundle._activity_with_connection(
+        "learner", Connection(), now=now
+    )
+
+    assert result["weekly_answers"] == 2
+    assert result["weekly_correct"] == 1
+    assert result["weekly_study_minutes"] == 5
+    assert all("qualification_id = %s" in sql for sql, _ in calls)
+    assert all(params == ("learner", "pt") for _, params in calls)
 
 
 def test_learner_navigation_bundle_shares_one_production_connection(monkeypatch):


### PR DESCRIPTION
## Purpose
Continue #321 by making the remaining learner-dashboard summary/activity reads explicitly PT-scoped.

## Changes
- dashboard summary reads only `learning_events.qualification_id='pt'`
- dashboard study-time total reads `qualification_learning_time_totals` for PT
- seven-day activity reads only PT `learning_events` and `learning_time_events`
- local fallback remains unchanged
- focused regression tests cover all PT predicates

## Explicitly unchanged
- no schema/migration changes
- no Question Bank/selector/session format changes
- no learner-visible layout/copy changes
- Takken remains disabled/fail-closed

Issue: #321