### PR TITLE
feat: add PT low-coverage exploration floor

### DIFF
--- a/adaptive_question_selector.py
+++ b/adaptive_question_selector.py
@@ -120,6 +120,49 @@ def _priority(state: str, summary: dict[str, Any], safety: str) -> tuple[int, st
     return 100, "stable_maintenance", "maintenance"
 
 
+def _field_node_coverage(attempts: Iterable[dict[str, Any]]) -> tuple[dict[str, int], dict[int, tuple[int, int]]]:
+    """Return evidence-Q -> field and per-field (seen nodes, total nodes).
+
+    Coverage is based on canonical Knowledge Nodes, not raw answer volume. This
+    keeps the exploration floor aligned with the same semantic unit used by the
+    repair engine while leaving Safety/repair priority scores unchanged.
+    """
+    field_by_evidence: dict[str, int] = {}
+    total_nodes: dict[int, set[str]] = defaultdict(set)
+    seen_nodes: dict[int, set[str]] = defaultdict(set)
+
+    for question_id in question_ids():
+        field_id = get_category_small(question_id)
+        evidence_question_id = canonicalize_question_evidence_id(question_id)
+        tag = get_question_tag(question_id)
+        node = canonicalize_question_evidence_node(
+            question_id,
+            str(tag["knowledge_node_id"]),
+        )
+        field_by_evidence.setdefault(evidence_question_id, field_id)
+        if node:
+            total_nodes[field_id].add(str(node))
+
+    for item in attempts:
+        raw_question_id = str(item.get("question_id") or "")
+        evidence_question_id = canonicalize_question_evidence_id(raw_question_id)
+        field_id = field_by_evidence.get(evidence_question_id)
+        if field_id is None:
+            continue
+        node = canonicalize_question_evidence_node(
+            raw_question_id,
+            str(item.get("knowledge_node_id") or ""),
+        )
+        if node:
+            seen_nodes[field_id].add(str(node))
+
+    coverage = {
+        field_id: (len(seen_nodes[field_id]), len(nodes))
+        for field_id, nodes in total_nodes.items()
+    }
+    return field_by_evidence, coverage
+
+
 def select_node_adaptive_questions(
     attempts: Iterable[dict[str, Any]],
     question_count: int = 30,
@@ -155,12 +198,17 @@ def select_node_adaptive_questions(
         canonicalize_question_evidence_id(str(value))
         for value in (exclude_ids or ())
     }
+    field_by_evidence, field_coverage = _field_node_coverage(attempts)
     candidates = []
     for question_id in question_ids():
         evidence_question_id = canonicalize_question_evidence_id(question_id)
         if evidence_question_id in excluded:
             continue
-        if category_small is not None and get_category_small(question_id) != category_small:
+        field_id = field_by_evidence.get(
+            evidence_question_id,
+            get_category_small(question_id),
+        )
+        if category_small is not None and field_id != category_small:
             continue
         tag = get_question_tag(question_id)
         node = canonicalize_question_evidence_node(
@@ -198,10 +246,16 @@ def select_node_adaptive_questions(
             score += 20
         if evidence_question_id not in seen_question_ids:
             score += 10
+        seen_nodes, total_nodes = field_coverage.get(field_id, (0, 0))
+        coverage_ratio = seen_nodes / total_nodes if total_nodes else 1.0
         candidates.append({
             "question_id": question_id,
             "evidence_question_id": evidence_question_id,
             "canonical_node_id": str(node),
+            "category_small": field_id,
+            "field_seen_nodes": seen_nodes,
+            "field_total_nodes": total_nodes,
+            "field_node_coverage": coverage_ratio,
             "state": state,
             "priority_reason": reason,
             "priority_group": group,
@@ -228,6 +282,15 @@ def select_node_adaptive_questions(
         if item["evidence_question_id"] not in seen_question_ids
         or item["state"] == "recheck_due"
     ]
+    exploration_candidates = sorted(
+        normal_candidates,
+        key=lambda item: (
+            item["field_node_coverage"],
+            item["field_seen_nodes"],
+            -item["priority_score"],
+            -item["tie"],
+        ),
+    )
 
     intent_group = {
         "repair": "repair",
@@ -273,9 +336,43 @@ def select_node_adaptive_questions(
                 continue
             append_item(item)
 
+    def take_exploration(limit: int, node_cap: int):
+        """Fill exploration from lowest-coverage fields, one field each first."""
+        def selected_count() -> int:
+            return sum(value["priority_group"] == "exploration" for value in selected)
+
+        used_fields = {
+            value["category_small"]
+            for value in selected
+            if value["priority_group"] == "exploration"
+        }
+        for item in exploration_candidates:
+            if selected_count() >= limit:
+                return
+            if item["priority_group"] != "exploration" or not available(item, node_cap):
+                continue
+            if item["category_small"] in used_fields:
+                continue
+            append_item(item)
+            used_fields.add(item["category_small"])
+
+        # A field-filtered session, a small bank, or exhausted low-coverage
+        # fields may not have enough distinct fields. Fill the remaining floor
+        # without weakening uniqueness or Node caps.
+        for item in exploration_candidates:
+            if selected_count() >= limit:
+                return
+            if item["priority_group"] != "exploration" or not available(item, node_cap):
+                continue
+            append_item(item)
+
     for group, limit in targets.items():
-        take(normal_candidates, group, limit, node_cap=1)
-        take(normal_candidates, group, limit, node_cap=2)
+        if group == "exploration":
+            take_exploration(limit, node_cap=1)
+            take_exploration(limit, node_cap=2)
+        else:
+            take(normal_candidates, group, limit, node_cap=1)
+            take(normal_candidates, group, limit, node_cap=2)
 
     for cap in (1, 2, 3, question_count):
         for item in normal_candidates:

--- a/tests/test_adaptive_coverage_floor.py
+++ b/tests/test_adaptive_coverage_floor.py
@@ -1,0 +1,105 @@
+import random
+from datetime import datetime, timezone
+
+import adaptive_question_selector as selector
+
+
+NOW = datetime(2026, 9, 12, tzinfo=timezone.utc)
+
+
+def _attempt(qid, node, correct, *, confidence=2, minute=0):
+    return {
+        "user_id": "u",
+        "question_id": qid,
+        "knowledge_node_id": node,
+        "is_correct": correct,
+        "confidence": confidence,
+        "answer_status": "answered",
+        "answered_at": NOW,
+        "event_key": f"e-{qid}-{minute}",
+        "attempt_position": 1,
+    }
+
+
+def _install_bank(monkeypatch, specs):
+    ids = tuple(specs)
+    monkeypatch.setattr(selector, "question_ids", lambda: ids)
+    monkeypatch.setattr(selector, "get_category_small", lambda qid: specs[qid][0])
+    monkeypatch.setattr(selector, "get_question_tag", lambda qid: {
+        "knowledge_node_id": specs[qid][1],
+        "safety": specs[qid][2],
+    })
+
+
+def test_exploration_floor_uses_distinct_lowest_coverage_fields(monkeypatch):
+    specs = {}
+    q = 1
+    for field_id in range(1, 7):
+        for node_index in range(1, 5):
+            specs[f"Q{q}"] = (field_id, f"F{field_id}N{node_index}", "none")
+            q += 1
+    _install_bank(monkeypatch, specs)
+
+    attempts = []
+    # Field node coverage before this session:
+    # F1=0/4, F2=1/4, F3=2/4, F4=3/4, F5=3/4, F6=4/4.
+    for field_id, seen_nodes in ((2, 1), (3, 2), (4, 3), (5, 3), (6, 4)):
+        field_qids = [qid for qid, spec in specs.items() if spec[0] == field_id]
+        for qid in field_qids[:seen_nodes]:
+            attempts.append(_attempt(qid, specs[qid][1], True, confidence=1))
+
+    selected = selector.select_node_adaptive_questions(
+        attempts,
+        question_count=5,
+        learning_intent="exploration",
+        rng=random.Random(7),
+        as_of=NOW,
+    )
+
+    assert len(selected) == 5
+    assert [item["category_small"] for item in selected] == [1, 2, 3, 4, 5]
+    assert all(item["priority_group"] == "exploration" for item in selected)
+
+
+def test_safety_repair_stays_first_while_exploration_uses_low_coverage_field(monkeypatch):
+    specs = {
+        "Q1": (1, "F1N1", "none"),
+        "Q2": (1, "F1N2", "none"),
+        "Q3": (2, "F2N1", "none"),
+        "Q4": (2, "F2N2", "none"),
+        "Q5": (3, "F3N1", "none"),
+        "Q6": (3, "F3N2", "none"),
+        "Q7": (4, "F4N1", "none"),
+        "Q8": (4, "F4N2", "none"),
+        "Q9": (5, "F5N1", "none"),
+        "Q10": (5, "F5N2", "none"),
+        "Q11": (6, "SAFE", "critical"),
+        "Q12": (6, "SAFE", "critical"),
+    }
+    _install_bank(monkeypatch, specs)
+    monkeypatch.setattr(
+        selector,
+        "classify_repair_confirmation",
+        lambda old, new: "same_question" if old == new else "different_question_strong",
+    )
+
+    attempts = [
+        _attempt("Q11", "SAFE", False, confidence=2),
+        _attempt("Q3", "F2N1", True, confidence=1),
+        _attempt("Q4", "F2N2", True, confidence=1),
+        _attempt("Q5", "F3N1", True, confidence=1),
+        _attempt("Q6", "F3N2", True, confidence=1),
+    ]
+
+    selected = selector.select_node_adaptive_questions(
+        attempts,
+        question_count=6,
+        rng=random.Random(11),
+        as_of=NOW,
+    )
+
+    assert selected[0]["question_id"] == "Q12"
+    assert selected[0]["priority_reason"] == "safety_wrong"
+    exploration = [item for item in selected if item["priority_group"] == "exploration"]
+    assert exploration
+    assert exploration[0]["category_small"] == 1

--- a/tests/test_adaptive_coverage_floor.py
+++ b/tests/test_adaptive_coverage_floor.py
@@ -57,7 +57,9 @@ def test_exploration_floor_uses_distinct_lowest_coverage_fields(monkeypatch):
     )
 
     assert len(selected) == 5
-    assert [item["category_small"] for item in selected] == [1, 2, 3, 4, 5]
+    selected_fields = [item["category_small"] for item in selected]
+    assert selected_fields[:3] == [1, 2, 3]
+    assert set(selected_fields) == {1, 2, 3, 4, 5}
     assert all(item["priority_group"] == "exploration" for item in selected)
 
 
@@ -89,6 +91,10 @@ def test_safety_repair_stays_first_while_exploration_uses_low_coverage_field(mon
         _attempt("Q4", "F2N2", True, confidence=1),
         _attempt("Q5", "F3N1", True, confidence=1),
         _attempt("Q6", "F3N2", True, confidence=1),
+        _attempt("Q7", "F4N1", True, confidence=1),
+        _attempt("Q8", "F4N2", True, confidence=1),
+        _attempt("Q9", "F5N1", True, confidence=1),
+        _attempt("Q10", "F5N2", True, confidence=1),
     ]
 
     selected = selector.select_node_adaptive_questions(


### PR DESCRIPTION
Issue #340 audit found a real syllabus-breadth imbalance despite 2,010 PT attempts: 9/18 fields remain below 50% canonical-Node coverage, including 理学療法治療各論 17.9%, 運動器 22.1%, 神経医学 24.6%, and 理学療法評価各論 32.3%. The existing adaptive metadata shows 155/939 selections were exploration (all 155 unique), but exploration was globally unseen rather than field-aware; one under-covered field (人間発達学, 42.9% Node coverage) received zero exploration-tagged questions in the measured period.

This change keeps all Safety/repair scores and the 15/10/5 default composition unchanged. It changes only exploration ordering: canonical Knowledge-Node coverage is computed per PT field, then exploration fills from the lowest-coverage fields with one distinct field each before filling extra slots. Existing uniqueness, recent-repeat guard, Node caps, category filters, and repair priority remain intact.

Tests add deterministic proof that (1) the exploration floor picks distinct lowest-coverage fields and (2) a critical Safety repair still wins first while the exploration slot goes to the lowest-coverage field.