### PR TITLE
audit: temporary PT 18-field static map dump

### DIFF
--- a/tests/test__temporary_pt_18field_audit_dump.py
+++ b/tests/test__temporary_pt_18field_audit_dump.py
@@ -1,0 +1,31 @@
+import json
+from collections import defaultdict
+
+import pytest
+
+from knowledge_node_canonical import canonicalize_knowledge_node_id
+from question_bank import CATEGORY_NAMES, get_category_small, get_question_tag, question_ids
+
+
+def test_emit_static_pt_field_map_for_one_off_audit():
+    questions_by_field = defaultdict(list)
+    nodes_by_field = defaultdict(set)
+    for qid in question_ids():
+        field_id = get_category_small(qid)
+        node_id = canonicalize_knowledge_node_id(get_question_tag(qid)["knowledge_node_id"])
+        questions_by_field[field_id].append(qid)
+        nodes_by_field[field_id].add(node_id)
+
+    payload = {
+        str(field_id): {
+            "name": CATEGORY_NAMES[field_id],
+            "question_count": len(questions_by_field[field_id]),
+            "canonical_node_count": len(nodes_by_field[field_id]),
+            "qids": questions_by_field[field_id],
+            "nodes": sorted(nodes_by_field[field_id]),
+        }
+        for field_id in sorted(CATEGORY_NAMES)
+    }
+    # Deliberately fail only on this temporary audit branch so Actions exposes
+    # the static mapping in the job log. This branch is never merged.
+    pytest.fail("PT18_AUDIT=" + json.dumps(payload, ensure_ascii=False, separators=(",", ":")))

--- a/tests/test__temporary_pt_18field_audit_dump.py
+++ b/tests/test__temporary_pt_18field_audit_dump.py
@@ -1,31 +1,21 @@
-import json
 from collections import defaultdict
 
 import pytest
 
-from knowledge_node_canonical import canonicalize_knowledge_node_id
-from question_bank import CATEGORY_NAMES, get_category_small, get_question_tag, question_ids
+from question_bank import CATEGORY_NAMES, get_category_small, question_ids
 
 
 def test_emit_static_pt_field_map_for_one_off_audit():
     questions_by_field = defaultdict(list)
-    nodes_by_field = defaultdict(set)
     for qid in question_ids():
-        field_id = get_category_small(qid)
-        node_id = canonicalize_knowledge_node_id(get_question_tag(qid)["knowledge_node_id"])
-        questions_by_field[field_id].append(qid)
-        nodes_by_field[field_id].add(node_id)
+        questions_by_field[get_category_small(qid)].append(qid)
 
-    payload = {
-        str(field_id): {
-            "name": CATEGORY_NAMES[field_id],
-            "question_count": len(questions_by_field[field_id]),
-            "canonical_node_count": len(nodes_by_field[field_id]),
-            "qids": questions_by_field[field_id],
-            "nodes": sorted(nodes_by_field[field_id]),
-        }
-        for field_id in sorted(CATEGORY_NAMES)
-    }
+    clauses = []
+    for field_id in sorted(CATEGORY_NAMES):
+        quoted = ",".join(f"'{qid}'" for qid in questions_by_field[field_id])
+        clauses.append(f"WHEN question_id IN ({quoted}) THEN {field_id}")
+
+    sql_case = "CASE " + " ".join(clauses) + " END"
     # Deliberately fail only on this temporary audit branch so Actions exposes
-    # the static mapping in the job log. This branch is never merged.
-    pytest.fail("PT18_AUDIT=" + json.dumps(payload, ensure_ascii=False, separators=(",", ":")))
+    # a compact SQL CASE mapping for the one-off production read-only audit.
+    pytest.fail("PT18_SQL_CASE=" + sql_case)


### PR DESCRIPTION
One-off READ-ONLY audit helper for Issue #340. Deliberately fails CI to expose static Question Bank field/Q/Canonical-Node mapping in the job log. Contains no learner data and will NOT be merged.