### PR TITLE
refactor: scope dashboard side-route history to PT

### DIFF
--- a/qualification_dashboard_scope.py
+++ b/qualification_dashboard_scope.py
@@ -1,0 +1,106 @@
+"""Qualification-scoped composition for dashboard side routes.
+
+The main dashboard bundle is already explicitly PT-scoped in Production. This
+module closes the remaining direct legacy reads used by footprints and the
+supporter weekly-question page without changing their public route contracts.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
+
+from qualifications.common.learning_store_registry import get_learning_history_store
+
+
+def _ordered_question_ids(values):
+    def key(value):
+        text = str(value)
+        return (
+            int(text[1:]) if text.startswith("Q") and text[1:].isdigit() else 10**9,
+            text,
+        )
+
+    return sorted(values, key=key)
+
+
+def _is_unknown_attempt(item):
+    return (
+        item.get("answer_status") == "unknown"
+        or (not item.get("selected_answers") and item.get("confidence") is None)
+    )
+
+
+def build_pt_weekly_question_history(
+    user_id: str,
+    *,
+    now: datetime | None = None,
+    store=None,
+):
+    """Return the existing weekly-question shape from PT-only formal attempts."""
+    history_store = store or get_learning_history_store("pt")
+    jst = ZoneInfo("Asia/Tokyo")
+    current = now or datetime.now(timezone.utc)
+    if current.tzinfo is None:
+        current = current.replace(tzinfo=timezone.utc)
+    end_date = current.astimezone(jst).date()
+    start_date = end_date - timedelta(days=6)
+    start_at = datetime.combine(start_date, datetime.min.time(), jst).astimezone(timezone.utc)
+    end_at = datetime.combine(
+        end_date + timedelta(days=1), datetime.min.time(), jst
+    ).astimezone(timezone.utc)
+
+    attempts = [
+        item
+        for item in history_store.get_question_attempts(user_id, start_at=start_at)
+        if item.get("answered_at") is not None
+        and (
+            item["answered_at"].replace(tzinfo=timezone.utc)
+            if item["answered_at"].tzinfo is None
+            else item["answered_at"].astimezone(timezone.utc)
+        ) < end_at
+    ]
+    attempted = {str(item.get("question_id")) for item in attempts}
+    wrong = {
+        str(item.get("question_id"))
+        for item in attempts
+        if item.get("is_correct") is False and not _is_unknown_attempt(item)
+    }
+    unknown = {
+        str(item.get("question_id"))
+        for item in attempts
+        if _is_unknown_attempt(item)
+    }
+    confident_wrong = {
+        str(item.get("question_id"))
+        for item in attempts
+        if item.get("is_correct") is False
+        and item.get("confidence") == 1
+        and not _is_unknown_attempt(item)
+    }
+    return {
+        "start_date": start_date,
+        "end_date": end_date,
+        "total_attempts": len(attempts),
+        "unique_questions": len(attempted),
+        "attempted_question_ids": _ordered_question_ids(attempted),
+        "wrong_question_ids": _ordered_question_ids(wrong),
+        "unknown_question_ids": _ordered_question_ids(unknown),
+        "confident_wrong_question_ids": _ordered_question_ids(confident_wrong),
+    }
+
+
+def install_pt_dashboard_history_scope(goukaku_module) -> None:
+    """Bind direct dashboard history helpers to the explicit PT store once."""
+    if getattr(goukaku_module, "_pt_dashboard_history_scope_installed", False):
+        return
+
+    store = get_learning_history_store("pt")
+    goukaku_module.get_question_attempts = store.get_question_attempts
+    goukaku_module.get_weekly_question_history = (
+        lambda user_id, now=None: build_pt_weekly_question_history(
+            user_id, now=now, store=store
+        )
+    )
+    goukaku_module._pt_dashboard_history_store = store
+    goukaku_module._pt_dashboard_history_scope_installed = True

--- a/tests/test_qualification_dashboard_scope.py
+++ b/tests/test_qualification_dashboard_scope.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+from qualification_dashboard_scope import (
+    build_pt_weekly_question_history,
+    install_pt_dashboard_history_scope,
+)
+from qualifications.common.learning_store_registry import get_learning_history_store
+
+
+NOW = datetime(2026, 9, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def test_weekly_history_uses_pt_store_and_preserves_shape():
+    calls = []
+
+    class Store:
+        def get_question_attempts(self, user_id, start_at=None):
+            calls.append((user_id, start_at))
+            return [
+                {
+                    "question_id": "Q10",
+                    "selected_answers": [1],
+                    "is_correct": False,
+                    "confidence": 1,
+                    "answered_at": NOW,
+                },
+                {
+                    "question_id": "Q2",
+                    "selected_answers": [],
+                    "is_correct": False,
+                    "confidence": None,
+                    "answer_status": "unknown",
+                    "answered_at": NOW,
+                },
+            ]
+
+    result = build_pt_weekly_question_history(
+        "learner", now=NOW, store=Store()
+    )
+
+    assert calls and calls[0][0] == "learner"
+    assert result["total_attempts"] == 2
+    assert result["unique_questions"] == 2
+    assert result["attempted_question_ids"] == ["Q2", "Q10"]
+    assert result["wrong_question_ids"] == ["Q10"]
+    assert result["unknown_question_ids"] == ["Q2"]
+    assert result["confident_wrong_question_ids"] == ["Q10"]
+
+
+def test_install_rebinds_only_dashboard_history_helpers_and_is_idempotent():
+    legacy_attempts = lambda user_id: ["legacy"]
+    legacy_weekly = lambda user_id: {"legacy": True}
+    module = SimpleNamespace(
+        get_question_attempts=legacy_attempts,
+        get_weekly_question_history=legacy_weekly,
+    )
+
+    install_pt_dashboard_history_scope(module)
+    first_attempts = module.get_question_attempts
+    first_weekly = module.get_weekly_question_history
+
+    store = get_learning_history_store("pt")
+    assert first_attempts.__self__ is store
+    assert module._pt_dashboard_history_store is store
+
+    install_pt_dashboard_history_scope(module)
+    assert module.get_question_attempts is first_attempts
+    assert module.get_weekly_question_history is first_weekly

--- a/wsgi.py
+++ b/wsgi.py
@@ -33,6 +33,7 @@ from learning_time_guard import install_learning_time_guard
 from one_question_starter import install_one_question_starter, one_question_quick_reply_item
 from phase11_gate_ui import install_phase11_gate_ui
 from prerequisite_attempt_cache import install_prerequisite_attempt_cache
+from qualification_dashboard_scope import install_pt_dashboard_history_scope
 from qualification_history_scope import install_pt_learning_history_scope
 from qualification_learning_time_scope import install_pt_learning_time_scope
 from site_beta_copy import install_site_beta_copy
@@ -125,6 +126,7 @@ def _apply_rich_menu_v2_if_requested() -> None:
 # Registered LINE callbacks resolve these names from the legacy app module at
 # call time, so production behavior can be composed without rewriting app.py.
 install_pt_learning_history_scope(legacy)
+install_pt_dashboard_history_scope(goukaku_module)
 install_durable_paused_sessions(legacy, database_module)
 install_durable_web_learning_sessions(legacy, database_module)
 install_pt_learning_time_scope(legacy, database_module)


### PR DESCRIPTION
## Purpose
Continue #321 by closing the remaining direct PT dashboard history reads outside the main read bundle.

## Changes
- add PT-scoped dashboard history composition
- `footprints` direct attempt reads now resolve through the PT learning-history store
- supporter weekly-question history is rebuilt from PT-only attempts while preserving the existing return shape
- install the composition from `wsgi.py`
- add focused idempotency/shape tests

## Explicitly unchanged
- no schema/migration changes
- no Question Bank/selector changes
- no route URLs or learner-visible copy changes
- Takken remains disabled/fail-closed

Issue: #321