### PR TITLE
fix: preserve existing PT assessment evidence after qualification migration

### DIFF
--- a/qualifications/pt/learning_store.py
+++ b/qualifications/pt/learning_store.py
@@ -112,8 +112,13 @@ class PTLearningHistoryStore:
                     (user_id, self.qualification_id),
                 )
                 row = cur.fetchone()
-                if row is not None:
-                    return bool(row[0])
+                # A completed qualification state is authoritative. During the
+                # PT migration, however, a stale legacy FALSE may have been
+                # copied for a learner who already has substantial PT history.
+                # In that case preserve the pre-migration evidence contract
+                # instead of forcing a mature learner through onboarding again.
+                if row is not None and bool(row[0]):
+                    return True
                 cur.execute(
                     """
                     SELECT EXISTS (

--- a/tests/test_pt_assessment_state_evidence_fallback.py
+++ b/tests/test_pt_assessment_state_evidence_fallback.py
@@ -1,0 +1,55 @@
+from unittest.mock import MagicMock
+
+import database
+from qualifications.pt.learning_store import PTLearningHistoryStore
+
+
+def db_context_with_fetches(*rows):
+    cursor = MagicMock()
+    cursor.fetchone.side_effect = rows
+    connection = MagicMock()
+    connection.cursor.return_value.__enter__.return_value = cursor
+    context = MagicMock()
+    context.__enter__.return_value = connection
+    return context, cursor
+
+
+def test_true_qualified_state_short_circuits_learning_evidence(monkeypatch):
+    context, cursor = db_context_with_fetches((True,))
+    monkeypatch.setattr(database, "database_is_available", lambda: True)
+    monkeypatch.setattr(database, "get_db_connection", lambda: context)
+
+    assert PTLearningHistoryStore().is_initial_assessment_completed("learner") is True
+    assert cursor.execute.call_count == 1
+
+
+def test_false_qualified_state_preserves_existing_pt_learning_evidence(monkeypatch):
+    context, cursor = db_context_with_fetches((False,), (True,))
+    monkeypatch.setattr(database, "database_is_available", lambda: True)
+    monkeypatch.setattr(database, "get_db_connection", lambda: context)
+
+    assert PTLearningHistoryStore().is_initial_assessment_completed("learner") is True
+    assert cursor.execute.call_count == 2
+    evidence_sql = cursor.execute.call_args_list[1].args[0]
+    evidence_params = cursor.execute.call_args_list[1].args[1]
+    assert "qualification_id = %s" in evidence_sql
+    assert "answered_count > 0" in evidence_sql
+    assert evidence_params == ("learner", "pt")
+
+
+def test_false_state_without_pt_learning_evidence_remains_incomplete(monkeypatch):
+    context, cursor = db_context_with_fetches((False,), (False,))
+    monkeypatch.setattr(database, "database_is_available", lambda: True)
+    monkeypatch.setattr(database, "get_db_connection", lambda: context)
+
+    assert PTLearningHistoryStore().is_initial_assessment_completed("learner") is False
+    assert cursor.execute.call_count == 2
+
+
+def test_missing_state_with_pt_learning_evidence_remains_backward_compatible(monkeypatch):
+    context, cursor = db_context_with_fetches(None, (True,))
+    monkeypatch.setattr(database, "database_is_available", lambda: True)
+    monkeypatch.setattr(database, "get_db_connection", lambda: context)
+
+    assert PTLearningHistoryStore().is_initial_assessment_completed("learner") is True
+    assert cursor.execute.call_count == 2


### PR DESCRIPTION
## Purpose
Fix #338: a migrated FALSE qualification assessment flag must not override substantial existing PT learning evidence and force a mature learner through the first-time assessment again.

## Production evidence
Before the 2026-09-12 morning session, the learner already had 526 answered PT learning events / 1,970 answers in Production, yet entered initial assessment after the qualification-state migration.

## Changes
- TRUE `qualification_user_state` remains authoritative
- FALSE or missing qualified state now checks answered PT learning-event evidence
- existing PT learning evidence => assessment treated as completed
- no evidence => remains incomplete
- focused tests cover TRUE short-circuit, migrated FALSE + evidence, FALSE + no evidence, and missing-state compatibility

## Safety
- no DB migration
- no Takken activation
- no scoring/selector/session-key change
- explicit PT reset remains valid because it deletes PT learning evidence together with qualification state

Issue: #338