### PR TITLE
feat: add dormant PT qualification-explicit learning writer

### DIFF
--- a/qualifications/pt/learning_writer.py
+++ b/qualifications/pt/learning_writer.py
@@ -175,7 +175,12 @@ class PTLearningWriter:
     ) -> bool:
         """Persist a PT non-answer activity using the same daily key contract."""
         timestamp = occurred_at or datetime.now(timezone.utc)
-        jst_date = timestamp.astimezone(ZoneInfo("Asia/Tokyo")).date().isoformat()
+        jst_date = (
+            database._as_utc(timestamp)
+            .astimezone(ZoneInfo("Asia/Tokyo"))
+            .date()
+            .isoformat()
+        )
         user_hash = hashlib.sha256(user_id.encode("utf-8")).hexdigest()[:16]
         activity_metadata = {"activity_type": activity_type}
         if metadata:

--- a/qualifications/pt/learning_writer.py
+++ b/qualifications/pt/learning_writer.py
@@ -1,0 +1,191 @@
+"""Qualification-explicit PT learning-event writer.
+
+This writer is intentionally not installed into the live runtime yet. Production
+activation requires the Phase-2a qualification-aware unique targets to exist
+first. Keeping it dormant lets the SQL contract be reviewed and tested without
+changing current PT behavior.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from typing import Any
+from zoneinfo import ZoneInfo
+
+import database
+
+from .config import PT
+
+
+class PTLearningWriter:
+    """Persist PT learning facts with qualification identity on every write."""
+
+    qualification_id: str = PT.qualification_id
+
+    def record_learning_batch(
+        self,
+        user_id: str,
+        event_key: str,
+        mode: str,
+        answered_count: int,
+        correct_count: int,
+        answered_at: datetime | None = None,
+        question_results: list[dict[str, Any]] | dict[str, Any] | None = None,
+    ) -> bool:
+        if not database.database_is_available():
+            return database.record_learning_batch(
+                user_id=user_id,
+                event_key=event_key,
+                mode=mode,
+                answered_count=answered_count,
+                correct_count=correct_count,
+                answered_at=answered_at,
+                question_results=question_results,
+            )
+
+        timestamp = answered_at or datetime.now(timezone.utc)
+        attempts = database._result_attempts(question_results)
+        encoded_results = (
+            json.dumps(question_results, ensure_ascii=False)
+            if question_results is not None
+            else None
+        )
+
+        with database.get_db_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    INSERT INTO learning_events (
+                        qualification_id, event_key, user_id, mode,
+                        answered_count, correct_count, answered_at, question_results
+                    ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s::jsonb)
+                    ON CONFLICT (qualification_id, event_key) DO NOTHING
+                    """,
+                    (
+                        self.qualification_id,
+                        event_key,
+                        user_id,
+                        mode,
+                        answered_count,
+                        correct_count,
+                        timestamp,
+                        encoded_results,
+                    ),
+                )
+                if cur.rowcount != 1:
+                    return False
+
+                for attempt_position, result in attempts:
+                    cur.execute(
+                        """
+                        INSERT INTO question_attempts (
+                            qualification_id, event_key, user_id, question_id,
+                            knowledge_node_id, mode, selected_answers, is_correct,
+                            confidence, answered_at, attempt_position
+                        ) VALUES (
+                            %s, %s, %s, %s, %s, %s, %s::jsonb, %s, %s, %s, %s
+                        )
+                        """,
+                        (
+                            self.qualification_id,
+                            event_key,
+                            user_id,
+                            result["question_id"],
+                            result["knowledge_node_id"],
+                            mode,
+                            json.dumps(
+                                result.get("selected_answers", []), ensure_ascii=False
+                            ),
+                            bool(result.get("is_correct")),
+                            result.get("confidence"),
+                            timestamp,
+                            attempt_position,
+                        ),
+                    )
+
+                    is_correct = bool(result.get("is_correct"))
+                    confident_wrong = int(
+                        not is_correct and result.get("confidence") == 1
+                    )
+                    cur.execute(
+                        """
+                        INSERT INTO user_node_state (
+                            qualification_id, user_id, knowledge_node_id, state,
+                            attempt_count, correct_count, incorrect_count,
+                            confident_wrong_count, consecutive_correct,
+                            first_seen_at, last_seen_at, last_correct_at,
+                            last_incorrect_at, last_question_id, updated_at
+                        ) VALUES (
+                            %s, %s, %s, %s, 1, %s, %s, %s, %s, %s, %s,
+                            %s, %s, %s, NOW()
+                        )
+                        ON CONFLICT (
+                            qualification_id, user_id, knowledge_node_id
+                        ) DO UPDATE SET
+                            state = CASE
+                                WHEN EXCLUDED.incorrect_count = 1 THEN 'repairing'
+                                ELSE user_node_state.state
+                            END,
+                            attempt_count = user_node_state.attempt_count + 1,
+                            correct_count = user_node_state.correct_count + EXCLUDED.correct_count,
+                            incorrect_count = user_node_state.incorrect_count + EXCLUDED.incorrect_count,
+                            confident_wrong_count = user_node_state.confident_wrong_count + EXCLUDED.confident_wrong_count,
+                            consecutive_correct = CASE
+                                WHEN EXCLUDED.incorrect_count = 1 THEN 0
+                                ELSE user_node_state.consecutive_correct + 1
+                            END,
+                            last_seen_at = EXCLUDED.last_seen_at,
+                            last_correct_at = COALESCE(
+                                EXCLUDED.last_correct_at,
+                                user_node_state.last_correct_at
+                            ),
+                            last_incorrect_at = COALESCE(
+                                EXCLUDED.last_incorrect_at,
+                                user_node_state.last_incorrect_at
+                            ),
+                            last_question_id = EXCLUDED.last_question_id,
+                            updated_at = NOW()
+                        """,
+                        (
+                            self.qualification_id,
+                            user_id,
+                            result["knowledge_node_id"],
+                            "checking" if is_correct else "repairing",
+                            int(is_correct),
+                            int(not is_correct),
+                            confident_wrong,
+                            int(is_correct),
+                            timestamp,
+                            timestamp,
+                            timestamp if is_correct else None,
+                            timestamp if not is_correct else None,
+                            result["question_id"],
+                        ),
+                    )
+        return True
+
+    def record_activity_event(
+        self,
+        user_id: str,
+        activity_type: str,
+        metadata: dict[str, Any] | None = None,
+        occurred_at: datetime | None = None,
+    ) -> bool:
+        """Persist a PT non-answer activity using the same daily key contract."""
+        timestamp = occurred_at or datetime.now(timezone.utc)
+        jst_date = timestamp.astimezone(ZoneInfo("Asia/Tokyo")).date().isoformat()
+        user_hash = hashlib.sha256(user_id.encode("utf-8")).hexdigest()[:16]
+        activity_metadata = {"activity_type": activity_type}
+        if metadata:
+            activity_metadata.update(metadata)
+        return self.record_learning_batch(
+            user_id=user_id,
+            event_key=f"{activity_type}:{user_hash}:{jst_date}",
+            mode=activity_type,
+            answered_count=0,
+            correct_count=0,
+            answered_at=timestamp,
+            question_results=activity_metadata,
+        )

