### PR TITLE
feat: add qualification-scoped PT reset boundary

### DIFF
--- a/qualifications/common/learning_store.py
+++ b/qualifications/common/learning_store.py
@@ -1,7 +1,7 @@
 """Shared contract for qualification-scoped learner history access.
 
-This is an interface only. It does not change the existing database schema or
-runtime storage behavior.
+This interface keeps qualification identity explicit and does not select another
+qualification implicitly.
 """
 
 from __future__ import annotations
@@ -11,7 +11,7 @@ from typing import Protocol
 
 
 class LearningHistoryStore(Protocol):
-    """Small read/assessment-state boundary needed before storage is qualified."""
+    """Qualification-scoped learner history and state boundary."""
 
     qualification_id: str
 
@@ -28,3 +28,6 @@ class LearningHistoryStore(Protocol):
 
     def mark_initial_assessment_completed(self, user_id: str) -> None:
         """Mark this qualification's initial assessment complete."""
+
+    def reset_qualification_state(self, user_id: str) -> None:
+        """Clear learning state for this qualification without deleting the account."""

--- a/qualifications/pt/learning_store.py
+++ b/qualifications/pt/learning_store.py
@@ -1,6 +1,6 @@
 """PT adapter for qualification-scoped learner-history persistence.
 
-Production schema now carries ``qualification_id``. This adapter makes the PT
+Production schema carries ``qualification_id``. This adapter makes the PT
 boundary explicit while preserving the legacy in-memory fallback used when no
 DATABASE_URL is configured.
 """
@@ -149,3 +149,59 @@ class PTLearningHistoryStore:
                 )
         # Keep the legacy PT profile flag in sync during the transition period.
         database.mark_initial_assessment_completed(user_id)
+
+    def reset_qualification_state(self, user_id: str) -> None:
+        """Clear PT learning state while preserving account/profile identity."""
+        if not database.database_is_available():
+            for event_key in [
+                key for key, event in database._local_learning_events.items()
+                if event.get("user_id") == user_id
+            ]:
+                database._local_learning_events.pop(event_key, None)
+            database._local_learning_seconds.pop(user_id, None)
+            database._local_learning_time_events[:] = [
+                event for event in database._local_learning_time_events
+                if event.get("user_id") != user_id
+            ]
+            database._local_question_attempts[:] = [
+                attempt for attempt in database._local_question_attempts
+                if attempt.get("user_id") != user_id
+            ]
+            for state_key in [
+                key for key in database._local_user_node_states if key[0] == user_id
+            ]:
+                database._local_user_node_states.pop(state_key, None)
+            database._local_initial_assessment_completed.discard(user_id)
+            return
+
+        qualified_tables = (
+            "question_attempts",
+            "user_node_state",
+            "learning_events",
+            "learning_time_events",
+            "qualification_learning_time_totals",
+            "qualification_user_state",
+            "paused_quiz_sessions",
+            "web_learning_sessions",
+        )
+        with database.get_db_connection() as conn:
+            with conn.cursor() as cur:
+                for table in qualified_tables:
+                    cur.execute(
+                        f"DELETE FROM {table} WHERE user_id = %s AND qualification_id = %s",
+                        (user_id, self.qualification_id),
+                    )
+                # These legacy fields are PT-only compatibility state during the
+                # migration; preserve the profile/name/mode and monitor access.
+                cur.execute(
+                    "DELETE FROM learning_time_totals WHERE user_id = %s",
+                    (user_id,),
+                )
+                cur.execute(
+                    """
+                    UPDATE user_profiles
+                    SET initial_assessment_completed = FALSE, updated_at = NOW()
+                    WHERE user_id = %s
+                    """,
+                    (user_id,),
+                )

