### PR TITLE
db: add qualification-aware conflict keys phase2a

### DIFF
--- a/migrations/20260912_qualification_scope_unique_keys_phase2a.sql
+++ b/migrations/20260912_qualification_scope_unique_keys_phase2a.sql
@@ -1,0 +1,30 @@
+-- Phase 2a: add qualification-aware uniqueness alongside legacy conflict keys.
+--
+-- This migration is intentionally additive. It does NOT drop or replace any
+-- existing primary/unique constraint, so current PT runtime conflict targets
+-- remain valid. A later code cutover can start using these qualified targets;
+-- only after that may a separate migration remove legacy global uniqueness.
+
+ALTER TABLE learning_events
+    ADD CONSTRAINT learning_events_qualification_event_key_key
+    UNIQUE (qualification_id, event_key);
+
+ALTER TABLE question_attempts
+    ADD CONSTRAINT question_attempts_qualification_event_position_key
+    UNIQUE (qualification_id, event_key, attempt_position);
+
+ALTER TABLE user_node_state
+    ADD CONSTRAINT user_node_state_qualification_user_node_key
+    UNIQUE (qualification_id, user_id, knowledge_node_id);
+
+CREATE UNIQUE INDEX learning_time_events_qualification_event_key_idx
+    ON learning_time_events (qualification_id, event_key)
+    WHERE event_key IS NOT NULL;
+
+ALTER TABLE paused_quiz_sessions
+    ADD CONSTRAINT paused_quiz_sessions_qualification_user_key
+    UNIQUE (qualification_id, user_id);
+
+ALTER TABLE web_learning_sessions
+    ADD CONSTRAINT web_learning_sessions_qualification_session_key
+    UNIQUE (qualification_id, session_id);


### PR DESCRIPTION
## Purpose
Prepare the next safe multi-qualification storage step from #321 without removing any legacy conflict target.

## Changes
- add qualified uniqueness for learning event keys
- add qualified event-position uniqueness for question attempts
- add qualified user/node uniqueness for Knowledge Node state
- add qualified learning-time event-key uniqueness
- add qualified paused-session user uniqueness
- add qualified Web session identity uniqueness

## Safety
- additive only: all existing global PK/UNIQUE constraints remain
- current PT `ON CONFLICT` targets remain valid
- no Production migration is auto-applied by this PR
- migration was applied successfully on a Neon temporary branch and existing row counts remained unchanged, with all current rows still `pt`
- Takken runtime remains disabled

Issue: #321