### PR TITLE
fix: enforce short-term repeat guard in initial assessment

### DIFF
--- a/initial_assessment_repeat_guard.py
+++ b/initial_assessment_repeat_guard.py
@@ -1,0 +1,73 @@
+"""Production composition guard for initial-assessment short-term repeats.
+
+The legacy initial-assessment branch already supports exclusions in
+``learning_engine.build_initial_assessment`` but does not pass learner history
+from ``app.start_quiz``.  This hook keeps ``app.py`` stable while making the
+same short-term evidence floor used by the other learner-facing paths apply to
+initial assessment as well.
+"""
+
+from __future__ import annotations
+
+from contextvars import ContextVar
+from functools import wraps
+
+from short_term_repeat_guard import blocked_short_term_evidence_ids
+
+
+_INITIAL_ASSESSMENT_BLOCKED: ContextVar[frozenset[str] | None] = ContextVar(
+    "lt_initial_assessment_blocked",
+    default=None,
+)
+
+
+def install_initial_assessment_repeat_guard(legacy_module) -> None:
+    """Make legacy initial assessment honor the learner's short-term guard."""
+    if getattr(legacy_module, "_initial_assessment_repeat_guard_installed", False):
+        return
+
+    original_start_quiz = legacy_module.start_quiz
+    original_build_initial_assessment = legacy_module.build_initial_assessment
+
+    @wraps(original_build_initial_assessment)
+    def guarded_build_initial_assessment(question_count=30, *args, **kwargs):
+        contextual_blocked = _INITIAL_ASSESSMENT_BLOCKED.get()
+        if contextual_blocked is None:
+            return original_build_initial_assessment(question_count, *args, **kwargs)
+
+        explicit = {str(value) for value in (kwargs.pop("exclude_ids", ()) or ())}
+        explicit.update(contextual_blocked)
+        return original_build_initial_assessment(
+            question_count,
+            *args,
+            exclude_ids=explicit,
+            **kwargs,
+        )
+
+    @wraps(original_start_quiz)
+    def guarded_start_quiz(user_id, session_kind=None, question_count=None, exclude_ids=None):
+        if session_kind != "initial_assessment":
+            return original_start_quiz(
+                user_id,
+                session_kind=session_kind,
+                question_count=question_count,
+                exclude_ids=exclude_ids,
+            )
+
+        attempts = legacy_module.get_question_attempts(user_id)
+        blocked = blocked_short_term_evidence_ids(attempts)
+        blocked.update(str(value) for value in (exclude_ids or ()))
+        token = _INITIAL_ASSESSMENT_BLOCKED.set(frozenset(blocked))
+        try:
+            return original_start_quiz(
+                user_id,
+                session_kind=session_kind,
+                question_count=question_count,
+                exclude_ids=exclude_ids,
+            )
+        finally:
+            _INITIAL_ASSESSMENT_BLOCKED.reset(token)
+
+    legacy_module.build_initial_assessment = guarded_build_initial_assessment
+    legacy_module.start_quiz = guarded_start_quiz
+    legacy_module._initial_assessment_repeat_guard_installed = True