--- a/tests/test_pt_qualification_reset.py
+++ b/tests/test_pt_qualification_reset.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import database
+from qualifications.pt.learning_store import PTLearningHistoryStore
+
+
+class FakeCursor:
+    def __init__(self):
+        self.calls = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def execute(self, sql, params=()):
+        self.calls.append((" ".join(sql.split()), params))
+
+
+class FakeConnection:
+    def __init__(self, cursor):
+        self._cursor = cursor
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def cursor(self):
+        return self._cursor
+
+
+def test_pt_reset_deletes_only_qualified_learning_state_in_production(monkeypatch):
+    store = PTLearningHistoryStore()
+    cursor = FakeCursor()
+    monkeypatch.setattr(database, "database_is_available", lambda: True)
+    monkeypatch.setattr(database, "get_db_connection", lambda: FakeConnection(cursor))
+
+    store.reset_qualification_state("user-1")
+
+    qualified_tables = {
+        "question_attempts",
+        "user_node_state",
+        "learning_events",
+        "learning_time_events",
+        "qualification_learning_time_totals",
+        "qualification_user_state",
+        "paused_quiz_sessions",
+        "web_learning_sessions",
+    }
+    qualified_calls = cursor.calls[: len(qualified_tables)]
+    assert len(qualified_calls) == len(qualified_tables)
+    assert all("qualification_id = %s" in sql for sql, _ in qualified_calls)
+    assert all(params == ("user-1", "pt") for _, params in qualified_calls)
+    assert {
+        next(table for table in qualified_tables if f"FROM {table}" in sql)
+        for sql, _ in qualified_calls
+    } == qualified_tables
+
+    assert cursor.calls[-2] == (
+        "DELETE FROM learning_time_totals WHERE user_id = %s",
+        ("user-1",),
+    )
+    profile_sql, profile_params = cursor.calls[-1]
+    assert profile_sql.startswith("UPDATE user_profiles SET initial_assessment_completed = FALSE")
+    assert profile_params == ("user-1",)
+    assert not any("DELETE FROM user_profiles" in sql for sql, _ in cursor.calls)
+
+
+def test_pt_reset_local_fallback_clears_learning_state_only(monkeypatch):
+    store = PTLearningHistoryStore()
+    monkeypatch.setattr(database, "database_is_available", lambda: False)
+    monkeypatch.setattr(
+        database,
+        "_local_learning_events",
+        {"event": {"user_id": "user-1"}, "other": {"user_id": "other"}},
+    )
+    monkeypatch.setattr(database, "_local_learning_seconds", {"user-1": 120, "other": 60})
+    monkeypatch.setattr(
+        database,
+        "_local_learning_time_events",
+        [{"user_id": "user-1"}, {"user_id": "other"}],
+    )
+    monkeypatch.setattr(
+        database,
+        "_local_question_attempts",
+        [{"user_id": "user-1"}, {"user_id": "other"}],
+    )
+    monkeypatch.setattr(
+        database,
+        "_local_user_node_states",
+        {("user-1", "KN1"): {}, ("other", "KN2"): {}},
+    )
+    monkeypatch.setattr(
+        database,
+        "_local_initial_assessment_completed",
+        {"user-1", "other"},
+    )
+
+    store.reset_qualification_state("user-1")
+
+    assert list(database._local_learning_events) == ["other"]
+    assert database._local_learning_seconds == {"other": 60}
+    assert database._local_learning_time_events == [{"user_id": "other"}]
+    assert database._local_question_attempts == [{"user_id": "other"}]
+    assert database._local_user_node_states == {("other", "KN2"): {}}
+    assert database._local_initial_assessment_completed == {"other"}


### PR DESCRIPTION
## Purpose
Continue Phase D of #321 by defining a qualification-scoped reset operation before changing the live reset command.

## Changes
- extend the common learning-history contract with `reset_qualification_state`
- PT reset deletes only PT-qualified learning/session/time state
- PT reset preserves the account/profile row, name/mode, and monitor access
- transition-only PT compatibility state (`learning_time_totals`, legacy assessment flag) is synchronized to cleared state
- local PT-only fallback clears learning state without deleting account identity
- focused regression coverage added

## Explicitly unchanged
- live `ふりだしにもどる` call site is NOT rewired in this PR
- no schema/migration changes
- Takken remains unavailable/fail-closed
- no Question Bank/selector changes

Issue: #321