### PR TITLE
feat: activate PT qualification-explicit learning writer

### DIFF
--- a/qualification_learning_writer_scope.py
+++ b/qualification_learning_writer_scope.py
@@ -1,0 +1,35 @@
+"""Production composition hook for qualification-explicit PT learning writes.
+
+The legacy learner app and dashboard import write helpers by value from
+``database``. This installer rebinds only those module-local write hooks to the
+PT-qualified writer after the qualified database conflict keys are available.
+"""
+
+from __future__ import annotations
+
+from qualifications.pt.learning_writer import PTLearningWriter
+
+
+_LEGACY_WRITE_NAMES = (
+    "record_learning_batch",
+    "record_activity_event",
+)
+
+
+def install_pt_learning_writer_scope(legacy_module, dashboard_module) -> None:
+    """Bind current PT write call sites to one explicit PT writer instance."""
+    if getattr(legacy_module, "_pt_learning_writer_scope_installed", False):
+        return
+
+    for name in _LEGACY_WRITE_NAMES:
+        if not hasattr(legacy_module, name):
+            raise AttributeError(f"legacy learner runtime missing write hook: {name}")
+    if not hasattr(dashboard_module, "record_activity_event"):
+        raise AttributeError("dashboard runtime missing write hook: record_activity_event")
+
+    writer = PTLearningWriter()
+    legacy_module.record_learning_batch = writer.record_learning_batch
+    legacy_module.record_activity_event = writer.record_activity_event
+    dashboard_module.record_activity_event = writer.record_activity_event
+    legacy_module._pt_learning_writer = writer
+    legacy_module._pt_learning_writer_scope_installed = True

--- a/tests/test_qualification_learning_writer_scope.py
+++ b/tests/test_qualification_learning_writer_scope.py
@@ -1,0 +1,71 @@
+"""Regression coverage for PT qualification-explicit write composition."""
+
+from types import SimpleNamespace
+
+from qualification_learning_writer_scope import install_pt_learning_writer_scope
+from qualifications.pt.learning_writer import PTLearningWriter
+
+
+def make_legacy():
+    return SimpleNamespace(
+        record_learning_batch=object(),
+        record_activity_event=object(),
+    )
+
+
+def make_dashboard():
+    return SimpleNamespace(record_activity_event=object())
+
+
+def test_installer_binds_legacy_and_dashboard_writes_to_one_pt_writer():
+    legacy = make_legacy()
+    dashboard = make_dashboard()
+
+    install_pt_learning_writer_scope(legacy, dashboard)
+
+    writer = legacy._pt_learning_writer
+    assert isinstance(writer, PTLearningWriter)
+    assert writer.qualification_id == "pt"
+    assert legacy._pt_learning_writer_scope_installed is True
+
+    assert legacy.record_learning_batch.__self__ is writer
+    assert legacy.record_learning_batch.__func__ is PTLearningWriter.record_learning_batch
+    assert legacy.record_activity_event.__self__ is writer
+    assert legacy.record_activity_event.__func__ is PTLearningWriter.record_activity_event
+    assert dashboard.record_activity_event.__self__ is writer
+    assert dashboard.record_activity_event.__func__ is PTLearningWriter.record_activity_event
+
+
+def test_installer_is_idempotent():
+    legacy = make_legacy()
+    dashboard = make_dashboard()
+    install_pt_learning_writer_scope(legacy, dashboard)
+    first_writer = legacy._pt_learning_writer
+    first_batch_hook = legacy.record_learning_batch
+    first_legacy_activity_hook = legacy.record_activity_event
+    first_dashboard_activity_hook = dashboard.record_activity_event
+
+    install_pt_learning_writer_scope(legacy, dashboard)
+
+    assert legacy._pt_learning_writer is first_writer
+    assert legacy.record_learning_batch == first_batch_hook
+    assert legacy.record_activity_event == first_legacy_activity_hook
+    assert dashboard.record_activity_event == first_dashboard_activity_hook
+
+
+def test_installer_fails_closed_before_mutating_when_hook_is_missing():
+    legacy = make_legacy()
+    dashboard = SimpleNamespace()
+    original_batch = legacy.record_learning_batch
+    original_activity = legacy.record_activity_event
+
+    try:
+        install_pt_learning_writer_scope(legacy, dashboard)
+    except AttributeError as exc:
+        assert "record_activity_event" in str(exc)
+    else:
+        raise AssertionError("missing dashboard write hook must fail closed")
+
+    assert legacy.record_learning_batch is original_batch
+    assert legacy.record_activity_event is original_activity
+    assert not hasattr(legacy, "_pt_learning_writer_scope_installed")

--- a/wsgi.py
+++ b/wsgi.py
@@ -36,6 +36,7 @@ from prerequisite_attempt_cache import install_prerequisite_attempt_cache
 from qualification_dashboard_scope import install_pt_dashboard_history_scope
 from qualification_history_scope import install_pt_learning_history_scope
 from qualification_learning_time_scope import install_pt_learning_time_scope
+from qualification_learning_writer_scope import install_pt_learning_writer_scope
 from site_beta_copy import install_site_beta_copy
 from site_direct_line_cta import install_site_direct_line_cta
 from site_marketing_hotfix import install_site_marketing_hotfix
@@ -127,6 +128,7 @@ def _apply_rich_menu_v2_if_requested() -> None:
 # call time, so production behavior can be composed without rewriting app.py.
 install_pt_learning_history_scope(legacy)
 install_pt_dashboard_history_scope(goukaku_module)
+install_pt_learning_writer_scope(legacy, goukaku_module)
 install_durable_paused_sessions(legacy, database_module)
 install_durable_web_learning_sessions(legacy, database_module)
 install_pt_learning_time_scope(legacy, database_module)


### PR DESCRIPTION
## Purpose
Complete the PT write-side cutover from #321 now that qualification-aware conflict keys are present in Production.

## Changes
- add a production composition hook for the PT-qualified learning writer
- bind legacy `record_learning_batch` and `record_activity_event` to one `PTLearningWriter`
- bind dashboard `record_activity_event` to that same PT writer
- activate the composition from `wsgi.py`
- add focused idempotency and fail-closed regression coverage

## Safety
- Production Neon Phase-2a qualified conflict keys were applied and verified before this runtime activation
- existing global conflict keys remain in place
- no Question Bank/selector/session-key format changes
- no Takken runtime activation
- PT duplicate/cooldown and learning selection behavior are untouched

Issue: #321