--- a/tests/test_global_short_term_repeat_guard.py
+++ b/tests/test_global_short_term_repeat_guard.py
@@ -224,12 +224,8 @@ def test_adaptive_session_boundary_applies_guard_for_web_style_direct_call(monke
     assert result == [{"id": "Q2"}]
 
 
-def test_initial_assessment_fixed_contract_does_not_read_attempts(monkeypatch):
-    monkeypatch.setattr(
-        app,
-        "get_question_attempts",
-        lambda _user_id: (_ for _ in ()).throw(AssertionError("must not read attempts")),
-    )
+def test_initial_assessment_runtime_reads_attempts_for_repeat_guard(monkeypatch):
+    monkeypatch.setattr(app, "get_question_attempts", lambda _user_id: [])
     monkeypatch.setattr(app, "build_initial_assessment", lambda count: questions(count))
     monkeypatch.setattr(app, "format_quiz_messages", lambda _questions: ["quiz"])
     assert app.start_quiz("initial-user", session_kind="initial_assessment", question_count=10) == ["quiz"]

--- a/tests/test_initial_assessment_repeat_guard.py
+++ b/tests/test_initial_assessment_repeat_guard.py
@@ -1,0 +1,78 @@
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+from initial_assessment_repeat_guard import install_initial_assessment_repeat_guard
+
+
+NOW = datetime(2026, 9, 12, 0, tzinfo=timezone.utc)
+
+
+def recent_attempt(question_id):
+    return {
+        "question_id": question_id,
+        "answered_at": NOW - timedelta(hours=2),
+        "answer_status": "answered",
+    }
+
+
+def make_legacy(attempts):
+    calls = {"build": [], "start": []}
+
+    def build_initial_assessment(question_count=30, *, exclude_ids=()):
+        calls["build"].append((question_count, set(exclude_ids)))
+        return ["built"]
+
+    def start_quiz(user_id, session_kind=None, question_count=None, exclude_ids=None):
+        calls["start"].append((user_id, session_kind, question_count, exclude_ids))
+        if session_kind == "initial_assessment":
+            return legacy.build_initial_assessment(question_count or 30)
+        return "other"
+
+    legacy = SimpleNamespace(
+        start_quiz=start_quiz,
+        build_initial_assessment=build_initial_assessment,
+        get_question_attempts=lambda _user_id: list(attempts),
+    )
+    return legacy, calls
+
+
+def test_initial_assessment_injects_recent_question_exclusions():
+    legacy, calls = make_legacy([recent_attempt("Q1783")])
+    install_initial_assessment_repeat_guard(legacy)
+
+    assert legacy.start_quiz("learner", session_kind="initial_assessment", question_count=30) == ["built"]
+    assert calls["build"] == [(30, {"Q1783"})]
+
+
+def test_initial_assessment_merges_explicit_exclusions():
+    legacy, calls = make_legacy([recent_attempt("Q1783")])
+    install_initial_assessment_repeat_guard(legacy)
+
+    legacy.start_quiz(
+        "learner",
+        session_kind="initial_assessment",
+        question_count=30,
+        exclude_ids={"Q9"},
+    )
+
+    assert calls["build"] == [(30, {"Q1783", "Q9"})]
+
+
+def test_non_initial_paths_are_unchanged():
+    legacy, calls = make_legacy([recent_attempt("Q1783")])
+    install_initial_assessment_repeat_guard(legacy)
+
+    assert legacy.start_quiz("learner", session_kind="adaptive_daily", question_count=30) == "other"
+    assert calls["build"] == []
+
+
+def test_installer_is_idempotent():
+    legacy, _calls = make_legacy([])
+    install_initial_assessment_repeat_guard(legacy)
+    first_start = legacy.start_quiz
+    first_build = legacy.build_initial_assessment
+
+    install_initial_assessment_repeat_guard(legacy)
+
+    assert legacy.start_quiz is first_start
+    assert legacy.build_initial_assessment is first_build

--- a/wsgi.py
+++ b/wsgi.py
@@ -29,6 +29,7 @@ from dashboard_progress_trend import install_dashboard_progress_trend
 from developer_access_recovery import install_developer_access_recovery
 from durable_paused_session import install_durable_paused_sessions
 from durable_web_learning_session import install_durable_web_learning_sessions
+from initial_assessment_repeat_guard import install_initial_assessment_repeat_guard
 from learning_time_guard import install_learning_time_guard
 from one_question_starter import install_one_question_starter, one_question_quick_reply_item
 from phase11_gate_ui import install_phase11_gate_ui
@@ -127,6 +128,7 @@ def _apply_rich_menu_v2_if_requested() -> None:
 # Registered LINE callbacks resolve these names from the legacy app module at
 # call time, so production behavior can be composed without rewriting app.py.
 install_pt_learning_history_scope(legacy)
+install_initial_assessment_repeat_guard(legacy)
 install_pt_dashboard_history_scope(goukaku_module)
 install_pt_learning_writer_scope(legacy, goukaku_module)
 install_durable_paused_sessions(legacy, database_module)


### PR DESCRIPTION
## Purpose
Fix Production regression #336 where an initial-assessment session repeated Q1783 only 1.962 hours after the learner had already answered it.

## Changes
- add a production composition guard for initial-assessment starts
- load the already PT-scoped learner attempt history
- apply `blocked_short_term_evidence_ids(...)` before initial assessment selection
- merge explicit exclusions without changing other paths
- use ContextVar-scoped exclusions so concurrent requests do not share learner state
- install the guard after PT history scoping in `wsgi.py`
- add focused regression tests for recent exclusion, explicit exclusion merge, non-initial path parity, and idempotent installation

## Safety
- no DB/schema migration
- no selector priority changes
- no question bank changes
- no session-key changes
- no Takken runtime activation
- preserves the existing initial-assessment builder and its ability/level balancing; only the already-supported `exclude_ids` input is supplied

Production evidence and root cause: #336
Baseline to protect: #316