--- a/tests/test_pt_qualified_learning_writer.py
+++ b/tests/test_pt_qualified_learning_writer.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import database
+from qualifications.pt.learning_writer import PTLearningWriter
+
+
+NOW = datetime(2026, 9, 12, tzinfo=timezone.utc)
+
+
+class Cursor:
+    def __init__(self):
+        self.calls = []
+        self.rowcount = 1
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def execute(self, sql, params=()):
+        self.calls.append((" ".join(sql.split()), params))
+        self.rowcount = 1
+
+
+class Connection:
+    def __init__(self, cursor):
+        self.cursor_obj = cursor
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def cursor(self):
+        return self.cursor_obj
+
+
+def _result():
+    return [{
+        "question_id": "Q1",
+        "knowledge_node_id": "KN0001",
+        "selected_answers": [1],
+        "is_correct": False,
+        "confidence": 1,
+    }]
+
+
+def test_writer_uses_explicit_pt_identity_and_qualified_conflict_targets(monkeypatch):
+    cursor = Cursor()
+    monkeypatch.setattr(database, "database_is_available", lambda: True)
+    monkeypatch.setattr(database, "get_db_connection", lambda: Connection(cursor))
+
+    writer = PTLearningWriter()
+    assert writer.record_learning_batch(
+        "learner",
+        "session:1",
+        "study",
+        1,
+        0,
+        answered_at=NOW,
+        question_results=_result(),
+    ) is True
+
+    event_sql, event_params = cursor.calls[0]
+    attempt_sql, attempt_params = cursor.calls[1]
+    node_sql, node_params = cursor.calls[2]
+
+    assert "qualification_id" in event_sql
+    assert "ON CONFLICT (qualification_id, event_key) DO NOTHING" in event_sql
+    assert event_params[0] == "pt"
+
+    assert "INSERT INTO question_attempts ( qualification_id" in attempt_sql
+    assert attempt_params[0] == "pt"
+
+    assert "qualification_id" in node_sql
+    assert "ON CONFLICT ( qualification_id, user_id, knowledge_node_id ) DO UPDATE" in node_sql
+    assert node_params[0] == "pt"
+
+
+def test_duplicate_event_returns_false_before_attempt_or_node_writes(monkeypatch):
+    cursor = Cursor()
+
+    def execute(sql, params=()):
+        cursor.calls.append((" ".join(sql.split()), params))
+        cursor.rowcount = 0
+
+    cursor.execute = execute
+    monkeypatch.setattr(database, "database_is_available", lambda: True)
+    monkeypatch.setattr(database, "get_db_connection", lambda: Connection(cursor))
+
+    assert PTLearningWriter().record_learning_batch(
+        "learner", "session:1", "study", 1, 0, question_results=_result()
+    ) is False
+    assert len(cursor.calls) == 1
+
+
+def test_local_fallback_delegates_to_legacy_writer_exactly(monkeypatch):
+    calls = []
+    monkeypatch.setattr(database, "database_is_available", lambda: False)
+    monkeypatch.setattr(
+        database,
+        "record_learning_batch",
+        lambda **kwargs: calls.append(kwargs) or True,
+    )
+
+    result = PTLearningWriter().record_learning_batch(
+        "learner",
+        "session:1",
+        "study",
+        1,
+        1,
+        answered_at=NOW,
+        question_results=_result(),
+    )
+
+    assert result is True
+    assert calls == [{
+        "user_id": "learner",
+        "event_key": "session:1",
+        "mode": "study",
+        "answered_count": 1,
+        "correct_count": 1,
+        "answered_at": NOW,
+        "question_results": _result(),
+    }]
+
+
+def test_activity_event_reuses_qualified_batch_writer(monkeypatch):
+    writer = PTLearningWriter()
+    calls = []
+    monkeypatch.setattr(
+        writer,
+        "record_learning_batch",
+        lambda **kwargs: calls.append(kwargs) or True,
+    )
+
+    assert writer.record_activity_event(
+        "learner", "recommendation_plan", {"goal": 5}, occurred_at=NOW
+    ) is True
+    assert len(calls) == 1
+    assert calls[0]["mode"] == "recommendation_plan"
+    assert calls[0]["answered_count"] == 0
+    assert calls[0]["question_results"] == {
+        "activity_type": "recommendation_plan",
+        "goal": 5,
+    }


### PR DESCRIPTION
## Purpose
Prepare the PT write-side cutover for #321 without changing the live runtime before the Phase-2a qualified conflict keys exist in Production.

## Changes
- add `PTLearningWriter`
- every Production learning-event, question-attempt, and Knowledge Node state write includes `qualification_id='pt'`
- conflict targets are qualification-aware
- activity-event writes reuse the same qualified batch writer
- local fallback delegates to the current legacy writer
- focused regression tests cover qualification identity and conflict targets

## Safety
- this writer is intentionally dormant and is NOT installed by `wsgi.py`
- no current PT runtime behavior changes
- no schema/migration changes in this PR
- activation must happen only after Phase-2a qualified uniqueness is present in Production
- Takken remains disabled/fail-closed

Issue: #321